### PR TITLE
Redefine `mkRestrPainting` to have better computation rule for `q := 0` case

### DIFF
--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -453,12 +453,8 @@ Fixpoint mkIdReflRestrPainting {p k}
 Proof.
   intros ε d c.
   destruct extraDeps.
-  - destruct deps, _depsCohs3.
-    generalize dependent _extraDepsCohs0; intro.
-    refine (match _extraDepsCohs0 with TopCohDep E => _ end).
-    intros; simpl.
-    rewrite rew_compose.
-    set (e := (mkIdReflRestrFrames _).2 ε d0).
+  - rewrite rew_compose.
+    set (e := (mkIdReflRestrFrames _).2 ε d).
     enough (eq_sym e • e = eq_refl) as ->. now trivial.
     now apply (mkFrame _).(UIP).
   - unshelve eapply (eq_existT_curried_dep
@@ -676,11 +672,7 @@ Fixpoint mkCohReflRestrPainting {p k}
 Proof.
   intros ε i Hi d [l c].
   destruct i.
-  - destruct extraDeps, deps, _depsReflCohs0, _depsCohs3.
-    + generalize dependent _extraDepsCohs0; intro.
-      refine (match _extraDepsCohs0 with TopCohDep E => _ end).
-      now intros.
-    + now trivial.
+  - now trivial.
   - unfold ReflPaintingBase, PaintingBase, toDepsRefl; simpl.
     destruct extraDeps.
     + now contradiction.

--- a/theories/νSet/νSet.v
+++ b/theories/νSet/νSet.v
@@ -363,19 +363,21 @@ Proof.
     (mkExtraDeps p.+1 k depsCohs extraDepsCohs)).
 Defined.
 
-Fixpoint mkRestrPainting `(extraDepsCohs: DepsCohsExtension p k depsCohs):
-  mkRestrPaintingType (mkExtraDeps extraDepsCohs).
-Proof.
-  red; intros * (l, c); destruct q.
-  - now exact (l ε).
-  - destruct extraDepsCohs.
-    + exfalso; now apply leR_O_contra in Hq.
-    + unshelve esplit.
-      * now exact (mkRestrLayer depsCohs.(_restrPaintings) depsCohs.(_cohs)
-        q (⇓ Hq) ε d l).
-      * now exact (mkRestrPainting p.+1 k depsCohs extraDepsCohs
-        q (⇓ Hq) ε (d; l) c).
-Defined.
+Fixpoint mkRestrPainting `(extraDepsCohs: DepsCohsExtension p k depsCohs)
+  q {struct q}:
+  forall (Hq: q <= k) ε (d: mkFrame mkDepsRestr.(1)),
+    (mkPaintings (mkDepsRestr; mkExtraDeps extraDepsCohs)).2 d ->
+    mkDepsRestr.(_paintings).2 (mkDepsRestr.(_restrFrames).2 q Hq ε d) :=
+  match q with
+  | 0 => fun _ ε _ '(l; _) => l ε
+  | q.+1 =>
+    match extraDepsCohs with
+    | TopCohDep E => fun Hq _ _ _ => match leR_O_contra Hq with end
+    | AddCohDep depsCohs extraDepsCohs => fun Hq ε d '(l; c) =>
+      (mkRestrLayer depsCohs.(_restrPaintings) depsCohs.(_cohs) q (⇓ Hq) ε d l;
+       mkRestrPainting extraDepsCohs q (⇓ Hq) ε (d; l) c)
+    end
+  end.
 
 Fixpoint mkRestrPaintingsPrefix {p k}:
   forall `(extraDepsCohs: DepsCohsExtension p k depsCohs),
@@ -558,10 +560,7 @@ Fixpoint mkCohPainting `{depsCohs2: DepsCohs2 p k}
 Proof.
   red; intros *. destruct c as (l, c), r.
   - (* r = 0 *)
-    destruct extraDepsCohs2, depsCohs2.
-    generalize dependent _extraDepsCohs0. intro.
-    now refine (match _extraDepsCohs0 with TopCohDep E => _ end).
-    now reflexivity.
+    now trivial.
   - (* r = r'+1, q is necessarily q'+1 and extraDepsCohs non empty *)
     destruct q.
     { exfalso; now apply leR_O_contra in Hr. }


### PR DESCRIPTION
## The problem

Here is the current definition of `mkRestrPainting`:

```rocq
Fixpoint mkRestrPainting `(extraDepsCohs: DepsCohsExtension p k depsCohs):
  mkRestrPaintingType (mkExtraDeps extraDepsCohs).
