### PR TITLE
Make projection unfolding equalities definitional

### DIFF
--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -627,8 +627,6 @@ From which we can deduce $\painting[n+1][0,...,p]$ for $p \leq n+1$ by a second 
   \end{array}
 \end{equation*}
 
-TODO: talk about unfoldPaintingProj.
-
 \subsection{Specifying painting restrictions}
 
 At this stage, we are able to define $\framep[n+1][0,...,n+1]$, $\painting[n+1][0,...,n+1]$ and $\restrftype[n][0,...,n]$ from $\framep[n][0,...,n]$, $\painting[n][0,...,n]$ and $\restrf[n][0,...,n]$, that is from $\deps[n][0,...,n]$. To go further, we need to define the sequence $\restrptype[n][0,...,p-1]$ of types of painting restrictions, for $p \leq n+1$:


### PR DESCRIPTION
Modify the definitions of `mkPaintings` and `mkRestrPaintings` to make `unfoldPaintingProj` and `unfoldRestrPaintings` equalities definitional. This simplifies the definition of `mkCohPainting`