Proof.
  red; intros * (l, c); destruct q.
  - now exact (l ε).
  - destruct extraDepsCohs.
    + exfalso; now apply leR_O_contra in Hq.
    + unshelve esplit.
      * now exact (mkRestrLayer depsCohs.(_restrPaintings) depsCohs.(_cohs)
        q (⇓ Hq) ε d l).
      * now exact (mkRestrPainting p.+1 k depsCohs extraDepsCohs
        q (⇓ Hq) ε (d; l) c).
Defined.
```

In the recursive case of this definition, both direction variable `q` and `extraDepsCohs` are decreasing, so Rocq is free to choose either of them as a structurally smaller value that makes the recursion well-founded. In practice, for this definition, Rocq chooses `extraDepsCohs`. However, at the `q := 0` case the definition of `mkRestrPainting` actually doesn't depend on `extraDepsCohs`. Thus, we might expect `mkRestrPainting` to evaluate at `q := 0` irregardless of `extraDepsCohs`, but with the current definition this is not the case:

```rocq
Lemma mkRestrPainting_q0 `(extraDepsCohs: DepsCohsExtension p k depsCohs) ε
    (d: mkFrame mkDepsRestr.(1))
    (l: mkLayer mkDepsRestr .(_restrFrames) d)
    (c: mkPainting (mkExtraDeps extraDepsCohs) (d; l)):
  mkRestrPainting extraDepsCohs 0 leR_O ε d (l; c) = (l ε).
Proof.
  Fail reflexivity.
  now destruct extraDepsCohs.
Defined.
```

This makes the proofs of coherence equations for paintings more complicated than they should be, i.e. makes it necessary to rely on dependent pattern matching, which doesn't always behave in obvious way:

```rocq
destruct extraDepsCohs2, depsCohs2.
Fail destruct _extraDepsCohs0.
(* Abstracting over the terms n, _depsCohs0 and _extraDepsCohs0 leads to a term which is ill-typed! *)
generalize dependent _extraDepsCohs0. intro.
now refine (match _extraDepsCohs0 with TopCohDep E => _ end).
```

## Possible solutions

Implement `mkRestrPainting` in such a way to regain this definitional equality at `q := 0`. The issue here is that we can't directly instruct Rocq to consider `q` the structurally smaller value for the recursion, as `q` is hidden beyond `mkRestrPaintingType` definition. We can consider inlining `mkRestrPaintingType` and making recursion over `q` explicit:

```rocq
Fixpoint mkRestrPainting `(extraDepsCohs: DepsCohsExtension p k depsCohs)
  q {struct q}:
  forall (Hq: q <= k) ε (d: mkFrame mkDepsRestr.(1)),
    (mkPaintings (mkDepsRestr; mkExtraDeps extraDepsCohs)).2 d ->
    mkDepsRestr.(_paintings).2 (mkDepsRestr.(_restrFrames).2 q Hq ε d) :=
  match q with
  | 0 => fun _ ε _ '(l; _) => l ε
  | q.+1 =>
    match extraDepsCohs with
    | TopCohDep E => fun Hq _ _ _ => match leR_O_contra Hq with end
    | AddCohDep depsCohs extraDepsCohs => fun Hq ε d '(l; c) =>
      (mkRestrLayer depsCohs.(_restrPaintings) depsCohs.(_cohs) q (⇓ Hq) ε d l;
       mkRestrPainting extraDepsCohs q (⇓ Hq) ε (d; l) c)
    end
  end.
```

Note that this term-level definition with explicit recursion over `q` turns to be cleaner and less verbose than the one proposed in pull request #9. This is the one implemented in this pull request.

Alternatively, we can continue using tactics, but explicitly use `induction q`:

```rocq
Definition mkRestrPainting `(extraDepsCohs: DepsCohsExtension p k depsCohs):
  mkRestrPaintingType (mkExtraDeps extraDepsCohs).
Proof.
  intros q.
  generalize dependent k.
  generalize dependent p.
  induction q as [| q mkRestrPainting]; intros * (l, c).
  - now exact (l ε).
  - destruct extraDepsCohs.
    + exfalso; now apply leR_O_contra in Hq.
    + unshelve esplit.
      * now exact (mkRestrLayer depsCohs.(_restrPaintings) depsCohs.(_cohs)
        q (⇓ Hq) ε d l).
      * now exact (mkRestrPainting p.+1 k depsCohs extraDepsCohs
        (⇓ Hq) ε (d; l) c).
Defined.
```
With both of the definitions above we get `mkRestrPainting extraDepsCohs 0 leR_O ε d (l; c) = (l ε)` provable by `reflexivity` without the need to destruct `extraDepsCohs`, which allows to avoid `refine (match ...)` trick in coherence equations for paintings. This is especially beneficial in a more complicated coherence proofs that I am working on, for degeneracies in all directions.
