### PR TITLE
Degeneracies in all directions

### DIFF
--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -16,4 +16,4 @@ jobs:
         uses: "coq-community/docker-coq-action@v1"
         with:
           opam_file: "bonak.opam"
-          coq_version: "latest"
+          coq_version: "9.1.1"

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -9,7 +9,7 @@ on:
       - "**/dune"
       - ".github/workflows/coq-action.yml"
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     paths:
       - "**.v"
       - "bonak.opam"

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -2,9 +2,20 @@ name: coq-action
 
 on:
   push:
-    paths: "**.v"
+    paths:
+      - "**.v"
+      - "bonak.opam"
+      - "dune-project"
+      - "**/dune"
+      - ".github/workflows/coq-action.yml"
   pull_request:
     types: [opened, reopened]
+    paths:
+      - "**.v"
+      - "bonak.opam"
+      - "dune-project"
+      - "**/dune"
+      - ".github/workflows/coq-action.yml"
 jobs:
   build:
     runs-on: "ubuntu-latest"

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -664,6 +664,62 @@ Fixpoint mkCohReflRestrPaintingBelowInfTypes {p}:
       &T mkCohReflRestrPaintingBelowInfType deps extraDeps }
   end.
 
+Definition mkCohReflRestrPaintingBelowSupType {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  (extraDeps: DepsReflCohs2Extension p.+1 k deps)
+  (cohFramesBelowSup: mkCohReflRestrFrameBelowSupType deps.(_depsReflCohs)): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= k) (ε: arity)
+    (d: FrameBase (RestrOfReflCohs2 deps))
+    (c: PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps) d),
+  rew [PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps)]
+    cohFramesBelowSup q r Hq Hr ε d in
+  deps.(_depsReflCohs).(_reflPaintingsBelow).2 q (Hq ↕ Hr)
+    ((RestrOfReflCohs2 deps).(_restrFrames).2 r Hr ε d)
+    ((CohsOfReflCohs2 deps).(_restrPaintings).2 r Hr ε d c) =
+  mkRestrPainting (CohsExtOfReflCohs2 deps.(1)) r.+1 (⇑ Hr) ε
+    (mkReflFrameBelow deps.(_depsReflCohs).(1) q (Hq ↕ ↑ Hr) d)
+    (mkReflPaintingBelow deps.(1) (deps; extraDeps) q (Hq ↕ ↑ Hr) d c).
+
+Fixpoint mkCohReflRestrPaintingBelowSupTypes {p}:
+  forall {k} (deps: DepsReflCohs2 p k)
+    (extraDeps: DepsReflCohs2Extension p k deps)
+    (cohFramesBelowSup: mkCohReflRestrFrameBelowSupTypes deps.(_depsReflCohs)),
+  Type :=
+  match p with
+  | 0 => fun _ _ _ _ => unit
+  | S p =>
+    fun k deps extraDeps cohFramesBelowSup =>
+    { _: mkCohReflRestrPaintingBelowSupTypes deps.(1) (deps; extraDeps)
+        cohFramesBelowSup.1
+      &T mkCohReflRestrPaintingBelowSupType deps extraDeps cohFramesBelowSup.2 }
+  end.
+
+Definition mkCohReflRestrPaintingAboveSupType {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  (extraDeps: DepsReflCohs2Extension p.+1 k deps): Type :=
+  forall q r (Hq: q <= p) (Hr: r <= k) (ε: arity)
+    (d: FrameBase (RestrOfReflCohs2 deps))
+    (c: PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps) d),
+  rew [mkPainting (RestrExtOfReflCohs2 deps)]
+    deps.(_cohReflRestrFramesAboveSup).2 q r Hq Hr ε d c in
+  deps.(_reflPaintingsAbove).2 q Hq _
+    ((CohsOfReflCohs2 deps).(_restrPaintings).2 r Hr ε d c) =
+  mkRestrPainting (CohsExtOfReflCohs2 deps) r Hr ε
+    (mkReflFrameAbove deps.(1) q Hq d c)
+    (mkReflPaintingAbove deps.(1) (deps; extraDeps) q Hq d c).
+
+Fixpoint mkCohReflRestrPaintingAboveSupTypes {p}:
+  forall {k}
+    (deps: DepsReflCohs2 p k)
+    (extraDeps: DepsReflCohs2Extension p k deps), Type :=
+  match p with
+  | 0 => fun _ _ _ => unit
+  | S p =>
+    fun k deps extraDeps =>
+    { _: mkCohReflRestrPaintingAboveSupTypes deps.(1) (deps; extraDeps)
+      &T mkCohReflRestrPaintingAboveSupType deps extraDeps }
+  end.
+
 Fixpoint mkIdReflRestrPaintingBelow {p k}
   (deps: DepsReflCohs2 p k)
   (extraDeps: DepsReflCohs2Extension p k deps):
@@ -699,57 +755,73 @@ Fixpoint mkIdReflRestrPaintingsBelow {p k}:
        mkIdReflRestrPaintingBelow deps extraDeps)
   end.
 
-(*
-
-Class DepsReflCohs2 p k := {
-  _depsReflCohs: DepsReflCohs p k;
-  _extraDepsCohs2: DepsCohs2Extension p k _depsReflCohs.(_depsCohs2);
-  _extraDepsRefl: DepsReflCohsExtension p k _depsReflCohs;
-  _cohReflRestrPaintings: mkCohReflRestrPaintingTypes _depsReflCohs _extraDepsRefl;
+Class DepsReflCohs3 p k := {
+  _depsReflCohs2: DepsReflCohs2 p k;
+  _extraDepsCohs2: DepsCohs2Extension p k (Cohs2OfReflCohs2 _depsReflCohs2);
+  _extraDepsReflCohs2: DepsReflCohs2Extension p k _depsReflCohs2;
+  _cohReflRestrFramesBelowSup:
+    mkCohReflRestrFrameBelowSupTypes _depsReflCohs2.(_depsReflCohs);
+  _cohReflRestrPaintingsBelowInf:
+    mkCohReflRestrPaintingBelowInfTypes _depsReflCohs2 _extraDepsReflCohs2;
+  _cohReflRestrPaintingsBelowSup:
+    mkCohReflRestrPaintingBelowSupTypes _depsReflCohs2 _extraDepsReflCohs2
+      _cohReflRestrFramesBelowSup;
+  _cohReflRestrPaintingsAboveSup:
+    mkCohReflRestrPaintingAboveSupTypes _depsReflCohs2 _extraDepsReflCohs2;
 }.
 
-Definition Cohs2OfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsCohs2 p k :=
-  depsCohs2.(_depsReflCohs).(_depsCohs2).
-
-Definition ReflBelowOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsReflBelow p k :=
-  ReflBelowOfReflCohs (depsCohs2.(_depsReflCohs)).
-
-Definition RestrOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsRestr p k :=
-  (ReflBelowOfReflCohs (depsCohs2.(_depsReflCohs))).(_deps).
-
-Definition CohsOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsCohs p k :=
-  depsCohs2.(_depsReflCohs).(_depsCohs2).(_depsCohs).
-
-Definition RestrExtOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsRestrExtension p k
-    (RestrOfReflCohs2 depsCohs2) :=
-  depsCohs2.(_depsReflCohs).(_depsCohs2).(_depsCohs).(_extraDeps).
-
-Definition CohsExtOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsCohsExtension p k
-    (CohsOfReflCohs2 depsCohs2) :=
-  depsCohs2.(_depsReflCohs).(_depsCohs2).(_extraDepsCohs).
-
 #[local]
-Instance proj1DepsReflCohs2 {p k} (depsCohs2: DepsReflCohs2 p.+1 k):
-DepsReflCohs2 p k.+1 :=
+Instance proj1DepsReflCohs3 {p k} (depsCohs3: DepsReflCohs3 p.+1 k):
+DepsReflCohs3 p k.+1 :=
 {|
-  _depsReflCohs := depsCohs2.(_depsReflCohs).(1);
-  _extraDepsCohs2 := (depsCohs2.(_depsReflCohs).(_depsCohs2);
-    depsCohs2.(_extraDepsCohs2));
-  _extraDepsRefl := (depsCohs2.(_depsReflCohs); depsCohs2.(_extraDepsRefl));
-  _cohReflRestrPaintings := depsCohs2.(_cohReflRestrPaintings).1;
+  _depsReflCohs2 := depsCohs3.(_depsReflCohs2).(1);
+  _extraDepsCohs2 := (Cohs2OfReflCohs2 depsCohs3.(_depsReflCohs2);
+    depsCohs3.(_extraDepsCohs2));
+  _extraDepsReflCohs2 := (depsCohs3.(_depsReflCohs2);
+    depsCohs3.(_extraDepsReflCohs2));
+  _cohReflRestrFramesBelowSup :=
+    depsCohs3.(_cohReflRestrFramesBelowSup).1;
+  _cohReflRestrPaintingsBelowInf :=
+    depsCohs3.(_cohReflRestrPaintingsBelowInf).1;
+  _cohReflRestrPaintingsBelowSup :=
+    depsCohs3.(_cohReflRestrPaintingsBelowSup).1;
+  _cohReflRestrPaintingsAboveSup :=
+    depsCohs3.(_cohReflRestrPaintingsAboveSup).1;
 |}.
 
-Declare Scope depsreflcohs2_scope.
-Delimit Scope depsreflcohs2_scope with depsreflcohs2.
-Bind Scope depsreflcohs2_scope with DepsReflCohs2.
-Notation "x .(1)" := (proj1DepsReflCohs2 x%depsreflcohs2)
-  (at level 1, left associativity, format "x .(1)"): depsreflcohs2_scope.
+Declare Scope depsreflcohs3_scope.
+Delimit Scope depsreflcohs3_scope with depsreflcohs3.
+Bind Scope depsreflcohs3_scope with DepsReflCohs3.
+Notation "x .(1)" := (proj1DepsReflCohs3 x%depsreflcohs3)
+  (at level 1, left associativity, format "x .(1)"): depsreflcohs3_scope.
+
+Definition ReflBelowOfReflCohs3 {p k}
+  (depsCohs3: DepsReflCohs3 p k): DepsReflBelow p k :=
+  ReflBelowOfReflCohs2 depsCohs3.(_depsReflCohs2).
+
+Definition RestrOfReflCohs3 {p k}
+  (depsCohs3: DepsReflCohs3 p k): DepsRestr p k :=
+  RestrOfReflCohs2 depsCohs3.(_depsReflCohs2).
+
+Definition CohsOfReflCohs3 {p k}
+  (depsCohs3: DepsReflCohs3 p k): DepsCohs p k :=
+  CohsOfReflCohs2 depsCohs3.(_depsReflCohs2).
+
+Definition Cohs2OfReflCohs3 {p k}
+  (depsCohs3: DepsReflCohs3 p k): DepsCohs2 p k :=
+  Cohs2OfReflCohs2 depsCohs3.(_depsReflCohs2).
+
+Definition RestrExtOfReflCohs3 {p k}
+  (depsCohs3: DepsReflCohs3 p k): DepsRestrExtension p k
+    (RestrOfReflCohs3 depsCohs3) :=
+  RestrExtOfReflCohs2 depsCohs3.(_depsReflCohs2).
+
+Definition CohsExtOfReflCohs3 {p k}
+  (depsCohs3: DepsReflCohs3 p k): DepsCohsExtension p k
+    (CohsOfReflCohs3 depsCohs3) :=
+  CohsExtOfReflCohs2 depsCohs3.(_depsReflCohs2).
+
+(*
 
 Definition mkCohReflRestrLayer {p k}
   (deps: DepsReflCohs2 p.+1 k)

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1348,22 +1348,10 @@ Proof.
         rewrite rew_app_rl. now trivial.
         now apply (deps'.(_frames).2.(UIP)).
       * destruct p.
-        -- destruct d.
-           eassert (h : (=eq_refl; _) = eq_refl).
+        -- rewrite <- (mkCohReflRestrPaintingAboveSup deps.(1) (deps;extraDeps) 0 r leR_O Hr ε d (l; c)).
+           destruct d.
+           enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
            now apply (mkFrame (RestrOfReflCohs2 (mkDepsReflCohs2 deps.(1)))).(UIP).
-           rewrite h; clear h.
-           destruct r.
-           ++ now trivial.
-           ++ destruct c as [l' c].
-              unshelve eapply eq_existT_curried.
-              ** rewrite <- (mkCohReflRestrLayerAboveSup deps ε 0 r (⇑ leR_O) Hr tt l l' c).
-                 now trivial.
-              ** rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 1 r (⇑ leR_O) Hr ε (tt; l) (l'; c)).
-                 set (deps' := RestrExtOfReflCohs2 (mkDepsReflCohs2 deps)).
-                 rewrite rew_map with (P := fun x => mkPainting deps' x).
-                 apply rew_swap with (P := fun x => mkPainting deps' x).
-                 rewrite rew_app_rl. now trivial.
-                 now apply (mkFrame (RestrOfReflCohs2 (mkDepsReflCohs2 deps))).(UIP).
         -- now exact (mkCohReflRestrPaintingAboveSup deps.(1) (deps;extraDeps) 0 r leR_O Hr ε d (l; c)).
   - destruct r; try contradiction.
     destruct extraDeps; try contradiction.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -68,19 +68,19 @@ Bind Scope depsreflbelow_scope with DepsReflBelow.
 Notation "x .(1)" := (proj1DepsReflBelow x%depsreflbelow)
   (at level 1, left associativity, format "x .(1)"): depsreflbelow_scope.
 
-Definition mkIdReflRestrFrameBelowType {p k}
+Definition mkIdRestrReflFrameBelowType {p k}
   (deps: DepsReflBelow p.+1 k): Type :=
   forall i (Hi: i <= k) ε (d: FramePrev deps.(_depsRestr)),
   deps.(_depsRestr).(_restrFrames).2 i Hi ε (deps.(_reflFramesBelow).2 i Hi d) = d.
 
-Fixpoint mkIdReflRestrFrameBelowTypes {p}:
+Fixpoint mkIdRestrReflFrameBelowTypes {p}:
   forall {k} (deps: DepsReflBelow p k), Type :=
   match p with
   | 0 => fun _ _ => unit
   | S p =>
     fun k deps =>
-    { _: mkIdReflRestrFrameBelowTypes deps.(1) &T
-      mkIdReflRestrFrameBelowType deps }
+    { _: mkIdRestrReflFrameBelowTypes deps.(1) &T
+      mkIdRestrReflFrameBelowType deps }
   end.
 
 Definition mkReflPaintingBelowType {p k} (deps: DepsReflBelow p.+1 k)
@@ -177,34 +177,34 @@ Definition mkCohReflRestrFrameBelowInfTypes {p k}
   (mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow deps reflFramesBelow
     reflPaintingsBelow).(CohReflRestrFrameBelowInfTypesDef).
 
-Definition mkIdReflRestrPaintingBelowType {p k}
+Definition mkIdRestrReflPaintingBelowType {p k}
   (deps: DepsCohs p.+1 k)
   (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
   (reflPaintingsBelow: mkReflPaintingBelowTypes (toDepsReflBelow deps reflFramesBelow)
     deps.(_extraDeps))
-  (idReflRestrFrames: mkIdReflRestrFrameBelowTypes (toDepsReflBelow deps reflFramesBelow)):
+  (idRestrReflFrames: mkIdRestrReflFrameBelowTypes (toDepsReflBelow deps reflFramesBelow)):
   Type :=
   forall i (Hi: i <= k) (ε: arity)
     (d: FramePrev deps.(_deps))
     (c: PaintingPrev deps.(_deps) d),
-  rew [PaintingPrev deps.(_deps)] idReflRestrFrames.2 i Hi ε d in
+  rew [PaintingPrev deps.(_deps)] idRestrReflFrames.2 i Hi ε d in
   deps.(_restrPaintings).2 i Hi ε
     (reflFramesBelow.2 i Hi d) (reflPaintingsBelow.2 i Hi d c) = c.
 
-Fixpoint mkIdReflRestrPaintingBelowTypes {p}:
+Fixpoint mkIdRestrReflPaintingBelowTypes {p}:
   forall {k} (deps: DepsCohs p k)
     (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
     (reflPaintingsBelow: mkReflPaintingBelowTypes (toDepsReflBelow deps reflFramesBelow)
       deps.(_extraDeps))
-    (idReflRestrFrames: mkIdReflRestrFrameBelowTypes (toDepsReflBelow deps reflFramesBelow)),
+    (idRestrReflFrames: mkIdRestrReflFrameBelowTypes (toDepsReflBelow deps reflFramesBelow)),
   Type :=
   match p with
   | 0 => fun _ _ _ _ _ => unit
   | S p =>
-    fun k deps reflFramesBelow reflPaintingsBelow idReflRestrFrames =>
-    { _: mkIdReflRestrPaintingBelowTypes deps.(1) reflFramesBelow.1 reflPaintingsBelow.1 idReflRestrFrames.1 &T
-      mkIdReflRestrPaintingBelowType deps reflFramesBelow reflPaintingsBelow
-        idReflRestrFrames }
+    fun k deps reflFramesBelow reflPaintingsBelow idRestrReflFrames =>
+    { _: mkIdRestrReflPaintingBelowTypes deps.(1) reflFramesBelow.1 reflPaintingsBelow.1 idRestrReflFrames.1 &T
+      mkIdRestrReflPaintingBelowType deps reflFramesBelow reflPaintingsBelow
+        idRestrReflFrames }
   end.
 
 Class DepsReflCohsInf p k := {
@@ -213,9 +213,9 @@ Class DepsReflCohsInf p k := {
   _reflFramesAbove: mkReflFrameAboveTypes _depsCohs.(_deps);
   _reflPaintingsBelow: mkReflPaintingBelowTypes
     (toDepsReflBelow _depsCohs _reflFramesBelow') _depsCohs.(_extraDeps);
-  _idReflRestrFramesBelow: mkIdReflRestrFrameBelowTypes
+  _idRestrReflFramesBelow: mkIdRestrReflFrameBelowTypes
     (toDepsReflBelow _depsCohs _reflFramesBelow');
-  _idReflRestrPaintingsBelow: mkIdReflRestrPaintingBelowTypes _depsCohs _reflFramesBelow' _reflPaintingsBelow _idReflRestrFramesBelow;
+  _idRestrReflPaintingsBelow: mkIdRestrReflPaintingBelowTypes _depsCohs _reflFramesBelow' _reflPaintingsBelow _idRestrReflFramesBelow;
   _cohReflRestrFramesBelowInf: mkCohReflRestrFrameBelowInfTypes _depsCohs _reflFramesBelow' _reflPaintingsBelow
 }.
 
@@ -226,8 +226,8 @@ Instance proj1DepsReflCohsInf {p k} (depsCohs: DepsReflCohsInf p.+1 k): DepsRefl
   _reflFramesBelow' := depsCohs.(_reflFramesBelow').1;
   _reflFramesAbove := depsCohs.(_reflFramesAbove).1;
   _reflPaintingsBelow := depsCohs.(_reflPaintingsBelow).1;
-  _idReflRestrFramesBelow := depsCohs.(_idReflRestrFramesBelow).1;
-  _idReflRestrPaintingsBelow := depsCohs.(_idReflRestrPaintingsBelow).1;
+  _idRestrReflFramesBelow := depsCohs.(_idRestrReflFramesBelow).1;
+  _idRestrReflPaintingsBelow := depsCohs.(_idRestrReflPaintingsBelow).1;
   _cohReflRestrFramesBelowInf := depsCohs.(_cohReflRestrFramesBelowInf).1;
 |}.
 
@@ -296,14 +296,14 @@ Fixpoint mkCohReflRestrFrameBelowSupTypes {p}:
       mkCohReflRestrFrameBelowSupType deps }
   end.
 
-Definition mkIdReflRestrLayerBelow {p k}
+Definition mkIdRestrReflLayerBelow {p k}
   (deps: DepsReflCohsInf p.+1 k)
   i (Hi: i <= k)
   (ε: arity)
   (d: FrameBase (RestrOfReflCohsInf deps))
   (l: mkLayer (RestrOfReflCohsInf deps).(_restrFrames) d)
-  (prevIdReflRestrFrames: mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps.(1))):
-  rew [mkLayer _] prevIdReflRestrFrames.2 i.+1 (⇑ Hi) ε d in
+  (prevIdRestrReflFrames: mkIdRestrReflFrameBelowTypes (mkDepsReflBelow deps.(1))):
+  rew [mkLayer _] prevIdRestrReflFrames.2 i.+1 (⇑ Hi) ε d in
   mkRestrLayer deps.(_depsCohs2).(_depsCohs).(_restrPaintings)
     (deps.(_depsCohs2).(_depsCohs).(_cohs)) i Hi ε _
       (mkReflLayerBelow deps.(_depsCohs2).(_depsCohs)
@@ -313,7 +313,7 @@ Proof.
   apply functional_extensionality_dep.
   intros θ.
   unfold mkRestrLayer, mkReflLayerBelow.
-  rewrite <- (deps.(_idReflRestrPaintingsBelow).2 i Hi ε _ (l θ)).
+  rewrite <- (deps.(_idRestrReflPaintingsBelow).2 i Hi ε _ (l θ)).
   rewrite <- map_subst_app, <- map_subst.
   set (deps' := deps.(_depsCohs2).(_depsCohs).(_deps)).
   rewrite rew_map with
@@ -328,24 +328,24 @@ Proof.
   now apply (RestrOfReflCohsInf deps).(_frames).2.(UIP).
 Defined.
 
-Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohsInf p k):
-  mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps).
+Fixpoint mkIdRestrReflFramesBelow {p k} (deps: DepsReflCohsInf p k):
+  mkIdRestrReflFrameBelowTypes (mkDepsReflBelow deps).
   destruct p.
   - unshelve econstructor.
     now exact tt.
     now intros i Hi ε [].
-  - set (h := mkIdReflRestrFramesBelow p k.+1 deps.(1)%depsreflcohsinf).
+  - set (h := mkIdRestrReflFramesBelow p k.+1 deps.(1)%depsreflcohsinf).
     unshelve econstructor.
     + now apply h.
     + intros i Hi ε [d l].
       unshelve eapply eq_existT_curried.
       * now exact (h.2 i.+1 (⇑ Hi) ε d).
-      * now exact (mkIdReflRestrLayerBelow deps i Hi ε d l h).
+      * now exact (mkIdRestrReflLayerBelow deps i Hi ε d l h).
 Defined.
 
-Definition mkIdReflRestrFrameBelow {p k} (deps: DepsReflCohsInf p k):
-  mkIdReflRestrFrameBelowType (mkDepsReflBelow deps) :=
-  (mkIdReflRestrFramesBelow deps).2.
+Definition mkIdRestrReflFrameBelow {p k} (deps: DepsReflCohsInf p k):
+  mkIdRestrReflFrameBelowType (mkDepsReflBelow deps) :=
+  (mkIdRestrReflFramesBelow deps).2.
 
 Class DepsReflAbove p k := {
   _depsRefl: DepsReflBelow p k;
@@ -399,7 +399,7 @@ Definition mkReflLayerAbove0 {p k} (deps: DepsReflCohsInf p k)
     (paintings := (mkDepsRestr (CohsOfReflCohsInf deps)).(_paintings))
     (mkDepsRestr (CohsOfReflCohsInf deps)).(_restrFrames)
     (mkReflFrameBelow deps 0 leR_O d) :=
-  fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c.
+  fun ε => rew <- mkIdRestrReflFrameBelow deps 0 leR_O ε d in c.
 
 Definition mkReflFrameAbove0 {p k} (deps: DepsReflCohsInf p k)
   (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
@@ -799,39 +799,39 @@ Fixpoint mkCohReflRestrPaintingAboveSupTypes {p}:
       &T mkCohReflRestrPaintingAboveSupType deps extraDeps }
   end.
 
-Fixpoint mkIdReflRestrPaintingBelow {p k}
+Fixpoint mkIdRestrReflPaintingBelow {p k}
   (deps: DepsReflCohsSup p k)
   (extraDeps: DepsReflCohsSupExtension p k deps):
-  mkIdReflRestrPaintingBelowType
+  mkIdRestrReflPaintingBelowType
     (mkDepsCohs (Cohs2OfReflCohsSup deps))
     (mkReflFramesBelow deps.(_depsReflCohsInf))
     (mkReflPaintingsBelow deps extraDeps)
-    (mkIdReflRestrFramesBelow deps.(_depsReflCohsInf)).
+    (mkIdRestrReflFramesBelow deps.(_depsReflCohsInf)).
 Proof.
   intros i Hi ε d c.
   destruct i.
   - now rewrite rew_compose, eq_trans_sym_inv_l.
   - destruct extraDeps; [now contradiction |].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting (RestrExtOfReflCohsSup deps))).
-    + now apply (mkIdReflRestrLayerBelow deps.(_depsReflCohsInf) i Hi ε).
+    + now apply (mkIdRestrReflLayerBelow deps.(_depsReflCohsInf) i Hi ε).
     + destruct c as [l c].
-      now exact (mkIdReflRestrPaintingBelow p.+1 k deps extraDeps i (⇓ Hi) ε (d; l) c).
+      now exact (mkIdRestrReflPaintingBelow p.+1 k deps extraDeps i (⇓ Hi) ε (d; l) c).
 Defined.
 
-Fixpoint mkIdReflRestrPaintingsBelow {p k}:
+Fixpoint mkIdRestrReflPaintingsBelow {p k}:
   forall (deps: DepsReflCohsSup p k) (extraDeps: DepsReflCohsSupExtension p k deps),
-  mkIdReflRestrPaintingBelowTypes
+  mkIdRestrReflPaintingBelowTypes
     (mkDepsCohs (Cohs2OfReflCohsSup deps))
     (mkReflFramesBelow deps.(_depsReflCohsInf))
     (mkReflPaintingsBelow deps extraDeps)
-    (mkIdReflRestrFramesBelow deps.(_depsReflCohsInf)) :=
+    (mkIdRestrReflFramesBelow deps.(_depsReflCohsInf)) :=
   match p with
   | 0 => fun deps extraDeps =>
-      (tt; mkIdReflRestrPaintingBelow deps extraDeps)
+      (tt; mkIdRestrReflPaintingBelow deps extraDeps)
   | S p =>
       fun deps extraDeps =>
-      (mkIdReflRestrPaintingsBelow deps.(1) (deps; extraDeps);
-       mkIdReflRestrPaintingBelow deps extraDeps)
+      (mkIdRestrReflPaintingsBelow deps.(1) (deps; extraDeps);
+       mkIdRestrReflPaintingBelow deps extraDeps)
   end.
 
 Definition mkCohReflBelowBelowFrameType {p k}
@@ -1165,9 +1165,9 @@ Proof.
     + now apply mkCohPaintings.
   - now apply mkReflFramesBelow.
   - now exact (mkReflPaintingsBelow _ deps.(_extraDepsReflCohsSup)).
-  - now apply mkIdReflRestrFramesBelow.
+  - now apply mkIdRestrReflFramesBelow.
   - now apply mkReflFramesAbove.
-  - now apply mkIdReflRestrPaintingsBelow. 
+  - now apply mkIdRestrReflPaintingsBelow. 
   - now apply mkCohReflRestrFramesBelowInf.
 Defined.
 
@@ -1721,8 +1721,8 @@ Proof.
   rewrite <- map_subst_app.
   eassert (coh_id_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
-    - now exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
-    - now exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
+    - now exact (mkIdRestrReflFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
+    - now exact (mkIdRestrReflPaintingBelow deps.(_depsReflCohsSup)
         deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
   rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
     deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
@@ -2087,11 +2087,11 @@ Definition dgnDepsReflCohsInf {p} (C: νSetData p)
   (reflPaintingsBelow: mkReflPaintingBelowTypes
     (dgnDepsReflBelow C reflFramesBelow)
     (TopRestrDep (deps := dgnDepsRestr C) E))
-  (idReflRestrFramesBelow:
-    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
-  (idReflRestrPaintingsBelow:
-    mkIdReflRestrPaintingBelowTypes (dgnDepsCohs C E)
-      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow)
+  (idRestrReflFramesBelow:
+    mkIdRestrReflFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
+  (idRestrReflPaintingsBelow:
+    mkIdRestrReflPaintingBelowTypes (dgnDepsCohs C E)
+      reflFramesBelow reflPaintingsBelow idRestrReflFramesBelow)
   (cohReflRestrFramesBelowInf:
     mkCohReflRestrFrameBelowInfTypes
       (dgnDepsCohs C E) reflFramesBelow reflPaintingsBelow):
@@ -2101,8 +2101,8 @@ Definition dgnDepsReflCohsInf {p} (C: νSetData p)
     _reflFramesBelow' := reflFramesBelow;
     _reflFramesAbove := reflFramesAbove;
     _reflPaintingsBelow := reflPaintingsBelow;
-    _idReflRestrFramesBelow := idReflRestrFramesBelow;
-    _idReflRestrPaintingsBelow := idReflRestrPaintingsBelow;
+    _idRestrReflFramesBelow := idRestrReflFramesBelow;
+    _idRestrReflPaintingsBelow := idRestrReflPaintingsBelow;
     _cohReflRestrFramesBelowInf := cohReflRestrFramesBelowInf;
   |}.
 
@@ -2114,11 +2114,11 @@ Definition dgnDepsReflCohsSup {p} (C: νSetData p)
   (reflPaintingsBelow: mkReflPaintingBelowTypes
     (dgnDepsReflBelow C reflFramesBelow)
     (TopRestrDep (deps := dgnDepsRestr C) E))
-  (idReflRestrFramesBelow:
-    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
-  (idReflRestrPaintingsBelow:
-    mkIdReflRestrPaintingBelowTypes (dgnDepsCohs C E)
-      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow)
+  (idRestrReflFramesBelow:
+    mkIdRestrReflFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
+  (idRestrReflPaintingsBelow:
+    mkIdRestrReflPaintingBelowTypes (dgnDepsCohs C E)
+      reflFramesBelow reflPaintingsBelow idRestrReflFramesBelow)
   (cohReflRestrFramesBelowInf:
     mkCohReflRestrFrameBelowInfTypes
       (dgnDepsCohs C E) reflFramesBelow reflPaintingsBelow)
@@ -2126,27 +2126,27 @@ Definition dgnDepsReflCohsSup {p} (C: νSetData p)
     mkCohReflRestrFrameBelowSupTypes
       (dgnDepsReflCohsInf C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         cohReflRestrFramesBelowInf))
   (reflPaintingsAbove:
     mkReflPaintingAboveTypes
       (AboveOfReflCohsInf
         (dgnDepsReflCohsInf C E E'
           reflFramesBelow reflFramesAbove reflPaintingsBelow
-          idReflRestrFramesBelow idReflRestrPaintingsBelow
+          idRestrReflFramesBelow idRestrReflPaintingsBelow
           cohReflRestrFramesBelowInf)))
   (cohReflRestrFramesAboveSup:
     mkCohReflRestrFrameAboveSupTypes
       (dgnDepsReflCohsInf C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         cohReflRestrFramesBelowInf)
       reflPaintingsAbove):
   DepsReflCohsSup p 0 :=
   {|
     _depsReflCohsInf := dgnDepsReflCohsInf C E E'
       reflFramesBelow reflFramesAbove reflPaintingsBelow
-      idReflRestrFramesBelow idReflRestrPaintingsBelow
+      idRestrReflFramesBelow idRestrReflPaintingsBelow
       cohReflRestrFramesBelowInf;
     _cohReflRestrFramesBelowSup := cohReflRestrFramesBelowSup;
     _reflPaintingsAbove := reflPaintingsAbove;
@@ -2161,11 +2161,11 @@ Definition dgnHasRefl {p} (C: νSetData p)
   (reflPaintingsBelow: mkReflPaintingBelowTypes
     (dgnDepsReflBelow C reflFramesBelow)
     (TopRestrDep (deps := dgnDepsRestr C) E))
-  (idReflRestrFramesBelow:
-    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
-  (idReflRestrPaintingsBelow:
-    mkIdReflRestrPaintingBelowTypes (dgnDepsCohs C E)
-      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow)
+  (idRestrReflFramesBelow:
+    mkIdRestrReflFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
+  (idRestrReflPaintingsBelow:
+    mkIdRestrReflPaintingBelowTypes (dgnDepsCohs C E)
+      reflFramesBelow reflPaintingsBelow idRestrReflFramesBelow)
   (cohReflRestrFramesBelowInf:
     mkCohReflRestrFrameBelowInfTypes
       (dgnDepsCohs C E) reflFramesBelow reflPaintingsBelow)
@@ -2173,26 +2173,26 @@ Definition dgnHasRefl {p} (C: νSetData p)
     mkCohReflRestrFrameBelowSupTypes
       (dgnDepsReflCohsInf C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         cohReflRestrFramesBelowInf))
   (reflPaintingsAbove:
     mkReflPaintingAboveTypes
       (AboveOfReflCohsInf
         (dgnDepsReflCohsInf C E E'
           reflFramesBelow reflFramesAbove reflPaintingsBelow
-          idReflRestrFramesBelow idReflRestrPaintingsBelow
+          idRestrReflFramesBelow idRestrReflPaintingsBelow
           cohReflRestrFramesBelowInf)))
   (cohReflRestrFramesAboveSup:
     mkCohReflRestrFrameAboveSupTypes
       (dgnDepsReflCohsInf C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         cohReflRestrFramesBelowInf)
       reflPaintingsAbove): Type :=
   HasRefl
     (dgnDepsReflCohsSup C E E'
       reflFramesBelow reflFramesAbove reflPaintingsBelow
-      idReflRestrFramesBelow idReflRestrPaintingsBelow
+      idRestrReflFramesBelow idRestrReflPaintingsBelow
       cohReflRestrFramesBelowInf
       cohReflRestrFramesBelowSup
       reflPaintingsAbove
@@ -2207,12 +2207,12 @@ Class DgnDataCore {p} (C: νSetData p)
     mkReflPaintingBelowTypes
       (dgnDepsReflBelow C reflFramesBelow)
       (TopRestrDep (deps := dgnDepsRestr C) E);
-  idReflRestrFramesBelow:
-    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow);
-  idReflRestrPaintingsBelow:
-    mkIdReflRestrPaintingBelowTypes
+  idRestrReflFramesBelow:
+    mkIdRestrReflFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow);
+  idRestrReflPaintingsBelow:
+    mkIdRestrReflPaintingBelowTypes
       (dgnDepsCohs C E)
-      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow;
+      reflFramesBelow reflPaintingsBelow idRestrReflFramesBelow;
   cohReflRestrFramesBelowInf
     (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
     mkCohReflRestrFrameBelowInfTypes
@@ -2222,7 +2222,7 @@ Class DgnDataCore {p} (C: νSetData p)
     mkCohReflRestrFrameBelowSupTypes
       (dgnDepsReflCohsInf C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         (cohReflRestrFramesBelowInf E'));
   reflPaintingsAbove
     (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
@@ -2230,14 +2230,14 @@ Class DgnDataCore {p} (C: νSetData p)
       (AboveOfReflCohsInf
         (dgnDepsReflCohsInf C E E'
           reflFramesBelow reflFramesAbove reflPaintingsBelow
-          idReflRestrFramesBelow idReflRestrPaintingsBelow
+          idRestrReflFramesBelow idRestrReflPaintingsBelow
           (cohReflRestrFramesBelowInf E')));
   cohReflRestrFramesAboveSup
     (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
     mkCohReflRestrFrameAboveSupTypes
       (dgnDepsReflCohsInf C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         (cohReflRestrFramesBelowInf E'))
       (reflPaintingsAbove E');
   cohReflBelowBelowFrames
@@ -2245,14 +2245,14 @@ Class DgnDataCore {p} (C: νSetData p)
     mkCohReflBelowBelowFrameTypes
       (dgnDepsReflCohsInf C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         (cohReflRestrFramesBelowInf E'));
   cohReflAboveBelowFrames
     (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
     mkCohReflAboveBelowFrameTypes
       (dgnDepsReflCohsSup C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         (cohReflRestrFramesBelowInf E')
         (cohReflRestrFramesBelowSup E')
         (reflPaintingsAbove E')
@@ -2262,7 +2262,7 @@ Class DgnDataCore {p} (C: νSetData p)
     mkCohReflAboveAboveFrameTypes
       (dgnDepsReflCohsSup C E E'
         reflFramesBelow reflFramesAbove reflPaintingsBelow
-        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        idRestrReflFramesBelow idRestrReflPaintingsBelow
         (cohReflRestrFramesBelowInf E')
         (cohReflRestrFramesBelowSup E')
         (reflPaintingsAbove E')
@@ -2277,7 +2277,7 @@ Definition dgnDepsReflCohsInfFromBase {p}
   dgnDepsReflCohsInf C E E'
     D.(reflFramesBelow) D.(reflFramesAbove)
     D.(reflPaintingsBelow)
-    D.(idReflRestrFramesBelow) D.(idReflRestrPaintingsBelow)
+    D.(idRestrReflFramesBelow) D.(idRestrReflPaintingsBelow)
     (D.(cohReflRestrFramesBelowInf) E').
 
 Definition dgnDepsReflCohsSupFromBase {p}
@@ -2300,7 +2300,7 @@ Definition dgnHasReflFromBase {p}
   dgnHasRefl C E E'
     D.(reflFramesBelow) D.(reflFramesAbove)
     D.(reflPaintingsBelow)
-    D.(idReflRestrFramesBelow) D.(idReflRestrPaintingsBelow)
+    D.(idRestrReflFramesBelow) D.(idRestrReflPaintingsBelow)
     (D.(cohReflRestrFramesBelowInf) E')
     (D.(cohReflRestrFramesBelowSup) E')
     (D.(reflPaintingsAbove) E')
@@ -2462,8 +2462,8 @@ Instance mkDgnData {p} (C: νSetData p)
     (mkReflFramesBelow depsInf)
     (mkReflFramesAbove depsSup)
     (mkReflPaintingsBelow depsSup extraSup)
-    (mkIdReflRestrFramesBelow depsInf)
-    (mkIdReflRestrPaintingsBelow depsSup extraSup)
+    (mkIdRestrReflFramesBelow depsInf)
+    (mkIdRestrReflPaintingsBelow depsSup extraSup)
     (fun E'' => mkCohReflRestrFramesBelowInf (deps2 E''))
     (fun E'' => mkCohReflRestrFramesBelowSup (deps2 E''))
     (fun _ => mkReflPaintingsAbove depsSup extraSup)

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -783,6 +783,112 @@ Fixpoint mkIdReflRestrPaintingsBelow {p k}:
        mkIdReflRestrPaintingBelow deps extraDeps)
   end.
 
+Definition mkCohReflReflFrameBelowType {p k}
+  (deps: DepsReflCohsInf p.+1 k): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= k) (d: FramePrev (RestrOfReflCohsInf deps)),
+  (mkReflFrameBelow deps.(1) q (Hq ↕ ↑ Hr) (deps.(_reflFramesBelow').2 r Hr d)) =
+  (mkReflFrameBelow deps.(1) r.+1 (⇑ Hr) (deps.(_reflFramesBelow').2 q (Hq ↕ Hr) d)).
+
+Fixpoint mkCohReflReflFrameBelowTypes {p}:
+  forall {k} (deps: DepsReflCohsInf p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkCohReflReflFrameBelowTypes deps.(1) &T
+      mkCohReflReflFrameBelowType deps }
+  end.
+
+Definition mkCohReflReflFrameAboveType {p k}
+  (deps: DepsReflCohsSup p.+1 k): Type :=
+  forall q r (Hq: q <= p) (Hr: r <= k)
+    (d: FramePrev (RestrOfReflCohsSup deps))
+    (c: PaintingPrev (RestrOfReflCohsSup deps) d),
+  mkReflFrameAbove deps.(1)%depsreflcohssup q Hq
+    (deps.(_depsReflCohsInf).(_reflFramesBelow').2 r Hr d)
+    (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 r Hr d c) =
+  mkReflFrameBelow deps.(_depsReflCohsInf) r Hr
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q Hq d c).
+
+Fixpoint mkCohReflReflFrameAboveTypes {p}:
+  forall {k} (deps: DepsReflCohsSup p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkCohReflReflFrameAboveTypes deps.(1) &T
+      mkCohReflReflFrameAboveType deps }
+  end.
+
+Definition mkCohReflReflPaintingBelowType {p k}
+  (deps: DepsReflCohsSup p.+1 k)
+  (extraDeps: DepsReflCohsSupExtension p.+1 k deps)
+  (cohReflReflFramesBelow:
+    mkCohReflReflFrameBelowTypes deps.(_depsReflCohsInf)): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= k)
+    (d: FramePrev (RestrOfReflCohsInf deps.(_depsReflCohsInf)))
+    (c: PaintingPrev (RestrOfReflCohsInf deps.(_depsReflCohsInf)) d),
+  rew [PaintingBase
+    (mkDepsRestr (CohsOfReflCohsInf deps.(_depsReflCohsInf).(1)))
+    (mkExtraDeps (CohsExtOfReflCohsInf deps.(_depsReflCohsInf).(1)))]
+    cohReflReflFramesBelow.2 q r Hq Hr d in
+  mkReflPaintingBelow
+    deps.(1)%depsreflcohssup
+    (deps; extraDeps)
+    q (Hq ↕ ↑ Hr)
+    (deps.(_depsReflCohsInf).(_reflFramesBelow').2 r Hr d)
+    (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 r Hr d c) =
+  mkReflPaintingBelow
+    deps.(1)%depsreflcohssup
+    (deps; extraDeps)
+    r.+1 (⇑ Hr)
+    (deps.(_depsReflCohsInf).(_reflFramesBelow').2 q (Hq ↕ Hr) d)
+    (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 q (Hq ↕ Hr) d c).
+
+Fixpoint mkCohReflReflPaintingBelowTypes {p}:
+  forall {k}
+    (deps: DepsReflCohsSup p k)
+    (extraDeps: DepsReflCohsSupExtension p k deps)
+    (cohReflReflFramesBelow:
+      mkCohReflReflFrameBelowTypes deps.(_depsReflCohsInf)), Type :=
+  match p with
+  | 0 => fun _ _ _ _ => unit
+  | S p =>
+    fun k deps extraDeps cohReflReflFramesBelow =>
+    { _: mkCohReflReflPaintingBelowTypes deps.(1) (deps; extraDeps)
+        cohReflReflFramesBelow.1 &T
+      mkCohReflReflPaintingBelowType deps extraDeps cohReflReflFramesBelow }
+  end.
+
+Definition mkCohReflReflPaintingAboveType {p k}
+  (deps: DepsReflCohsSup p.+1 k)
+  (extraDeps: DepsReflCohsSupExtension p.+1 k deps)
+  (cohReflReflFramesAbove: mkCohReflReflFrameAboveTypes deps): Type :=
+  forall q r (Hq: q <= p) (Hr: r <= k)
+    (d: FramePrev (RestrOfReflCohsSup deps))
+    (c: PaintingPrev (RestrOfReflCohsSup deps) d),
+  rew [mkPainting _] cohReflReflFramesAbove.2 q r Hq Hr d c in
+  mkReflPaintingAbove deps.(1) (deps; extraDeps) q Hq
+    (deps.(_depsReflCohsInf).(_reflFramesBelow').2 r Hr d)
+    (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 r Hr d c) =
+  mkReflPaintingBelow deps extraDeps r Hr
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q Hq d c)
+    (deps.(_reflPaintingsAbove).2 q Hq d c).
+
+Fixpoint mkCohReflReflPaintingAboveTypes {p}:
+  forall {k}
+    (deps: DepsReflCohsSup p k)
+    (extraDeps: DepsReflCohsSupExtension p k deps)
+    (cohReflReflFramesAbove : mkCohReflReflFrameAboveTypes deps), Type :=
+  match p with
+  | 0 => fun _ _ _ _ => unit
+  | S p =>
+    fun k deps extraDeps cohReflReflFramesAbove =>
+    { _: mkCohReflReflPaintingAboveTypes deps.(1) (deps; extraDeps)
+        cohReflReflFramesAbove.1 &T
+      mkCohReflReflPaintingAboveType deps extraDeps cohReflReflFramesAbove }
+  end.
+
 Class DepsReflCohs2 p k := {
   _depsReflCohsSup: DepsReflCohsSup p k;
   _extraDepsCohs2: DepsCohs2Extension p k (Cohs2OfReflCohsSup _depsReflCohsSup);
@@ -793,6 +899,16 @@ Class DepsReflCohs2 p k := {
     mkCohReflRestrPaintingBelowSupTypes _depsReflCohsSup _extraDepsReflCohsSup;
   _cohReflRestrPaintingsAboveSup:
     mkCohReflRestrPaintingAboveSupTypes _depsReflCohsSup _extraDepsReflCohsSup;
+  _cohReflReflFramesBelow:
+    mkCohReflReflFrameBelowTypes _depsReflCohsSup.(_depsReflCohsInf);
+  _cohReflReflPaintingsBelow:
+    mkCohReflReflPaintingBelowTypes
+      _depsReflCohsSup _extraDepsReflCohsSup _cohReflReflFramesBelow;
+  _cohReflReflFramesAbove:
+    mkCohReflReflFrameAboveTypes _depsReflCohsSup;
+  _cohReflReflPaintingsAbove:
+    mkCohReflReflPaintingAboveTypes
+      _depsReflCohsSup _extraDepsReflCohsSup _cohReflReflFramesAbove;
 }.
 
 #[local]
@@ -810,6 +926,14 @@ DepsReflCohs2 p k.+1 :=
     depsCohs2.(_cohReflRestrPaintingsBelowSup).1;
   _cohReflRestrPaintingsAboveSup :=
     depsCohs2.(_cohReflRestrPaintingsAboveSup).1;
+  _cohReflReflFramesBelow :=
+    depsCohs2.(_cohReflReflFramesBelow).1;
+  _cohReflReflPaintingsBelow :=
+    depsCohs2.(_cohReflReflPaintingsBelow).1;
+  _cohReflReflFramesAbove :=
+    depsCohs2.(_cohReflReflFramesAbove).1;
+  _cohReflReflPaintingsAbove :=
+    depsCohs2.(_cohReflReflPaintingsAbove).1;
 |}.
 
 Declare Scope depsreflcohs2_scope.
@@ -1310,116 +1434,8 @@ Proof.
     + now apply mkCohReflRestrPaintingBelowSup.
 Defined.
 
-Definition mkCohReflReflFrameBelowType {p k}
-  (deps: DepsReflCohsInf p.+1 k): Type :=
-  forall q r (Hq: q <= r) (Hr: r <= k) (d: FramePrev (RestrOfReflCohsInf deps)),
-  (mkReflFrameBelow deps.(1) q (Hq ↕ ↑ Hr) (deps.(_reflFramesBelow').2 r Hr d)) =
-  (mkReflFrameBelow deps.(1) r.+1 (⇑ Hr) (deps.(_reflFramesBelow').2 q (Hq ↕ Hr) d)).
-
-Fixpoint mkCohReflReflFrameBelowTypes {p}:
-  forall {k} (deps: DepsReflCohsInf p k), Type :=
-  match p with
-  | 0 => fun _ _ => unit
-  | S p =>
-    fun k deps =>
-    { _: mkCohReflReflFrameBelowTypes deps.(1) &T
-      mkCohReflReflFrameBelowType deps }
-  end.
-
-Definition mkCohReflReflFrameAboveType {p k}
-  (deps: DepsReflCohsSup p.+1 k): Type :=
-  forall q r (Hq: q <= p) (Hr: r <= k)
-    (d: FramePrev (RestrOfReflCohsSup deps))
-    (c: PaintingPrev (RestrOfReflCohsSup deps) d),
-  mkReflFrameAbove deps.(1)%depsreflcohssup q Hq
-    (deps.(_depsReflCohsInf).(_reflFramesBelow').2 r Hr d)
-    (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 r Hr d c) =
-  mkReflFrameBelow deps.(_depsReflCohsInf) r Hr
-    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q Hq d c).
-
-Fixpoint mkCohReflReflFrameAboveTypes {p}:
-  forall {k} (deps: DepsReflCohsSup p k), Type :=
-  match p with
-  | 0 => fun _ _ => unit
-  | S p =>
-    fun k deps =>
-    { _: mkCohReflReflFrameAboveTypes deps.(1) &T
-      mkCohReflReflFrameAboveType deps }
-  end.
-
-Definition mkCohReflReflPaintingBelowType {p k}
-  (deps: DepsReflCohs2 p.+1 k)
-  (cohReflReflFramesBelow:
-    mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps)): Type :=
-  forall q r (Hq: q <= r) (Hr: r <= k)
-    (d: FramePrev (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)))
-    (c: PaintingPrev (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)) d),
-  rew [PaintingBase
-    (mkDepsRestr (CohsOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))
-    (mkExtraDeps (CohsExtOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))]
-    cohReflReflFramesBelow.2 q r Hq Hr d in
-  mkReflPaintingBelow
-    deps.(_depsReflCohsSup).(1)
-    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))
-    q (Hq ↕ ↑ Hr)
-    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d)
-    ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d c) =
-  mkReflPaintingBelow
-    deps.(_depsReflCohsSup).(1)
-    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))
-    r.+1 (⇑ Hr)
-    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q (Hq ↕ Hr) d)
-    ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 q (Hq ↕ Hr) d c).
-
-Fixpoint mkCohReflReflPaintingBelowTypes {p}:
-  forall {k} (deps: DepsReflCohs2 p k)
-    (cohReflReflFramesBelow :
-      mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps)), Type :=
-  match p with
-  | 0 => fun _ _ _ => unit
-  | S p =>
-    fun k deps cohReflReflFramesBelow =>
-    { _: mkCohReflReflPaintingBelowTypes deps.(1) cohReflReflFramesBelow.1 &T
-      mkCohReflReflPaintingBelowType deps cohReflReflFramesBelow }
-  end.
-
-Definition mkCohReflReflPaintingAboveType {p k}
-  (deps: DepsReflCohs2 p.+1 k)
-  (cohReflReflFramesAbove:
-    mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup)): Type :=
-  forall q r (Hq: q <= p) (Hr: r <= k)
-    (d: FramePrev (RestrOfReflCohsSup deps.(_depsReflCohsSup)))
-    (c: PaintingPrev (RestrOfReflCohsSup deps.(_depsReflCohsSup)) d),
-  rew [mkPainting _] cohReflReflFramesAbove.2 q r Hq Hr d c in
-  mkReflPaintingAbove
-    deps.(_depsReflCohsSup).(1)
-    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))
-    q Hq
-    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d)
-    ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d c) =
-  mkReflPaintingBelow
-    deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) r Hr
-    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesAbove).2 q Hq d c)
-    (deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q Hq d c).
-
-Fixpoint mkCohReflReflPaintingAboveTypes {p}:
-  forall {k} (deps: DepsReflCohs2 p k)
-    (cohReflReflFramesAbove :
-      mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup)), Type :=
-  match p with
-  | 0 => fun _ _ _ => unit
-  | S p =>
-    fun k deps cohReflReflFramesAbove =>
-    { _: mkCohReflReflPaintingAboveTypes deps.(1) cohReflReflFramesAbove.1 &T
-      mkCohReflReflPaintingAboveType deps cohReflReflFramesAbove }
-  end.
-
 Definition mkCohReflReflLayerBelow {p k}
   (deps: DepsReflCohs2 p.+1 k)
-  (cohReflReflFramesBelow:
-    mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps))
-  (cohReflReflPaintingsBelow:
-    mkCohReflReflPaintingBelowTypes deps cohReflReflFramesBelow)
   q r (Hq: q <= r) (Hr: r <= k)
   (d: mkFrame (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))
   (l: mkLayer (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)).(_restrFrames) d)
@@ -1462,7 +1478,7 @@ Proof.
     (mkDepsReflCohsInf deps).(1).(_depsCohs2).(_depsCohs)
     (mkDepsReflCohsInf deps).(1).(_reflFramesBelow'))).
   simpl.
-  rewrite <- (cohReflReflPaintingsBelow.2 q r Hq Hr d0 (l θ)).
+  rewrite <- (deps.(_cohReflReflPaintingsBelow).2 q r Hq Hr d0 (l θ)).
   rewrite rew_map with
     (P := fun b => deps'.(1).(_paintings).2 b)
     (f := fun x => deps'.(1).(_restrFrames).2 0 leR_O θ x).
@@ -1478,31 +1494,23 @@ Proof.
   now apply (deps'.(1).(_frames).2.(UIP)).
 Defined.
 
-Fixpoint mkCohReflReflFramesBelow {p k} (deps: DepsReflCohs2 p k)
-  (cohReflReflFramesBelow: mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps))
-  (cohReflReflPaintingsBelow: mkCohReflReflPaintingBelowTypes deps cohReflReflFramesBelow):
+Fixpoint mkCohReflReflFramesBelow {p k} (deps: DepsReflCohs2 p k):
   mkCohReflReflFrameBelowTypes (mkDepsReflCohsInf deps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
     now intros q r Hq Hr [].
-  - set (h := mkCohReflReflFramesBelow p k.+1 deps.(1)%depsreflcohs2
-      cohReflReflFramesBelow.1 cohReflReflPaintingsBelow.1).
+  - set (h := mkCohReflReflFramesBelow p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor.
     + now exact h.
     + intros q r Hq Hr [d l].
       unshelve eapply eq_existT_curried.
       * now exact (h.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) d).
-      * now exact (mkCohReflReflLayerBelow deps cohReflReflFramesBelow
-          cohReflReflPaintingsBelow q r Hq Hr d l h).
+      * now exact (mkCohReflReflLayerBelow deps q r Hq Hr d l h).
 Defined.
 
 Definition mkCohReflReflLayerAbove {p k}
   (deps: DepsReflCohs2 p.+1 k)
-  (cohReflReflFramesAbove:
-    mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup))
-  (cohReflReflPaintingsAbove:
-    mkCohReflReflPaintingAboveTypes deps cohReflReflFramesAbove)
   q r (Hq: q <= p) (Hr: r <= k)
   (d: mkFrame ((RestrOfReflCohs2 deps).(1)))
   (l: mkLayer
@@ -1546,9 +1554,9 @@ Proof.
     (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x.1 x.2)
     coh_below_inf_pair_eq tt).
 
-  rewrite (proj2 (@rew_swap _ _ _ _ (cohReflReflFramesAbove.2 q r Hq Hr d0 c0)
+  rewrite (proj2 (@rew_swap _ _ _ _ (deps.(_cohReflReflFramesAbove).2 q r Hq Hr d0 c0)
     ((mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x0.1 x0.2) _)
-    (cohReflReflPaintingsAbove.2 q r Hq Hr d0 c0)).
+    (deps.(_cohReflReflPaintingsAbove).2 q r Hq Hr d0 c0)).
 
   eassert (coh_above_sup_pair_eq : (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
@@ -1581,25 +1589,18 @@ Proof.
     (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_frames).2.(UIP)).
 Defined.
 
-Fixpoint mkCohReflReflFramesAbove {p k} (deps: DepsReflCohs2 p k)
-  (cohReflReflFramesBelow: mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps))
-  (cohReflReflPaintingsBelow: mkCohReflReflPaintingBelowTypes deps cohReflReflFramesBelow)
-  (cohReflReflFramesAbove: mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup))
-  (cohReflReflPaintingsAbove: mkCohReflReflPaintingAboveTypes deps cohReflReflFramesAbove):
+Fixpoint mkCohReflReflFramesAbove {p k} (deps: DepsReflCohs2 p k):
   mkCohReflReflFrameAboveTypes (mkDepsReflCohsSup deps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
     now intros q r Hq Hr [].
-  - set (h := mkCohReflReflFramesAbove p k.+1 deps.(1)%depsreflcohs2
-      cohReflReflFramesBelow.1 cohReflReflPaintingsBelow.1
-      cohReflReflFramesAbove.1 cohReflReflPaintingsAbove.1).
+  - set (h := mkCohReflReflFramesAbove p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor. now exact h.
     intros q r Hq Hr [d l] c.
     destruct q.
     + unshelve eapply eq_existT_curried.
-      * now exact ((mkCohReflReflFramesBelow deps
-          cohReflReflFramesBelow cohReflReflPaintingsBelow).2 0 r leR_O Hr (d; l)).
+      * now exact ((mkCohReflReflFramesBelow deps).2 0 r leR_O Hr (d; l)).
       * apply functional_extensionality_dep.
         intro θ.
         unfold mkReflLayerBelow.
@@ -1617,8 +1618,7 @@ Proof.
         now apply (deps'.(_frames).2.(UIP)).
     + unshelve eapply eq_existT_curried.
       * now exact (h.2 q r.+1 Hq (⇑ Hr) d (l; c)).
-      * now exact (mkCohReflReflLayerAbove deps cohReflReflFramesAbove
-          cohReflReflPaintingsAbove q r Hq Hr d l c h).
+      * now exact (mkCohReflReflLayerAbove deps q r Hq Hr d l c h).
 Defined.
 
 (*

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1248,63 +1248,6 @@ Proof.
     + now apply mkCohReflRestrPaintingBelowInf.
 Defined.
 
-Fixpoint mkCohReflRestrPaintingBelowSup {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
-  mkCohReflRestrPaintingBelowSupType
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
-Proof.
-  intros q r Hq Hr ε d [l c].
-  destruct q.
-  - destruct extraDeps.
-    + destruct r; try contradiction.
-      simpl.
-      admit.
-    + unshelve eapply (eq_existT_curried_dep
-        (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
-      * apply functional_extensionality_dep.
-        intro θ.
-        unfold mkRestrLayer.
-        rewrite <- map_subst_app, <- !map_subst.
-        set (deps' := (CohsOfReflCohs2 (mkDepsReflCohs2 deps.(1))).(_deps)).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
-        rewrite 2 rew_compose.
-        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-        rewrite rew_app_rl. now trivial.
-        now apply (deps'.(_frames).2.(UIP)).
-      * admit.
-  - destruct r; try contradiction.
-    destruct extraDeps; try contradiction.
-    unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
-    + now exact (mkCohReflRestrLayerBelowSup deps ε q r (⇓ Hq) (⇓ Hr) d l
-        (mkCohReflRestrFramesBelowSup deps.(1))).
-    + now exact (mkCohReflRestrPaintingBelowSup p.+1 k deps extraDeps
-        q r Hq Hr ε (d; l) c).
-Admitted.
-
-Fixpoint mkCohReflRestrPaintingsBelowSup {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
-  mkCohReflRestrPaintingBelowSupTypes
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
-Proof.
-  destruct p.
-  - unshelve econstructor. now exact tt.
-    now apply mkCohReflRestrPaintingBelowSup.
-  - unshelve econstructor.
-    + now exact (mkCohReflRestrPaintingsBelowSup p k.+1
-        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
-    + now apply mkCohReflRestrPaintingBelowSup.
-Defined.
-
 Fixpoint mkCohReflRestrPaintingAboveSup {p k}
   (deps: DepsReflCohs3 p k)
   (extraDeps: DepsReflCohs3Extension p k deps):
@@ -1312,11 +1255,7 @@ Fixpoint mkCohReflRestrPaintingAboveSup {p k}
     (mkDepsReflCohs2 deps)
     (mkExtraDepsReflCohs2 deps extraDeps).
 Proof.
-  intros q r Hq Hr ε d [l c].
-  destruct extraDeps.
-  - destruct r; try contradiction.
-    admit.
-  - admit.
+  admit.
 Admitted.
 
 Fixpoint mkCohReflRestrPaintingsAboveSup {p k}
@@ -1335,6 +1274,105 @@ Proof.
     + now apply mkCohReflRestrPaintingAboveSup.
 Defined.
 
+Fixpoint mkCohReflRestrPaintingBelowSup {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingBelowSupType
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
+Proof.
+  intros q r Hq Hr ε d [l c].
+  destruct q.
+  - destruct extraDeps.
+    + destruct r; try contradiction.
+      destruct deps as [deps2 extraDeps2 extraDepsRefl2 ? ? ?].
+      destruct (match_TopReflCoh2Dep extraDepsRefl2) as [L' ->].
+      destruct (match_TopCoh2Dep extraDeps2) as [E ->].
+      destruct deps2 as [depsReflCohs ? ? ?].
+      destruct depsReflCohs as [depsCohs2 ? ? ? ? ? ?].
+      destruct depsCohs2 as [depsCohs extraDepsCohs ?].
+      destruct (match_TopCohDep extraDepsCohs) as [E' ->].
+      unshelve eapply (eq_existT_curried_dep (Q := E')).
+      * apply functional_extensionality_dep.
+        intro θ.
+        unfold mkRestrLayer.
+        rewrite <- map_subst_app, <- !map_subst.
+        set (deps' := mkDepsRestr depsCohs).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun d0 => deps'.(_restrFrames).2 0 Hr ε d0).
+        rewrite 2 rew_compose.
+        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+        rewrite rew_app_rl. now trivial.
+        now apply (deps'.(_frames).2.(UIP)).
+      * destruct p.
+        -- destruct d.
+           enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
+           now apply (mkFrame (mkDepsRestr depsCohs)).(UIP).
+        -- now trivial.
+    + unshelve eapply (eq_existT_curried_dep
+        (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
+      * apply functional_extensionality_dep.
+        intro θ.
+        unfold mkRestrLayer.
+        rewrite <- map_subst_app, <- !map_subst.
+        set (deps' := (CohsOfReflCohs2 (mkDepsReflCohs2 deps.(1))).(_deps)).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+        rewrite 2 rew_compose.
+        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+        rewrite rew_app_rl. now trivial.
+        now apply (deps'.(_frames).2.(UIP)).
+      * destruct p.
+        -- destruct d.
+           eassert (h : (=eq_refl; _) = eq_refl).
+           now apply (mkFrame (RestrOfReflCohs2 (mkDepsReflCohs2 deps.(1)))).(UIP).
+           rewrite h; clear h.
+           destruct r.
+           ++ now trivial.
+           ++ destruct c as [l' c].
+              unshelve eapply eq_existT_curried.
+              ** rewrite <- (mkCohReflRestrLayerAboveSup deps ε 0 r (⇑ leR_O) Hr tt l l' c).
+                 now trivial.
+              ** rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 1 r (⇑ leR_O) Hr ε (tt; l) (l'; c)).
+                 set (deps' := RestrExtOfReflCohs2 (mkDepsReflCohs2 deps)).
+                 rewrite rew_map with (P := fun x => mkPainting deps' x).
+                 apply rew_swap with (P := fun x => mkPainting deps' x).
+                 rewrite rew_app_rl. now trivial.
+                 now apply (mkFrame (RestrOfReflCohs2 (mkDepsReflCohs2 deps))).(UIP).
+        -- now exact (mkCohReflRestrPaintingAboveSup deps.(1) (deps;extraDeps) 0 r leR_O Hr ε d (l; c)).
+  - destruct r; try contradiction.
+    destruct extraDeps; try contradiction.
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
+    + now exact (mkCohReflRestrLayerBelowSup deps ε q r (⇓ Hq) (⇓ Hr) d l
+        (mkCohReflRestrFramesBelowSup deps.(1))).
+    + now exact (mkCohReflRestrPaintingBelowSup p.+1 k deps extraDeps
+        q r Hq Hr ε (d; l) c).
+Defined.
+
+Fixpoint mkCohReflRestrPaintingsBelowSup {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingBelowSupTypes
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflRestrPaintingBelowSup.
+  - unshelve econstructor.
+    + now exact (mkCohReflRestrPaintingsBelowSup p k.+1
+        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
+    + now apply mkCohReflRestrPaintingBelowSup.
+Defined.
 
 (*
 Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -341,7 +341,7 @@ Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohs p k):
       * now exact (mkIdReflRestrLayerBelow deps i Hi ε l c h).
 Defined.
 
-Definition mkIdReflRestrBelowFrame {p k} (deps: DepsReflCohs p k):
+Definition mkIdReflRestrFrameBelow {p k} (deps: DepsReflCohs p k):
   mkIdReflRestrFrameBelowType (mkDepsReflBelow deps) :=
   (mkIdReflRestrFramesBelow deps).2.
 
@@ -434,7 +434,7 @@ Fixpoint mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove {p k}:
           (d: FramePrev (mkDepsRestr (CohsOfReflCohs deps)))
           (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs deps)) d) :=
           (mkReflFrameBelow deps 0 leR_O d;
-            fun ε => rew <- mkIdReflRestrBelowFrame deps 0 leR_O ε d in c) in
+            fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c) in
         ((tt; reflFrameAbove): mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohs deps)))
     |}
   | S p => fun deps reflPaintingsAbove =>
@@ -450,7 +450,7 @@ Fixpoint mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove {p k}:
           match i return i <= p.+1 -> mkFrame (mkDepsRestr (CohsOfReflCohs deps)) with
           | 0 => fun _ =>
             (mkReflFrameBelow deps 0 leR_O d;
-              fun ε => rew <- mkIdReflRestrBelowFrame deps 0 leR_O ε d in c)
+              fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c)
           | i.+1 => fun Hi =>
             (prevReflFrames.2 i Hi d.1 (d.2; c);
               mkReflLayerAbove deps reflPaintingsAbove prev Q i (⇓ Hi) d.1 (d.2; c))
@@ -592,7 +592,49 @@ Definition mkReflPaintingsAbove {p k}:
   fun deps extraDeps =>
     (mkReflPaintingsAbovePrefix deps extraDeps; mkReflPaintingAbove deps extraDeps).
 
-Fixpoint mkReflPaintingBelow {p k}
+Definition mkReflPaintingBelow1 {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps)
+  i (Hi: i <= k)
+  (d: FramePrev (mkDepsReflBelow deps.(_depsReflCohs)).(_depsRestr))
+  (c: PaintingPrev (mkDepsReflBelow deps .(_depsReflCohs)) .(_depsRestr) d) :
+  (mkLayer
+    (paintings := (mkDepsReflBelow deps .(_depsReflCohs)).(_depsRestr).(_paintings))
+    (mkDepsReflBelow deps .(_depsReflCohs)).(_depsRestr).(_restrFrames)
+    ((mkDepsReflBelow deps .(_depsReflCohs)).(_reflFramesBelow).2 i Hi d)).
+Proof.
+  destruct i.
+  - intros ε.
+    rewrite (mkIdReflRestrFrameBelow deps.(_depsReflCohs) 0 leR_O ε d).
+    now exact c.
+  - destruct extraDeps; [now contradiction |].
+    destruct c as [l c'].
+    now exact (mkReflLayerBelow _ _
+      deps.(_depsReflCohs).(_reflPaintingsBelow) _ _ i Hi d l).
+Defined.
+
+Fixpoint mkReflPaintingBelow2 {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps)
+  i (Hi: i <= k)
+  (d: FramePrev (mkDepsReflBelow deps.(_depsReflCohs)).(_depsRestr))
+  (c: PaintingPrev (mkDepsReflBelow deps .(_depsReflCohs)) .(_depsRestr) d)
+  {struct i} :
+  (mkPainting (mkExtraDeps (CohsExtOfReflCohs2 deps))
+    (mkReflFrameBelow deps.(_depsReflCohs) i Hi d;
+    (mkReflPaintingBelow1 deps extraDeps i Hi d c))).
+Proof.
+  destruct i.
+  - refine (rew _ in mkReflPaintingAbove deps extraDeps 0 leR_O d c).
+    now destruct p.
+  - destruct extraDeps; [now contradiction |].
+    destruct c as [l c'].
+    unshelve econstructor.
+    + now exact (mkReflPaintingBelow1 deps extraDeps i (⇓ Hi) (d; l) c').
+    + now exact (mkReflPaintingBelow2 p.+1 k deps extraDeps i (⇓ Hi) (d; l) c').
+Defined.
+
+Definition mkReflPaintingBelow {p k}
   (deps: DepsReflCohs2 p k)
   (extraDeps: DepsReflCohs2Extension p k deps):
   mkReflPaintingBelowType
@@ -600,19 +642,9 @@ Fixpoint mkReflPaintingBelow {p k}
     (mkExtraDeps (CohsExtOfReflCohs2 deps)).
 Proof.
   intros i Hi d c.
-  destruct i.
-  - unshelve econstructor.
-    + intros ε.
-      rewrite (mkIdReflRestrBelowFrame deps.(_depsReflCohs) 0 leR_O ε d).
-      now exact c.
-    + refine (rew _ in mkReflPaintingAbove deps extraDeps 0 leR_O d c).
-      now destruct p.
-  - destruct extraDeps; [now contradiction |].
-    destruct c as [l c'].
-    unshelve econstructor.
-    + now exact (mkReflLayerBelow _ _
-        deps.(_depsReflCohs).(_reflPaintingsBelow) _ _ i Hi d l).
-    + now exact (mkReflPaintingBelow p.+1 k deps extraDeps i (⇓ Hi) (d; l) c').
+  unshelve econstructor.
+  - now exact (mkReflPaintingBelow1 deps extraDeps i Hi d c).
+  - now exact (mkReflPaintingBelow2 deps extraDeps i Hi d c).
 Defined.
 
 Fixpoint mkReflPaintingsBelowPrefix {p k}:
@@ -1300,59 +1332,29 @@ Fixpoint mkCohReflRestrPaintingBelowSup {p k}
 Proof.
   intros q r Hq Hr ε d [l c].
   destruct q.
-  - destruct extraDeps.
-    + destruct r; try contradiction.
-      destruct deps as [deps2 extraDeps2 extraDepsRefl2 ? ? ?].
-      destruct (match_TopReflCoh2Dep extraDepsRefl2) as [L' ->].
-      destruct (match_TopCoh2Dep extraDeps2) as [E ->].
-      destruct deps2 as [depsReflCohs ? ? ?].
-      destruct depsReflCohs as [depsCohs2 ? ? ? ? ? ?].
-      destruct depsCohs2 as [depsCohs extraDepsCohs ?].
-      destruct (match_TopCohDep extraDepsCohs) as [E' ->].
-      unshelve eapply (eq_existT_curried_dep (Q := E')).
-      * apply functional_extensionality_dep.
-        intro θ.
-        unfold mkRestrLayer.
-        rewrite <- map_subst_app, <- !map_subst.
-        set (deps' := mkDepsRestr depsCohs).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun d0 => deps'.(_restrFrames).2 0 Hr ε d0).
-        rewrite 2 rew_compose.
-        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-        rewrite rew_app_rl. now trivial.
-        now apply (deps'.(_frames).2.(UIP)).
-      * destruct p.
-        -- destruct d.
-           enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
-           now apply (mkFrame (mkDepsRestr depsCohs)).(UIP).
-        -- now trivial.
-    + unshelve eapply (eq_existT_curried_dep
-        (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
-      * apply functional_extensionality_dep.
-        intro θ.
-        unfold mkRestrLayer.
-        rewrite <- map_subst_app, <- !map_subst.
-        set (deps' := (CohsOfReflCohs2 (mkDepsReflCohs2 deps.(1))).(_deps)).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
-        rewrite 2 rew_compose.
-        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-        rewrite rew_app_rl. now trivial.
-        now apply (deps'.(_frames).2.(UIP)).
-      * destruct p.
-        -- rewrite <- (mkCohReflRestrPaintingAboveSup deps.(1) (deps;extraDeps) 0 r leR_O Hr ε d (l; c)).
-           destruct d.
-           enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
-           now apply (mkFrame (RestrOfReflCohs2 (mkDepsReflCohs2 deps.(1)))).(UIP).
-        -- now exact (mkCohReflRestrPaintingAboveSup deps.(1) (deps;extraDeps) 0 r leR_O Hr ε d (l; c)).
+  - unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps)))).
+    + apply functional_extensionality_dep.
+      intro θ.
+      unfold mkRestrLayer.
+      rewrite <- map_subst_app, <- !map_subst.
+      set (deps' := (mkDepsRestr (Cohs2OfReflCohs3 deps).(_depsCohs))).
+      rewrite rew_map with
+        (P := fun b => deps'.(_paintings).2 b)
+        (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+      rewrite rew_map with
+        (P := fun b => deps'.(_paintings).2 b)
+        (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+      rewrite 2 rew_compose.
+      apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+      rewrite rew_app_rl. now trivial.
+      now apply (deps'.(_frames).2.(UIP)).
+    + destruct p.
+      * rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
+        destruct d.
+        enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
+        now apply (mkFrame (RestrOfReflCohs2 (mkDepsReflCohs2 deps))).(UIP).
+      * now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
   - destruct r; try contradiction.
     destruct extraDeps; try contradiction.
     unshelve eapply (eq_existT_curried_dep

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1765,7 +1765,9 @@ Proof.
       rewrite rew_app_rl. now trivial.
       now apply (deps'.(_frames).2.(UIP)).
     + destruct p.
-      * rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
+      * set (h := mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
+        unfold mkRestrPainting in h |- *.
+        rewrite <- h; clear h.
         destruct d.
         enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
         now apply (mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
@@ -1871,7 +1873,9 @@ Proof.
       now apply (mkFrame _).(UIP).
     + unfold mkReflPaintingBelow2; cbn [eq_rect].
       destruct p.
-      * rewrite <- (mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
+      * set (h := mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
+        unfold mkReflPaintingAbove in h |- *.
+        rewrite <- h; clear h.
         match goal with
         | |- rew [?P1'] ?H2' in rew [?P2'] ?H1' in ?y = ?x =>
           set (H2 := H2'); set (H1 := H1')
@@ -1879,7 +1883,9 @@ Proof.
         rewrite rew_compose.
         enough (HEq: H1 • H2 = eq_refl) by (now rewrite HEq).
         now apply (mkFrame (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))).(UIP).
-      * rewrite <- (mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
+      * set (h := mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
+        unfold mkReflPaintingAbove in h |- *.
+        rewrite <- h; clear h.
         match goal with
         | |- rew [?P1'] ?H2' in rew [?P2'] ?H1' in ?y = ?x =>
           set (H2 := H2'); set (H1 := H1')

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1383,6 +1383,37 @@ Fixpoint mkCohReflReflPaintingBelowTypes {p}:
       mkCohReflReflPaintingBelowType deps cohReflReflFramesBelow }
   end.
 
+Definition mkCohReflReflPaintingAboveType {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  (cohReflReflFramesAbove:
+    mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup)): Type :=
+  forall q r (Hq: q <= p) (Hr: r <= k)
+    (d: FramePrev (RestrOfReflCohsSup deps.(_depsReflCohsSup)))
+    (c: PaintingPrev (RestrOfReflCohsSup deps.(_depsReflCohsSup)) d),
+  rew [mkPainting _] cohReflReflFramesAbove.2 q r Hq Hr d c in
+  mkReflPaintingAbove
+    deps.(_depsReflCohsSup).(1)
+    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))
+    q Hq
+    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d)
+    ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d c) =
+  mkReflPaintingBelow
+    deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) r Hr
+    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesAbove).2 q Hq d c)
+    (deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q Hq d c).
+
+Fixpoint mkCohReflReflPaintingAboveTypes {p}:
+  forall {k} (deps: DepsReflCohs2 p k)
+    (cohReflReflFramesAbove :
+      mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup)), Type :=
+  match p with
+  | 0 => fun _ _ _ => unit
+  | S p =>
+    fun k deps cohReflReflFramesAbove =>
+    { _: mkCohReflReflPaintingAboveTypes deps.(1) cohReflReflFramesAbove.1 &T
+      mkCohReflReflPaintingAboveType deps cohReflReflFramesAbove }
+  end.
+
 Definition mkCohReflReflLayerBelow {p k}
   (deps: DepsReflCohs2 p.+1 k)
   (cohReflReflFramesBelow:
@@ -1464,6 +1495,130 @@ Proof.
       * now exact (h.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) d).
       * now exact (mkCohReflReflLayerBelow deps cohReflReflFramesBelow
           cohReflReflPaintingsBelow q r Hq Hr d l h).
+Defined.
+
+Definition mkCohReflReflLayerAbove {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  (cohReflReflFramesAbove:
+    mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup))
+  (cohReflReflPaintingsAbove:
+    mkCohReflReflPaintingAboveTypes deps cohReflReflFramesAbove)
+  q r (Hq: q <= p) (Hr: r <= k)
+  (d: mkFrame ((RestrOfReflCohs2 deps).(1)))
+  (l: mkLayer
+    (paintings := (RestrOfReflCohs2 deps).(_paintings))
+    (RestrOfReflCohs2 deps).(_restrFrames) d)
+  (c: PaintingPrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) (d; l))
+  (prevCohReflReflFrames:
+    mkCohReflReflFrameAboveTypes (mkDepsReflCohsSup deps.(1)%depsreflcohs2)):
+  rew [mkLayer _] prevCohReflReflFrames.2 q r.+1 Hq (⇑ Hr) d (l; c) in
+  mkReflLayerAbove (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf)
+    (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove) _
+    (mkDepsReflCohsSup deps).(1).(_cohReflRestrFramesAboveSup) q Hq
+    ((mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr (d; l)).1
+    (((mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr (d; l)).2;
+     (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr (d; l) c) =
+  mkReflLayerBelow
+    (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs)
+    (mkDepsReflCohsInf deps).(_reflFramesBelow')
+    (mkDepsReflCohsInf deps).(_reflPaintingsBelow) _
+    (mkDepsReflCohsInf deps).(_cohReflRestrFramesBelowInf)
+    r Hr
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ Hq) (d; l) c).1
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ Hq) (d; l) c).2.
+Proof.
+  apply functional_extensionality_dep.
+  intro θ.
+  unfold mkReflLayerBelow, mkReflLayerAbove.
+  rewrite <- map_subst_app.
+
+  set (d0 := (RestrOfReflCohs2 deps).(_restrFrames).2 0 leR_O θ d).
+  set (c0 := (CohsOfReflCohs2 deps).(_restrPaintings).2 0 leR_O θ d (l; c)).
+  set (x0 := (
+    (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d0;
+    (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d0 c0)).
+
+  eassert (coh_below_inf_pair_eq : (_;_) = (_;_)).
+  { unshelve eapply eq_existT_curried.
+    - now exact ((ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf).2 r 0 Hr leR_O θ d).
+    - now exact (deps.(_cohReflRestrPaintingsBelowInf).2 r 0 Hr leR_O θ d (l; c)). }
+  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
+    (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x.1 x.2)
+    coh_below_inf_pair_eq tt).
+
+  rewrite (proj2 (@rew_swap _ _ _ _ (cohReflReflFramesAbove.2 q r Hq Hr d0 c0)
+    ((mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x0.1 x0.2) _)
+    (cohReflReflPaintingsAbove.2 q r Hq Hr d0 c0)).
+
+  eassert (coh_above_sup_pair_eq : (_;_) = (_;_)).
+  { unshelve eapply eq_existT_curried.
+    - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 Hq leR_O θ d (l; c)).
+    - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q 0 Hq leR_O θ d (l; c)). }
+  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
+    (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr x.1 x.2)
+    coh_above_sup_pair_eq tt).
+
+  rewrite rew_map with
+    (P := fun b => mkPainting
+      (RestrExtOfReflCohsInf (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf)) b)
+    (f := fun x => (mkDepsRestr (CohsOfReflCohsInf
+      (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
+  rewrite rew_map with
+    (P := fun x => mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps).(1)) x)
+    (f := fun x =>
+      (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf).(_reflFramesAbove).2 q Hq x.1 x.2).
+  rewrite rew_map with
+    (P := fun b => (mkDepsRestr
+      (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs).(1)).(_paintings).2 b)
+    (f := fun x => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr x.1).
+
+  rewrite 4 rew_compose.
+
+  apply rew_swap with (P := fun b => (mkDepsRestr (CohsOfReflCohsInf
+    (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_paintings).2 b).
+  rewrite rew_app_rl. now trivial.
+  now apply ((mkDepsRestr (CohsOfReflCohsInf
+    (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_frames).2.(UIP)).
+Defined.
+
+Fixpoint mkCohReflReflFramesAbove {p k} (deps: DepsReflCohs2 p k)
+  (cohReflReflFramesBelow: mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps))
+  (cohReflReflPaintingsBelow: mkCohReflReflPaintingBelowTypes deps cohReflReflFramesBelow)
+  (cohReflReflFramesAbove: mkCohReflReflFrameAboveTypes deps.(_depsReflCohsSup))
+  (cohReflReflPaintingsAbove: mkCohReflReflPaintingAboveTypes deps cohReflReflFramesAbove):
+  mkCohReflReflFrameAboveTypes (mkDepsReflCohsSup deps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now intros q r Hq Hr [].
+  - set (h := mkCohReflReflFramesAbove p k.+1 deps.(1)%depsreflcohs2
+      cohReflReflFramesBelow.1 cohReflReflPaintingsBelow.1
+      cohReflReflFramesAbove.1 cohReflReflPaintingsAbove.1).
+    unshelve econstructor. now exact h.
+    intros q r Hq Hr [d l] c.
+    destruct q.
+    + unshelve eapply eq_existT_curried.
+      * now exact ((mkCohReflReflFramesBelow deps
+          cohReflReflFramesBelow cohReflReflPaintingsBelow).2 0 r leR_O Hr (d; l)).
+      * apply functional_extensionality_dep.
+        intro θ.
+        unfold mkReflLayerBelow.
+        rewrite <- map_subst_app, <- !map_subst.
+        set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1))).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr d0).
+        rewrite 2 rew_compose.
+        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+        rewrite rew_app_rl. now trivial.
+        now apply (deps'.(_frames).2.(UIP)).
+    + unshelve eapply eq_existT_curried.
+      * now exact (h.2 q r.+1 Hq (⇑ Hr) d (l; c)).
+      * now exact (mkCohReflReflLayerAbove deps cohReflReflFramesAbove
+          cohReflReflPaintingsAbove q r Hq Hr d l c h).
 Defined.
 
 (*

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1255,7 +1255,23 @@ Fixpoint mkCohReflRestrPaintingAboveSup {p k}
     (mkDepsReflCohs2 deps)
     (mkExtraDepsReflCohs2 deps extraDeps).
 Proof.
-  admit.
+  intros q r Hq Hr ε d [l c].
+  destruct q.
+  - destruct extraDeps.
+    + destruct r; try contradiction.
+      simpl.
+      destruct deps as [deps2 extraDeps2 extraDepsRefl2 ? ? ?].
+      destruct (match_TopReflCoh2Dep extraDepsRefl2) as [L' ->].
+      destruct (match_TopCoh2Dep extraDeps2) as [E ->].
+      destruct deps2 as [depsReflCohs ? ? ?].
+      destruct depsReflCohs as [depsCohs2 ? ? ? ? ? ?].
+      destruct depsCohs2 as [depsCohs extraDepsCohs ?].
+      destruct (match_TopCohDep extraDepsCohs) as [E' ->].
+      now trivial.
+    + admit.
+  - destruct p; try contradiction.
+    destruct d as [d l'].
+    admit.
 Admitted.
 
 Fixpoint mkCohReflRestrPaintingsAboveSup {p k}

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -15,72 +15,13 @@ Module νDgnSet (A: νSet.AritySig).
 Import A.
 
 Module Import νSet := νSet.νSet A.
+Arguments mkDepsRestr {p k} depsCohs.
 
 Definition FramePrev {p k} (deps: DepsRestr p.+1 k): Type :=
   deps.(_frames).2.
 
 Definition FrameBase {p k} (deps: DepsRestr p.+1 k): Type :=
   mkFrame (deps.(1)).
-
-Definition NextDepsRestr {p k} (depsCohs: DepsCohs p k): DepsRestr p.+1 k :=
-  mkDepsRestr.
-
-Fixpoint mkReflFrameTypes {p k}: DepsRestr p k -> Type :=
-  match p with
-  | 0 => fun _ => unit
-  | p'.+1 => fun deps =>
-    { R: mkReflFrameTypes deps.(1) &T
-          FramePrev deps -> FrameBase deps }
-  end.
-
-Class DepsReflRestr p k := {
-  _deps: DepsRestr p k;
-  _reflFrames: mkReflFrameTypes _deps;
-}.
-
-#[local]
-Instance proj1DepsRefl {p k}
-  `(deps: DepsReflRestr p.+1 k): DepsReflRestr p k.+1 :=
-{|
-  _deps := proj1DepsRestr (deps.(_deps));
-  _reflFrames := deps.(_reflFrames).1;
-|}.
-
-Declare Scope depsreflrestr_scope.
-Delimit Scope depsreflrestr_scope with depsreflrestr.
-Bind Scope depsreflrestr_scope with DepsReflRestr.
-Notation "x .(1)" := (proj1DepsRefl x%_depsreflrestr)
-  (at level 1, left associativity, format "x .(1)"): depsreflrestr_scope.
-
-
-Definition ReflFramePrev {p k} (deps: DepsReflRestr p.+1 k): Type :=
-  FramePrev deps.(_deps).
-
-Definition ReflFrameBase {p k} (deps: DepsReflRestr p.+1 k): Type :=
-  FrameBase deps.(_deps).
-
-Definition restrFrame {p k} i (Hi: i <= k) (deps: DepsRestr p.+1 k) (ε: arity):
-  FrameBase deps -> FramePrev deps :=
-  deps.(_restrFrames).2 i Hi ε.
-
-Definition reflFrame {p k} (deps: DepsReflRestr p.+1 k):
-  ReflFramePrev deps -> ReflFrameBase deps :=
-  deps.(_reflFrames).2.
-
-Definition mkIdReflRestrFrameType {p k}
-  (deps: DepsReflRestr p.+1 k): Type :=
-  forall ε (d: ReflFramePrev deps),
-  restrFrame k leR_refl deps.(_deps) ε (reflFrame deps d) = d.
-
-Fixpoint mkIdReflRestrFrameTypes {p}:
-  forall {k} (deps: DepsReflRestr p k), Type :=
-  match p with
-  | 0 => fun _ _ => unit
-  | S p =>
-    fun k deps =>
-    { _: mkIdReflRestrFrameTypes deps.(1) &T
-      mkIdReflRestrFrameType deps }
-  end.
 
 Definition PaintingPrev {p k} (deps: DepsRestr p.+1 k):
   FramePrev deps -> Type :=
@@ -90,154 +31,203 @@ Definition PaintingBase {p k} (deps: DepsRestr p.+1 k)
   (extraDeps: DepsRestrExtension p.+1 k deps): FrameBase deps -> Type :=
   (mkPaintings (deps; extraDeps)).2.
 
-Definition ReflPaintingPrev {p k} (deps: DepsReflRestr p.+1 k):
-  ReflFramePrev deps -> Type :=
-  PaintingPrev deps.(_deps).
+Fixpoint mkReflFrameBelowTypes {p k}: DepsRestr p k -> Type :=
+  match p with
+  | 0 => fun _ => unit
+  | p'.+1 => fun deps =>
+    { R: mkReflFrameBelowTypes deps.(1) &T
+          forall i (Hi: i <= k), FramePrev deps -> FrameBase deps }
+  end.
 
-Definition ReflPaintingBase {p k} (deps: DepsReflRestr p.+1 k)
-  (extraDeps: DepsRestrExtension p.+1 k deps.(_deps)):
-  ReflFrameBase deps -> Type :=
-  PaintingBase deps.(_deps) extraDeps.
+Fixpoint mkReflFrameAboveTypes {p k}: DepsRestr p k -> Type :=
+  match p with
+  | 0 => fun _ => unit
+  | p'.+1 => fun deps =>
+    { R: mkReflFrameAboveTypes deps.(1) &T
+          forall i (Hi: i <= p') (d: FramePrev deps), PaintingPrev deps d -> mkFrame deps }
+  end.
 
-Definition mkReflPaintingType {p k} (deps: DepsReflRestr p.+1 k)
-  `(extraDeps: DepsRestrExtension p.+1 k deps.(_deps)) :=
-  forall (d: ReflFramePrev deps),
-  ReflPaintingPrev deps d ->
-  ReflPaintingBase deps extraDeps (reflFrame deps d).
+Class DepsReflBelow p k := {
+  _depsRestr: DepsRestr p k;
+  _reflFramesBelow: mkReflFrameBelowTypes _depsRestr;
+}.
 
-Fixpoint mkReflPaintingTypes {p}:
-  forall {k} (deps: DepsReflRestr p k)
-  `(extraDeps: DepsRestrExtension p k deps.(_deps)), Type :=
+#[local]
+Instance proj1DepsReflBelow {p k}
+  (deps: DepsReflBelow p.+1 k): DepsReflBelow p k.+1 :=
+{|
+  _depsRestr := proj1DepsRestr (deps.(_depsRestr));
+  _reflFramesBelow := deps.(_reflFramesBelow).1;
+|}.
+
+Declare Scope depsreflbelow_scope.
+Delimit Scope depsreflbelow_scope with depsreflbelow.
+Bind Scope depsreflbelow_scope with DepsReflBelow.
+Notation "x .(1)" := (proj1DepsReflBelow x%depsreflbelow)
+  (at level 1, left associativity, format "x .(1)"): depsreflbelow_scope.
+
+Definition mkIdReflRestrFrameBelowType {p k}
+  (deps: DepsReflBelow p.+1 k): Type :=
+  forall i (Hi: i <= k) ε (d: FramePrev deps.(_depsRestr)),
+  deps.(_depsRestr).(_restrFrames).2 i Hi ε (deps.(_reflFramesBelow).2 i Hi d) = d.
+
+Fixpoint mkIdReflRestrFrameBelowTypes {p}:
+  forall {k} (deps: DepsReflBelow p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkIdReflRestrFrameBelowTypes deps.(1) &T
+      mkIdReflRestrFrameBelowType deps }
+  end.
+
+Definition mkReflPaintingBelowType {p k} (deps: DepsReflBelow p.+1 k)
+  (extraDeps: DepsRestrExtension p.+1 k deps.(_depsRestr)) :=
+  forall i (Hi: i <= k) (d: FramePrev deps.(_depsRestr)),
+  PaintingPrev deps.(_depsRestr) d ->
+  PaintingBase deps.(_depsRestr) extraDeps (deps.(_reflFramesBelow).2 i Hi d).
+
+Fixpoint mkReflPaintingBelowTypes {p}:
+  forall {k} (deps: DepsReflBelow p k)
+  (extraDeps: DepsRestrExtension p k deps.(_depsRestr)), Type :=
   match p with
   | 0 => fun _ _ _ => unit
   | S p =>
     fun k deps extraDeps =>
-    { _: mkReflPaintingTypes deps.(1) (deps.(_deps); extraDeps) &T
-      mkReflPaintingType deps extraDeps }
+    { _: mkReflPaintingBelowTypes deps.(1) (deps.(_depsRestr); extraDeps) &T
+      mkReflPaintingBelowType deps extraDeps }
   end.
 
-Class CohReflRestrFrameTypeBlock {p k} (deps: DepsRestr p k) := {
-  CohReflRestrFrameTypesDef: Type;
-  ReflFramesDef: CohReflRestrFrameTypesDef -> mkReflFrameTypes deps;
+Class CohReflRestrFrameBelowInfTypeBlock {p k} (deps: DepsRestr p k) := {
+  CohReflRestrFrameBelowInfTypesDef: Type;
+  ReflFramesBelowDef: CohReflRestrFrameBelowInfTypesDef -> mkReflFrameBelowTypes deps;
 }.
 
 #[local]
-Instance toDepsRefl {p k}
+Instance toDepsReflBelow {p k}
   (depsCohs: DepsCohs p k)
-  (reflFrames: mkReflFrameTypes depsCohs.(νSet._deps)): DepsReflRestr p k :=
-  {| _deps := depsCohs.(νSet._deps);
-     _reflFrames := reflFrames;
+  (reflFrames: mkReflFrameBelowTypes depsCohs.(_deps)): DepsReflBelow p k :=
+  {| _depsRestr := depsCohs.(_deps);
+     _reflFramesBelow := reflFrames;
   |}.
 
-Definition mkCohReflRestrFrameTypesStep {p k} (deps: DepsCohs p.+1 k)
-  (reflFrames: mkReflFrameTypes deps.(νSet._deps))
-  (prev: CohReflRestrFrameTypeBlock (NextDepsRestr deps.(1))): Type :=
-  { Q: prev.(CohReflRestrFrameTypesDef) &T
-    forall i (Hi: i <= k) (ε: arity) (d: ReflFrameBase (toDepsRefl deps reflFrames)),
-    let reflFrame': FramePrev _ -> FrameBase _ := (prev.(ReflFramesDef) Q).2 in
-    reflFrame _ (restrFrame i Hi _ ε d) =
-    restrFrame i (↑ Hi) _ ε (reflFrame' d) }.
+Definition mkCohReflRestrFrameBelowInfTypesStep {p k} (deps: DepsCohs p.+1 k)
+  (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
+  (prev: CohReflRestrFrameBelowInfTypeBlock (mkDepsRestr deps.(1))): Type :=
+  { Q: prev.(CohReflRestrFrameBelowInfTypesDef) &T
+    forall q r (Hq: q <= k) (Hr: r <= q) (ε: arity) (d: FrameBase deps.(_deps)),
+    reflFramesBelow.2 q Hq (deps.(_deps).(_restrFrames).2 r (Hr ↕ Hq) ε d) =
+    mkRestrFrame r (Hr ↕ ↑ Hq) ε ((prev.(ReflFramesBelowDef) Q).2 q.+1 (⇑ Hq) d) }.
 
-Definition mkReflLayer {p k} (deps: DepsCohs p.+1 k)
-  (reflFrames: mkReflFrameTypes deps.(νSet._deps))
-  (reflPaintings: mkReflPaintingTypes (toDepsRefl deps reflFrames)
+Definition mkReflLayerBelow {p k} (deps: DepsCohs p.+1 k)
+  (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
+  (reflPaintingsBelow: mkReflPaintingBelowTypes (toDepsReflBelow deps reflFramesBelow)
     deps.(_extraDeps))
-  (prev: CohReflRestrFrameTypeBlock (NextDepsRestr deps.(1)))
-  (cohFrames: mkCohReflRestrFrameTypesStep deps reflFrames prev)
-  (d: ReflFrameBase (toDepsRefl deps reflFrames)):
-  mkLayer deps.(νSet._deps).(_restrFrames) d ->
+  (prev: CohReflRestrFrameBelowInfTypeBlock (mkDepsRestr deps.(1)))
+  (cohFrames: mkCohReflRestrFrameBelowInfTypesStep deps reflFramesBelow prev)
+  i (Hi: i <= k)
+  (d: FrameBase deps.(_deps)):
+  mkLayer deps.(_deps).(_restrFrames) d ->
   mkLayer
-    (NextDepsRestr deps.(1)).(_restrFrames)
-    ((prev.(ReflFramesDef) cohFrames.1).2 d) :=
+    (mkDepsRestr deps.(1)).(_restrFrames)
+    ((prev.(ReflFramesBelowDef) cohFrames.1).2 i.+1 (⇑ Hi) d) :=
   fun l ε =>
-    rew [(NextDepsRestr deps.(1)).(_paintings).2] cohFrames.2 0 leR_O ε d in
-    reflPaintings.2 (restrFrame 0 leR_O (toDepsRefl deps reflFrames).(_deps)
-      ε d) (l ε).
+    rew [(mkDepsRestr deps.(1)).(_paintings).2]
+      cohFrames.2 i 0 Hi leR_O ε d in
+    reflPaintingsBelow.2 i Hi (deps.(_deps).(_restrFrames).2 0 leR_O ε d) (l ε).
 
-Fixpoint mkCohReflRestrFrameTypesAndReflFrames {p k}:
-  forall (deps: DepsCohs p k) (reflFrames: mkReflFrameTypes deps.(νSet._deps))
-    (reflPaintings: mkReflPaintingTypes (toDepsRefl deps reflFrames)
+Fixpoint mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow {p k}:
+  forall (deps: DepsCohs p k) (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
+    (reflPaintingsBelow: mkReflPaintingBelowTypes (toDepsReflBelow deps reflFramesBelow)
       deps.(_extraDeps)),
-    CohReflRestrFrameTypeBlock (NextDepsRestr deps) :=
+    CohReflRestrFrameBelowInfTypeBlock (mkDepsRestr deps) :=
   match p with
   | 0 =>
     fun deps reflFrames reflPaintings =>
     {|
-      CohReflRestrFrameTypesDef := unit;
-      ReflFramesDef _ := (tt; fun _ => tt):
-        mkReflFrameTypes (NextDepsRestr deps)
+      CohReflRestrFrameBelowInfTypesDef := unit;
+      ReflFramesBelowDef _ :=
+        let reflFrame0: forall i (Hi: i <= k),
+          FramePrev (mkDepsRestr deps) -> FrameBase (mkDepsRestr deps) :=
+          fun _ _ d => d in
+        (((tt: mkReflFrameBelowTypes (mkDepsRestr deps).(1)); reflFrame0):
+          mkReflFrameBelowTypes (mkDepsRestr deps))
     |}
   | S p =>
-    fun deps reflFrames reflPaintings =>
-    let prev := mkCohReflRestrFrameTypesAndReflFrames deps.(1)
-      reflFrames.1 reflPaintings.1 in
+    fun deps reflFramesBelow reflPaintingsBelow =>
+    let prev := mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow deps.(1)
+      reflFramesBelow.1 reflPaintingsBelow.1 in
     {|
-      CohReflRestrFrameTypesDef := mkCohReflRestrFrameTypesStep deps
-        reflFrames prev;
-      ReflFramesDef Q :=
-        let prevFrames := prev.(ReflFramesDef) Q.1 in
-        let reflFrame d := (prevFrames.2 d.1;
-          mkReflLayer deps reflFrames reflPaintings prev Q d.1 d.2) in
-        (prevFrames; reflFrame): mkReflFrameTypes (NextDepsRestr deps)
+      CohReflRestrFrameBelowInfTypesDef := mkCohReflRestrFrameBelowInfTypesStep deps
+        reflFramesBelow prev;
+      ReflFramesBelowDef Q :=
+        let prevFrames := prev.(ReflFramesBelowDef) Q.1 in
+        let reflFrame i (Hi: i <= k) d := (prevFrames.2 i.+1 (⇑ Hi) d.1;
+          mkReflLayerBelow deps reflFramesBelow reflPaintingsBelow prev Q i Hi d.1 d.2) in
+        (prevFrames; reflFrame): mkReflFrameBelowTypes (mkDepsRestr deps)
     |}
   end.
 
-Definition mkCohReflRestrFrameTypes {p k}
+Definition mkCohReflRestrFrameBelowInfTypes {p k}
   (deps: DepsCohs p k)
-  (reflFrames: mkReflFrameTypes deps.(νSet._deps))
-  (reflPaintings: mkReflPaintingTypes (toDepsRefl deps reflFrames)
+  (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
+  (reflPaintingsBelow: mkReflPaintingBelowTypes (toDepsReflBelow deps reflFramesBelow)
     deps.(_extraDeps)): Type :=
-  (mkCohReflRestrFrameTypesAndReflFrames deps reflFrames
-    reflPaintings).(CohReflRestrFrameTypesDef).
+  (mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow deps reflFramesBelow
+    reflPaintingsBelow).(CohReflRestrFrameBelowInfTypesDef).
 
-Definition mkIdReflRestrPaintingType {p k}
+Definition mkIdReflRestrPaintingBelowType {p k}
   (deps: DepsCohs p.+1 k)
-  (reflFrames: mkReflFrameTypes deps.(νSet._deps))
-  (reflPaintings: mkReflPaintingTypes (toDepsRefl deps reflFrames)
+  (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
+  (reflPaintingsBelow: mkReflPaintingBelowTypes (toDepsReflBelow deps reflFramesBelow)
     deps.(_extraDeps))
-  (idReflRestrFrames: mkIdReflRestrFrameTypes (toDepsRefl deps reflFrames)):
+  (idReflRestrFrames: mkIdReflRestrFrameBelowTypes (toDepsReflBelow deps reflFramesBelow)):
   Type :=
-  forall (ε: arity) (d: ReflFramePrev (toDepsRefl deps reflFrames))
-    (c: ReflPaintingPrev (toDepsRefl deps reflFrames) d),
-  rew [ReflPaintingPrev (toDepsRefl deps reflFrames)] idReflRestrFrames.2 ε d in
-  deps.(_restrPaintings).2 k leR_refl ε (reflFrames.2 d) (reflPaintings.2 d c) = c.
+  forall i (Hi: i <= k) (ε: arity)
+    (d: FramePrev deps.(_deps))
+    (c: PaintingPrev deps.(_deps) d),
+  rew [PaintingPrev deps.(_deps)] idReflRestrFrames.2 i Hi ε d in
+  deps.(_restrPaintings).2 i Hi ε
+    (reflFramesBelow.2 i Hi d) (reflPaintingsBelow.2 i Hi d c) = c.
 
-Fixpoint mkIdReflRestrPaintingTypes {p}:
+Fixpoint mkIdReflRestrPaintingBelowTypes {p}:
   forall {k} (deps: DepsCohs p k)
-    (reflFrames: mkReflFrameTypes deps.(νSet._deps))
-    (reflPaintings: mkReflPaintingTypes (toDepsRefl deps reflFrames)
+    (reflFramesBelow: mkReflFrameBelowTypes deps.(_deps))
+    (reflPaintingsBelow: mkReflPaintingBelowTypes (toDepsReflBelow deps reflFramesBelow)
       deps.(_extraDeps))
-    (idReflRestrFrames: mkIdReflRestrFrameTypes (toDepsRefl deps reflFrames)),
+    (idReflRestrFrames: mkIdReflRestrFrameBelowTypes (toDepsReflBelow deps reflFramesBelow)),
   Type :=
   match p with
   | 0 => fun _ _ _ _ _ => unit
   | S p =>
-    fun k deps reflFrames reflPaintings idReflRestrFrames =>
-    { _: mkIdReflRestrPaintingTypes deps.(1) reflFrames.1 reflPaintings.1 idReflRestrFrames.1 &T
-      mkIdReflRestrPaintingType deps reflFrames reflPaintings
+    fun k deps reflFramesBelow reflPaintingsBelow idReflRestrFrames =>
+    { _: mkIdReflRestrPaintingBelowTypes deps.(1) reflFramesBelow.1 reflPaintingsBelow.1 idReflRestrFrames.1 &T
+      mkIdReflRestrPaintingBelowType deps reflFramesBelow reflPaintingsBelow
         idReflRestrFrames }
   end.
 
 Class DepsReflCohs p k := {
   _depsCohs2: DepsCohs2 p k;
-  _reflFrameDeps: mkReflFrameTypes _depsCohs.(νSet._deps);
-  _reflPaintingDeps: mkReflPaintingTypes
-    (toDepsRefl _depsCohs _reflFrameDeps) _depsCohs.(_extraDeps);
-  _idReflRestrFrames: mkIdReflRestrFrameTypes
-    (toDepsRefl _depsCohs _reflFrameDeps);
-  _idReflRestrPaintings: mkIdReflRestrPaintingTypes _depsCohs _reflFrameDeps _reflPaintingDeps _idReflRestrFrames;
-  _cohReflRestrFrames: mkCohReflRestrFrameTypes _depsCohs _reflFrameDeps _reflPaintingDeps
+  _reflFramesBelow': mkReflFrameBelowTypes _depsCohs.(_deps);
+  _reflFramesAbove: mkReflFrameAboveTypes _depsCohs.(_deps);
+  _reflPaintingsBelow: mkReflPaintingBelowTypes
+    (toDepsReflBelow _depsCohs _reflFramesBelow') _depsCohs.(_extraDeps);
+  _idReflRestrFramesBelow: mkIdReflRestrFrameBelowTypes
+    (toDepsReflBelow _depsCohs _reflFramesBelow');
+  _idReflRestrPaintingsBelow: mkIdReflRestrPaintingBelowTypes _depsCohs _reflFramesBelow' _reflPaintingsBelow _idReflRestrFramesBelow;
+  _cohReflRestrFramesBelowInf: mkCohReflRestrFrameBelowInfTypes _depsCohs _reflFramesBelow' _reflPaintingsBelow
 }.
 
 #[local]
-Instance proj1DepsReflCohs {p k} `(depsCohs: DepsReflCohs p.+1 k): DepsReflCohs p k.+1 :=
+Instance proj1DepsReflCohs {p k} (depsCohs: DepsReflCohs p.+1 k): DepsReflCohs p k.+1 :=
 {|
   _depsCohs2 := (depsCohs.(_depsCohs2)).(1);
-  _reflFrameDeps := depsCohs.(_reflFrameDeps).1;
-  _reflPaintingDeps := depsCohs.(_reflPaintingDeps).1;
-  _idReflRestrFrames := depsCohs.(_idReflRestrFrames).1;
-  _idReflRestrPaintings := depsCohs.(_idReflRestrPaintings).1;
-  _cohReflRestrFrames := depsCohs.(_cohReflRestrFrames).1;
+  _reflFramesBelow' := depsCohs.(_reflFramesBelow').1;
+  _reflFramesAbove := depsCohs.(_reflFramesAbove).1;
+  _reflPaintingsBelow := depsCohs.(_reflPaintingsBelow).1;
+  _idReflRestrFramesBelow := depsCohs.(_idReflRestrFramesBelow).1;
+  _idReflRestrPaintingsBelow := depsCohs.(_idReflRestrPaintingsBelow).1;
+  _cohReflRestrFramesBelowInf := depsCohs.(_cohReflRestrFramesBelowInf).1;
 |}.
 
 Declare Scope depsreflcohs_scope.
@@ -246,189 +236,422 @@ Bind Scope depsreflcohs_scope with DepsReflCohs.
 Notation "x .(1)" := (proj1DepsReflCohs x%_depsreflcohs)
   (at level 1, left associativity, format "x .(1)"): depsreflcohs_scope.
 
-Definition ReflOfReflCohs {p k}
-  `(depsCohs: DepsReflCohs p k): DepsReflRestr p k :=
+Definition ReflBelowOfReflCohs {p k}
+  (depsCohs: DepsReflCohs p k): DepsReflBelow p k :=
 {|
-  _deps := depsCohs.(_depsCohs2).(_depsCohs).(νSet._deps);
-  _reflFrames := depsCohs.(_reflFrameDeps);
+  _depsRestr := depsCohs.(_depsCohs2).(_depsCohs).(_deps);
+  _reflFramesBelow := depsCohs.(_reflFramesBelow');
 |}.
 
 Definition RestrOfReflCohs {p k}
-  `(depsCohs: DepsReflCohs p k): DepsRestr p k :=
-  (ReflOfReflCohs depsCohs).(_deps).
+  (depsCohs: DepsReflCohs p k): DepsRestr p k :=
+  (ReflBelowOfReflCohs depsCohs).(_depsRestr).
 
 Definition CohsOfReflCohs {p k}
-  `(depsCohs: DepsReflCohs p k): DepsCohs p k :=
+  (depsCohs: DepsReflCohs p k): DepsCohs p k :=
   depsCohs.(_depsCohs2).(_depsCohs).
 
 Definition RestrExtOfReflCohs {p k}
-  `(depsCohs: DepsReflCohs p k): DepsRestrExtension p k
+  (depsCohs: DepsReflCohs p k): DepsRestrExtension p k
     (RestrOfReflCohs depsCohs) :=
   depsCohs.(_depsCohs2).(_depsCohs).(_extraDeps).
 
 Definition CohsExtOfReflCohs {p k}
-  `(depsCohs: DepsReflCohs p k): DepsCohsExtension p k
+  (depsCohs: DepsReflCohs p k): DepsCohsExtension p k
     (CohsOfReflCohs depsCohs) :=
   depsCohs.(_depsCohs2).(_extraDepsCohs).
 
-Definition mkReflFrames {p k} (deps: DepsReflCohs p k):
-  mkReflFrameTypes (NextDepsRestr (CohsOfReflCohs deps)) :=
-  (mkCohReflRestrFrameTypesAndReflFrames
+Definition mkReflFramesBelow {p k} (deps: DepsReflCohs p k):
+  mkReflFrameBelowTypes (mkDepsRestr (CohsOfReflCohs deps)) :=
+  (mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow
     deps.(_depsCohs2).(_depsCohs)
-    deps.(_reflFrameDeps)
-    deps.(_reflPaintingDeps)).(ReflFramesDef) deps.(_cohReflRestrFrames).
+    deps.(_reflFramesBelow')
+    deps.(_reflPaintingsBelow)).(ReflFramesBelowDef) deps.(_cohReflRestrFramesBelowInf).
 
-Definition mkReflFrame {p k} (deps: DepsReflCohs p.+1 k):
-  FramePrev (NextDepsRestr (CohsOfReflCohs deps)) ->
-  FrameBase (NextDepsRestr (CohsOfReflCohs deps)) :=
-  (mkReflFrames deps).2.
+Definition mkReflFrameBelow {p k} (deps: DepsReflCohs p k):
+  forall i (Hi: i <= k),
+  FramePrev (mkDepsRestr (CohsOfReflCohs deps)) ->
+  FrameBase (mkDepsRestr (CohsOfReflCohs deps)) :=
+  (mkReflFramesBelow deps).2.
 
-Definition NextDepsRefl {p k} (deps: DepsReflCohs p k): DepsReflRestr p.+1 k :=
-  {| _deps := NextDepsRestr (CohsOfReflCohs deps);
-     _reflFrames := mkReflFrames deps
+Definition mkDepsReflBelow {p k} (deps: DepsReflCohs p k): DepsReflBelow p.+1 k :=
+  {| _depsRestr := mkDepsRestr (CohsOfReflCohs deps);
+     _reflFramesBelow := mkReflFramesBelow deps
   |}.
 
-Definition restrPainting {p k} (deps: DepsReflCohs p.+1 k):
-  forall i (Hi: i <= k) (ε: arity) (d: ReflFrameBase (ReflOfReflCohs deps)),
-  ReflPaintingBase (ReflOfReflCohs deps) (RestrExtOfReflCohs deps) d ->
-  ReflPaintingPrev (ReflOfReflCohs deps)
-    (restrFrame i Hi (RestrOfReflCohs deps) ε d) :=
-  deps.(_depsCohs2).(_depsCohs).(_restrPaintings).2.
+Definition mkCohReflRestrFrameBelowSupType {p k}
+  (deps: DepsReflCohs p.+1 k): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= k) (ε: arity) (d: FrameBase (RestrOfReflCohs deps)),
+  deps.(_reflFramesBelow').2 q (Hq ↕ Hr) ((RestrOfReflCohs deps).(_restrFrames).2 r Hr ε d) =
+  mkRestrFrame r.+1 (⇑ Hr) ε (mkReflFrameBelow deps.(1) q (Hq ↕ ↑ Hr) d).
 
-Definition reflPainting {p k} (deps: DepsReflCohs p.+1 k):
-  forall (d: ReflFramePrev (ReflOfReflCohs deps)),
-  ReflPaintingPrev (ReflOfReflCohs deps) d ->
-  ReflPaintingBase (ReflOfReflCohs deps) (RestrExtOfReflCohs deps)
-    (reflFrame (ReflOfReflCohs deps) d) :=
-  deps.(_reflPaintingDeps).2.
+Fixpoint mkCohReflRestrFrameBelowSupTypes {p}:
+  forall {k} (deps: DepsReflCohs p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkCohReflRestrFrameBelowSupTypes deps.(1) &T
+      mkCohReflRestrFrameBelowSupType deps }
+  end.
 
-Definition mkIdReflRestrLayer {p k}
+Definition mkIdReflRestrLayerBelow {p k}
   (deps: DepsReflCohs p.+1 k)
+  i (Hi: i <= k)
   (ε: arity)
-  (d: ReflFrameBase (ReflOfReflCohs deps))
+  (d: FrameBase (RestrOfReflCohs deps))
   (l: mkLayer (RestrOfReflCohs deps).(_restrFrames) d)
-  (prevIdReflRestrFrames: mkIdReflRestrFrameTypes (NextDepsRefl deps.(1))):
-  rew [mkLayer _] prevIdReflRestrFrames.2 ε d in
+  (prevIdReflRestrFrames: mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps.(1))):
+  rew [mkLayer _] prevIdReflRestrFrames.2 i.+1 (⇑ Hi) ε d in
   mkRestrLayer deps.(_depsCohs2).(_depsCohs).(_restrPaintings)
-    (deps.(_depsCohs2).(_depsCohs).(_cohs)) k leR_refl ε _
-      (mkReflLayer deps.(_depsCohs2).(_depsCohs)
-        ((ReflOfReflCohs deps).(_reflFrames)) deps.(_reflPaintingDeps) _
-          deps.(_cohReflRestrFrames) d l) = l.
+    (deps.(_depsCohs2).(_depsCohs).(_cohs)) i Hi ε _
+      (mkReflLayerBelow deps.(_depsCohs2).(_depsCohs)
+        ((ReflBelowOfReflCohs deps).(_reflFramesBelow)) deps.(_reflPaintingsBelow) _
+          deps.(_cohReflRestrFramesBelowInf) i Hi d l) = l.
 Proof.
   apply functional_extensionality_dep.
   intros θ.
-  unfold mkRestrLayer, mkReflLayer.
-  rewrite <- (deps.(_idReflRestrPaintings).2 ε _ (l θ)).
+  unfold mkRestrLayer, mkReflLayerBelow.
+  rewrite <- (deps.(_idReflRestrPaintingsBelow).2 i Hi ε _ (l θ)).
   rewrite <- map_subst_app, <- map_subst.
-  unfold reflFrame, restrFrame, toDepsRefl, ReflPaintingPrev, PaintingPrev,
-         FramePrev, RestrOfReflCohs, mkFrame; simpl.
+  unfold toDepsReflBelow, PaintingPrev, FramePrev, RestrOfReflCohs, mkFrame; simpl.
   rewrite rew_map with
-    (P := fun x => deps.(_depsCohs2).(_depsCohs).(νSet._deps).(_paintings).2 x)
-    (f := fun x => (deps.(_depsCohs2).(_depsCohs).(νSet._deps).(_restrFrames).2 0 leR_O θ x)).
+    (P := fun x => deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x)
+    (f := fun x => (deps.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).2 0 leR_O θ x)).
   rewrite rew_map with
-    (P := fun x => deps.(_depsCohs2).(_depsCohs).(νSet._deps).(_paintings).2 x)
-    (f := fun x => ((deps.(_depsCohs2).(_depsCohs).(νSet._deps).(
-      _restrFrames).2 k leR_refl ε x))).
+    (P := fun x => deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x)
+    (f := fun x => ((deps.(_depsCohs2).(_depsCohs).(_deps).(
+      _restrFrames).2 i Hi ε x))).
   rewrite 2 rew_compose.
   apply rew_swap with (P := fun x =>
-    deps.(_depsCohs2).(_depsCohs).(νSet._deps).(_paintings).2 x).
+    deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x).
   rewrite rew_app_rl. now trivial.
   now apply (RestrOfReflCohs deps).(_frames).2.(UIP).
 Defined.
 
-Fixpoint mkIdReflRestrFrames {p k} (deps: DepsReflCohs p k):
-  mkIdReflRestrFrameTypes (NextDepsRefl deps).
+Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohs p k):
+  mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps).
   destruct p.
-  - simpl. unshelve econstructor. now exact tt. now intros ε [].
-  - set (h := mkIdReflRestrFrames p k.+1 deps.(1)%depsreflcohs).
+  - simpl. unshelve econstructor. now exact tt. now intros i Hi ε [].
+  - set (h := mkIdReflRestrFramesBelow p k.+1 deps.(1)%depsreflcohs).
     unshelve econstructor.
     + now apply h.
-    + intros ε [l c].
+    + intros i Hi ε [l c].
       unshelve eapply eq_existT_curried.
-      * now exact (h.2 ε l).
-      * now exact (mkIdReflRestrLayer deps ε l c h).
+      * now exact (h.2 i.+1 (⇑ Hi) ε l).
+      * now exact (mkIdReflRestrLayerBelow deps i Hi ε l c h).
 Defined.
 
-Definition mkIdReflRestrFrame {p k} (deps: DepsReflCohs p k):
-  mkIdReflRestrFrameType (NextDepsRefl deps) :=
-  (mkIdReflRestrFrames deps).2.
+Definition mkIdReflRestrBelowFrame {p k} (deps: DepsReflCohs p k):
+  mkIdReflRestrFrameBelowType (mkDepsReflBelow deps) :=
+  (mkIdReflRestrFramesBelow deps).2.
 
-Definition HasRefl {p} (deps: DepsReflCohs p 0)
-  (E: mkFrame (NextDepsRestr (CohsOfReflCohs deps)) -> HSet): Type :=
-  forall (d: FramePrev (NextDepsRestr (CohsOfReflCohs deps)))
-    (c: PaintingPrev (NextDepsRestr (CohsOfReflCohs deps)) d),
-  let l ε := (rew <- mkIdReflRestrFrame deps ε d in c) in
-  E (reflFrame (NextDepsRefl deps) d; l).
+Class DepsReflAbove p k := {
+  _depsRefl: DepsReflBelow p k;
+  _extraDeps: DepsRestrExtension p k _depsRefl.(_depsRestr);
+  _reflFramesAbove': mkReflFrameAboveTypes _depsRefl.(_depsRestr);
+}.
 
-Inductive DepsReflCohsExtension p: forall k (deps: DepsReflCohs p k), Type :=
-| TopReflCohDep `{deps: DepsReflCohs p 0}
-  (L: HasRefl deps (mkPaintings (mkExtraDeps (CohsExtOfReflCohs deps))).2):
-  DepsReflCohsExtension p 0 deps
-| AddReflCohDep {k} (deps: DepsReflCohs p.+1 k):
-  DepsReflCohsExtension p.+1 k deps -> DepsReflCohsExtension p k.+1 deps.(1).
+#[local]
+Instance proj1DepsReflAbove {p k}
+  (deps: DepsReflAbove p.+1 k): DepsReflAbove p k.+1 :=
+{|
+  _depsRefl := deps.(_depsRefl).(1)%depsreflbelow;
+  _extraDeps := (deps.(_depsRefl).(_depsRestr); deps.(_extraDeps));
+  _reflFramesAbove' := deps.(_reflFramesAbove').1;
+|}.
 
-Arguments TopReflCohDep {p deps}.
-Arguments AddReflCohDep {p k}.
+Declare Scope depsreflabove_scope.
+Delimit Scope depsreflabove_scope with depsreflabove.
+Bind Scope depsreflabove_scope with DepsReflAbove.
+Notation "x .(1)" := (proj1DepsReflAbove x%depsreflabove)
+  (at level 1, left associativity, format "x .(1)"): depsreflabove_scope.
 
-Declare Scope extra_depsreflcohs_scope.
-Delimit Scope extra_depsreflcohs_scope with extradepsreflcohs.
-Bind Scope extra_depsreflcohs_scope with DepsReflCohsExtension.
-Notation "( x ; y )" := (AddReflCohDep x y)
-  (at level 0, format "( x ; y )"): extra_depsreflcohs_scope.
+Definition AboveOfReflCohs {p k}
+  (depsCohs: DepsReflCohs p k): DepsReflAbove p k :=
+{|
+  _depsRefl := ReflBelowOfReflCohs depsCohs;
+  _extraDeps := RestrExtOfReflCohs depsCohs;
+  _reflFramesAbove' := depsCohs.(_reflFramesAbove);
+|}.
 
+Definition mkReflPaintingAboveType {p k} (deps: DepsReflAbove p.+1 k) :=
+  forall i (Hi: i <= p)
+    (d: FramePrev deps.(_depsRefl).(_depsRestr))
+    (c: PaintingPrev deps.(_depsRefl).(_depsRestr) d),
+  mkPainting deps.(_extraDeps) (deps.(_reflFramesAbove').2 i Hi d c).
 
-Fixpoint mkReflPainting {p k}
+Fixpoint mkReflPaintingAboveTypes {p}:
+  forall {k} (deps: DepsReflAbove p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkReflPaintingAboveTypes deps.(1) &T
+      mkReflPaintingAboveType deps }
+  end.
+
+Class CohReflRestrFrameAboveSupTypeBlock {p k} (deps: DepsRestr p k) := {
+  CohReflRestrFrameAboveSupTypesDef: Type;
+  ReflFramesAboveDef: CohReflRestrFrameAboveSupTypesDef -> mkReflFrameAboveTypes deps;
+}.
+
+Definition mkCohReflRestrFrameAboveSupTypesStep {p k} (deps: DepsReflCohs p.+1 k)
+  (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohs deps.(1)))): Type :=
+  { Q: prev.(CohReflRestrFrameAboveSupTypesDef) &T
+    forall q r (Hq: q <= p) (Hr: r <= k) (ε: arity)
+      (d: FrameBase (RestrOfReflCohs deps))
+      (c: PaintingBase (RestrOfReflCohs deps) (RestrExtOfReflCohs deps) d),
+    deps.(_reflFramesAbove).2 q Hq _ ((CohsOfReflCohs deps).(_restrPaintings).2 r Hr ε d c) =
+    mkRestrFrame r Hr ε (((prev.(ReflFramesAboveDef) Q).2) q Hq d c) }.
+
+Definition mkReflLayerAbove {p k} (deps: DepsReflCohs p.+1 k)
+  (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs deps))
+  (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohs deps.(1))))
+  (cohFrames: mkCohReflRestrFrameAboveSupTypesStep deps prev)
+  i (Hi: i <= p)
+  (d: FrameBase (RestrOfReflCohs deps))
+  (c: PaintingBase (RestrOfReflCohs deps) (RestrExtOfReflCohs deps) d):
+  mkLayer
+    (paintings := mkPaintings (RestrExtOfReflCohs deps))
+    (mkDepsRestr (CohsOfReflCohs deps)).(_restrFrames)
+    ((prev.(ReflFramesAboveDef) cohFrames.1).2 i Hi d c) :=
+  fun ε =>
+    rew [(mkDepsRestr (CohsOfReflCohs deps)).(_paintings).2]
+      cohFrames.2 i 0 Hi leR_O ε d c in
+  reflPaintingsAbove.2 i Hi _
+    ((CohsOfReflCohs deps).(_restrPaintings).2 0 leR_O ε d c).
+
+Fixpoint mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove {p k}:
+  forall (deps: DepsReflCohs p k)
+    (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs deps)),
+    CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohs deps)) :=
+  match p with
+  | 0 => fun deps reflPaintingsAbove =>
+    {|
+      CohReflRestrFrameAboveSupTypesDef := unit;
+      ReflFramesAboveDef _ :=
+        let reflFrameAbove i (Hi: i <= 0)
+          (d: FramePrev (mkDepsRestr (CohsOfReflCohs deps)))
+          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs deps)) d) :=
+          (mkReflFrameBelow deps 0 leR_O d;
+            fun ε => rew <- mkIdReflRestrBelowFrame deps 0 leR_O ε d in c) in
+        ((tt; reflFrameAbove): mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohs deps)))
+    |}
+  | S p => fun deps reflPaintingsAbove =>
+    let prev := mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(1)
+      reflPaintingsAbove.1 in
+    {|
+      CohReflRestrFrameAboveSupTypesDef := mkCohReflRestrFrameAboveSupTypesStep deps prev;
+      ReflFramesAboveDef Q :=
+        let prevReflFrames := prev.(ReflFramesAboveDef) Q.1 in
+        let reflFrameAbove i (Hi: i <= p.+1)
+          (d: FramePrev (mkDepsRestr (CohsOfReflCohs deps)))
+          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs deps)) d) :=
+          match i return i <= p.+1 -> mkFrame (mkDepsRestr (CohsOfReflCohs deps)) with
+          | 0 => fun _ =>
+            (mkReflFrameBelow deps 0 leR_O d;
+              fun ε => rew <- mkIdReflRestrBelowFrame deps 0 leR_O ε d in c)
+          | i.+1 => fun Hi =>
+            (prevReflFrames.2 i Hi d.1 (d.2; c);
+              mkReflLayerAbove deps reflPaintingsAbove prev Q i (⇓ Hi) d.1 (d.2; c))
+          end Hi in
+        (prevReflFrames; reflFrameAbove):
+          mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohs deps))
+    |}
+  end.
+
+Definition mkCohReflRestrFrameAboveSupTypes {p k}
   (deps: DepsReflCohs p k)
-  (extraDeps: DepsReflCohsExtension p k deps):
-  mkReflPaintingType (NextDepsRefl deps) (mkExtraDeps (CohsExtOfReflCohs deps)).
+  (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs deps)): Type :=
+  (mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps
+    reflPaintingsAbove).(CohReflRestrFrameAboveSupTypesDef).
+
+Class DepsReflCohs2 p k := {
+  _depsReflCohs: DepsReflCohs p k;
+  _reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs _depsReflCohs);
+  _cohReflRestrFramesAboveSup:
+    mkCohReflRestrFrameAboveSupTypes _depsReflCohs _reflPaintingsAbove;
+}.
+
+#[local]
+Instance proj1DepsReflCohs2 {p k} (depsCohs2: DepsReflCohs2 p.+1 k):
+  DepsReflCohs2 p k.+1 :=
+{|
+  _depsReflCohs := depsCohs2.(_depsReflCohs).(1)%depsreflcohs;
+  _reflPaintingsAbove := depsCohs2.(_reflPaintingsAbove).1;
+  _cohReflRestrFramesAboveSup := depsCohs2.(_cohReflRestrFramesAboveSup).1;
+|}.
+
+Declare Scope depsreflcohs2_scope.
+Delimit Scope depsreflcohs2_scope with depsreflcohs2.
+Bind Scope depsreflcohs2_scope with DepsReflCohs2.
+Notation "x .(1)" := (proj1DepsReflCohs2 x%depsreflcohs2)
+  (at level 1, left associativity, format "x .(1)"): depsreflcohs2_scope.
+
+Definition ReflBelowOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsReflBelow p k :=
+  ReflBelowOfReflCohs depsCohs2.(_depsReflCohs).
+
+Definition RestrOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsRestr p k :=
+  RestrOfReflCohs depsCohs2.(_depsReflCohs).
+
+Definition CohsOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsCohs p k :=
+  CohsOfReflCohs depsCohs2.(_depsReflCohs).
+
+Definition Cohs2OfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsCohs2 p k :=
+ depsCohs2.(_depsReflCohs).(_depsCohs2).
+
+Definition RestrExtOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsRestrExtension p k
+    (RestrOfReflCohs2 depsCohs2) :=
+  RestrExtOfReflCohs depsCohs2.(_depsReflCohs).
+
+Definition CohsExtOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsCohsExtension p k
+    (CohsOfReflCohs2 depsCohs2) :=
+  CohsExtOfReflCohs depsCohs2.(_depsReflCohs).
+
+Definition mkReflFramesAbove {p k} (deps: DepsReflCohs2 p k):
+  mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohs2 deps)) :=
+  (mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(_depsReflCohs)
+    deps.(_reflPaintingsAbove)).(ReflFramesAboveDef)
+      deps.(_cohReflRestrFramesAboveSup).
+
+Definition mkReflFrameAbove {p k} (deps: DepsReflCohs2 p k):
+  forall i (Hi: i <= p)
+    (d: FramePrev (mkDepsRestr (CohsOfReflCohs2 deps)))
+    (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs2 deps)) d),
+  mkFrame (mkDepsRestr (CohsOfReflCohs2 deps)) :=
+  (mkReflFramesAbove deps).2.
+
+Definition mkDepsReflAbove {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsReflAbove p.+1 k :=
+{|
+  _depsRefl := mkDepsReflBelow depsCohs2.(_depsReflCohs);
+  _extraDeps := mkExtraDeps (CohsExtOfReflCohs2 depsCohs2);
+  _reflFramesAbove' := mkReflFramesAbove depsCohs2;
+|}.
+
+Definition HasRefl {p} (deps: DepsReflCohs2 p 0)
+  (E: mkFrame (mkDepsRestr (CohsOfReflCohs2 deps)) -> HSet): Type :=
+  forall i (Hi: i <= p)
+    (d: FramePrev (mkDepsRestr (CohsOfReflCohs2 deps)))
+    (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs2 deps)) d),
+  E (mkReflFrameAbove deps i Hi d c).
+
+Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
+| TopReflCoh2Dep {deps: DepsReflCohs2 p 0}
+  (L: HasRefl deps (mkPaintings (mkExtraDeps (CohsExtOfReflCohs2 deps))).2):
+  DepsReflCohs2Extension p 0 deps
+| AddReflCoh2Dep {k} (deps: DepsReflCohs2 p.+1 k):
+  DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1).
+
+Arguments TopReflCoh2Dep {p deps}.
+Arguments AddReflCoh2Dep {p k}.
+
+Declare Scope extra_depsreflcohs2_scope.
+Delimit Scope extra_depsreflcohs2_scope with extradepsreflcohs2.
+Bind Scope extra_depsreflcohs2_scope with DepsReflCohs2Extension.
+Notation "( x ; y )" := (AddReflCoh2Dep x y)
+  (at level 0, format "( x ; y )"): extra_depsreflcohs2_scope.
+
+Fixpoint mkReflPaintingAbove {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkReflPaintingAboveType (mkDepsReflAbove deps).
 Proof.
-  intros d c.
+  intros i Hi d c.
   destruct extraDeps.
-  - unshelve econstructor.
-    + intros ε. now exact (rew <- mkIdReflRestrFrame deps ε d in c).
-    + now exact (L d c).
+  - now exact (L i Hi d c).
   - destruct c as [l c'].
     unshelve econstructor.
-    + apply mkReflLayer.
-      * now exact (deps.(_reflPaintingDeps)).
-      * now exact l.
-    + now exact (mkReflPainting p.+1 k deps extraDeps (d; l) c').
+    + now apply (mkReflLayerAbove _ deps.(_reflPaintingsAbove)).
+    + now exact (mkReflPaintingAbove p.+1 k deps extraDeps i.+1 (⇑ Hi) (d; l) c').
 Defined.
 
-Fixpoint mkReflPaintingsPrefix {p k}:
-  forall (deps: DepsReflCohs p k) (extraDeps: DepsReflCohsExtension p k deps),
-  mkReflPaintingTypes
-    ((NextDepsRefl deps).(1))
-    (NextDepsRestr (CohsOfReflCohs deps);
-    mkExtraDeps (CohsExtOfReflCohs deps)) :=
+Fixpoint mkReflPaintingsAbovePrefix {p k}:
+  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  mkReflPaintingAboveTypes ((mkDepsReflAbove deps).(1)) :=
   match p with
   | 0 => fun _ _ => tt
   | S p =>
     fun deps extraDeps =>
-      (mkReflPaintingsPrefix deps.(1) (deps; extraDeps);
-       mkReflPainting deps.(1) (deps; extraDeps))
+      (mkReflPaintingsAbovePrefix deps.(1) (deps; extraDeps);
+       mkReflPaintingAbove deps.(1) (deps; extraDeps))
   end.
 
-Definition mkReflPaintings {p k}:
-  forall (deps: DepsReflCohs p k) (extraDeps: DepsReflCohsExtension p k deps),
-  mkReflPaintingTypes (NextDepsRefl deps)
-    (mkExtraDeps (CohsExtOfReflCohs deps)) :=
+Definition mkReflPaintingsAbove {p k}:
+  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  mkReflPaintingAboveTypes (mkDepsReflAbove deps) :=
   fun deps extraDeps =>
-    (mkReflPaintingsPrefix deps extraDeps; mkReflPainting deps extraDeps).
+    (mkReflPaintingsAbovePrefix deps extraDeps; mkReflPaintingAbove deps extraDeps).
 
+Fixpoint mkReflPaintingBelow {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkReflPaintingBelowType
+    (mkDepsReflBelow deps.(_depsReflCohs))
+    (mkExtraDeps (CohsExtOfReflCohs2 deps)).
+Proof.
+  intros i Hi d c.
+  destruct i.
+  - unshelve econstructor.
+    + intros ε.
+      rewrite (mkIdReflRestrBelowFrame deps.(_depsReflCohs) 0 leR_O ε d).
+      now exact c.
+    + refine (rew _ in mkReflPaintingAbove deps extraDeps 0 leR_O d c).
+      f_equal.
+      unfold mkDepsReflAbove, mkDepsReflBelow; simpl. 
+      Fail reflexivity.
+      now destruct p.
+  - destruct extraDeps; [now contradiction |].
+    destruct c as [l c'].
+    unshelve econstructor.
+    + now exact (mkReflLayerBelow _ _
+        deps.(_depsReflCohs).(_reflPaintingsBelow) _ _ i Hi d l).
+    + now exact (mkReflPaintingBelow p.+1 k deps extraDeps i (⇓ Hi) (d; l) c').
+Defined.
+
+Fixpoint mkReflPaintingsBelowPrefix {p k}:
+  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  mkReflPaintingBelowTypes
+    ((mkDepsReflBelow deps.(_depsReflCohs)).(1))
+    (mkDepsRestr (CohsOfReflCohs2 deps);
+    mkExtraDeps (CohsExtOfReflCohs2 deps)) :=
+  match p with
+  | 0 => fun _ _ => tt
+  | S p =>
+    fun deps extraDeps =>
+      (mkReflPaintingsBelowPrefix deps.(1) (deps; extraDeps);
+       mkReflPaintingBelow deps.(1) (deps; extraDeps))
+  end.
+
+Definition mkReflPaintingsBelow {p k}:
+  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  mkReflPaintingBelowTypes
+    (mkDepsReflBelow deps.(_depsReflCohs))
+    (mkExtraDeps (CohsExtOfReflCohs2 deps)) :=
+  fun deps extraDeps =>
+    (mkReflPaintingsBelowPrefix deps extraDeps; mkReflPaintingBelow deps extraDeps).
+
+(*
 Definition mkCohReflRestrPaintingType {p k}
   (deps: DepsReflCohs p.+1 k)
   (extraDeps: DepsReflCohsExtension p.+1 k deps): Type :=
   forall (ε: arity) i (Hi: i <= k)
-    (d: ReflFrameBase (ReflOfReflCohs deps))
-    (c: ReflPaintingBase (ReflOfReflCohs deps) (RestrExtOfReflCohs deps) d),
+    (d: ReflFrameBase (ReflBelowOfReflCohs deps))
+    (c: ReflPaintingBase (ReflBelowOfReflCohs deps) (RestrExtOfReflCohs deps) d),
   rew [ReflPaintingBase
-        (toDepsRefl deps.(_depsCohs2).(_depsCohs) deps.(_reflFrameDeps))
+        (toDepsReflBelow deps.(_depsCohs2).(_depsCohs) deps.(_reflFrameDeps))
         deps.(_depsCohs2).(_depsCohs).(_extraDeps)]
   deps.(_cohReflRestrFrames).2 i Hi ε d in
   deps.(_reflPaintingDeps).2 ((RestrOfReflCohs deps).(_restrFrames).2 i Hi ε d)
     ((CohsOfReflCohs deps).(_restrPaintings).2 i Hi ε d c) =
-  mkRestrPainting (CohsExtOfReflCohs deps.(1)) i (↑ Hi) ε (reflFrame (NextDepsRefl deps.(1)) d)
+  mkRestrPainting (CohsExtOfReflCohs deps.(1)) i (↑ Hi) ε (reflFrame (mkDepsReflBelow deps.(1)) d)
     (mkReflPainting deps.(1) (deps; extraDeps) d c).
 
 Fixpoint mkCohReflRestrPaintingTypes {p}:
@@ -492,25 +715,25 @@ Definition Cohs2OfReflCohs2 {p k}
   (depsCohs2: DepsReflCohs2 p k): DepsCohs2 p k :=
   depsCohs2.(_depsReflCohs).(_depsCohs2).
 
-Definition ReflOfReflCohs2 {p k}
-  `(depsCohs2: DepsReflCohs2 p k): DepsReflRestr p k :=
-  ReflOfReflCohs (depsCohs2.(_depsReflCohs)).
+Definition ReflBelowOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsReflBelow p k :=
+  ReflBelowOfReflCohs (depsCohs2.(_depsReflCohs)).
 
 Definition RestrOfReflCohs2 {p k}
-  `(depsCohs2: DepsReflCohs2 p k): DepsRestr p k :=
-  (ReflOfReflCohs (depsCohs2.(_depsReflCohs))).(_deps).
+  (depsCohs2: DepsReflCohs2 p k): DepsRestr p k :=
+  (ReflBelowOfReflCohs (depsCohs2.(_depsReflCohs))).(_deps).
 
 Definition CohsOfReflCohs2 {p k}
-  `(depsCohs2: DepsReflCohs2 p k): DepsCohs p k :=
+  (depsCohs2: DepsReflCohs2 p k): DepsCohs p k :=
   depsCohs2.(_depsReflCohs).(_depsCohs2).(_depsCohs).
 
 Definition RestrExtOfReflCohs2 {p k}
-  `(depsCohs2: DepsReflCohs2 p k): DepsRestrExtension p k
+  (depsCohs2: DepsReflCohs2 p k): DepsRestrExtension p k
     (RestrOfReflCohs2 depsCohs2) :=
   depsCohs2.(_depsReflCohs).(_depsCohs2).(_depsCohs).(_extraDeps).
 
 Definition CohsExtOfReflCohs2 {p k}
-  `(depsCohs2: DepsReflCohs2 p k): DepsCohsExtension p k
+  (depsCohs2: DepsReflCohs2 p k): DepsCohsExtension p k
     (CohsOfReflCohs2 depsCohs2) :=
   depsCohs2.(_depsReflCohs).(_depsCohs2).(_extraDepsCohs).
 
@@ -534,10 +757,10 @@ Notation "x .(1)" := (proj1DepsReflCohs2 x%depsreflcohs2)
 Definition mkCohReflRestrLayer {p k}
   (deps: DepsReflCohs2 p.+1 k)
   (ε: arity) i (Hi: i <= k)
-  (d: mkFrame (((toDepsRefl
+  (d: mkFrame (((toDepsReflBelow
     (mkDepsCohs (Cohs2OfReflCohs2 deps))
     (mkReflFrames deps.(_depsReflCohs)))).(_deps).(1).(1)))
-  (l: mkLayer (toDepsRefl
+  (l: mkLayer (toDepsReflBelow
     (mkDepsCohs (Cohs2OfReflCohs2 deps))
     (mkReflFrames deps.(_depsReflCohs))).(_deps).(1).(_restrFrames) d)
   (prevCohReflRestrFrames:
@@ -567,40 +790,40 @@ Proof.
   unfold mkRestrLayer, mkReflLayer.
   rewrite <- map_subst_app, <- !map_subst.
 
-  set (d0 := restrFrame 0 leR_O (toDepsRefl
+  set (d0 := restrFrame 0 leR_O (toDepsReflBelow
     (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
     (mkReflFrames deps.(_depsReflCohs).(1))).(_deps) θ d).
 
   assert (h :
     (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2 i (↑ Hi) ε
-      (reflFrame (toDepsRefl
+      (reflFrame (toDepsReflBelow
         (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
         (mkReflFrames deps.(_depsReflCohs).(1))) d0)
       ((mkReflPaintings deps.(_depsReflCohs).(1)
         (deps.(_depsReflCohs); deps.(_extraDepsRefl))).2 d0 (l θ)) =
     mkRestrPainting (CohsExtOfReflCohs deps.(_depsReflCohs).(1)) i  (↑ Hi) ε
-      ((NextDepsRefl deps.(_depsReflCohs).(1)).(_reflFrames).2 d0)
+      ((mkDepsReflBelow deps.(_depsReflCohs).(1)).(_reflFrames).2 d0)
       (mkReflPainting deps.(_depsReflCohs).(1)
          (deps.(_depsReflCohs); deps.(_extraDepsRefl)) d0 (l θ)))
   by reflexivity; rewrite h; clear h.
 
   rewrite <- (deps.(_cohReflRestrPaintings).2 ε i Hi d0 (l θ)).
   rewrite rew_map with
-    (P := fun b => (NextDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
-    (f := fun x => (NextDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
+    (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
+    (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
       0 leR_O θ x).
   rewrite rew_map with
     (P := fun rf => ReflPaintingBase _ _ rf)
-    (f := fun d0 => reflFrame (toDepsRefl _ _) d0).
+    (f := fun d0 => reflFrame (toDepsReflBelow _ _) d0).
   rewrite rew_map with
     (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
-        νSet._deps).(_paintings).2 b)
+        _deps).(_paintings).2 b)
     (f := fun d0 => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
-      νSet._deps).(_restrFrames).2 i (↑ Hi) ε d0).
+      _deps).(_restrFrames).2 i (↑ Hi) ε d0).
   rewrite 4 rew_compose.
   apply rew_swap with
     (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
-      νSet._deps).(_paintings).2 b).
+      _deps).(_paintings).2 b).
   rewrite rew_app_rl. now trivial.
   now apply (mkFrame (RestrOfReflCohs2 deps).(1)).(UIP).
 Defined.
@@ -637,7 +860,7 @@ Proof.
 Defined.
 
 Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
-| TopReflCohDep2 `{deps: DepsReflCohs2 p 0}
+| TopReflCohDep2 {deps: DepsReflCohs2 p 0}
   (L: HasRefl
     (mkDepsReflCohs deps)
     (mkPaintings (mkExtraDeps (CohsExtOfReflCohs (mkDepsReflCohs deps)))).2):
@@ -673,7 +896,7 @@ Proof.
   intros ε i Hi d [l c].
   destruct i.
   - now trivial.
-  - unfold ReflPaintingBase, PaintingBase, toDepsRefl; simpl.
+  - unfold ReflPaintingBase, PaintingBase, toDepsReflBelow; simpl.
     destruct extraDeps.
     + now contradiction.
     + unshelve eapply (eq_existT_curried_dep
@@ -701,7 +924,7 @@ Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=
   toDepsRestr C.(restrFrames).
 
 Definition dgnDepsRefl {p} (C: νSetData p)
-  (reflFrames: mkReflFrameTypes (dgnDepsRestr C)): DepsReflRestr p 0 :=
+  (reflFrames: mkReflFrameTypes (dgnDepsRestr C)): DepsReflBelow p 0 :=
   {|
     _deps := dgnDepsRestr C;
     _reflFrames := reflFrames;
@@ -933,9 +1156,11 @@ CoInductive νDgnSetFrom n
 }.
 
 Definition νDgnSets (X: νSets) := νDgnSetFrom 0 tt X tt.
+*)
 
 End νDgnSet.
 
+(*
 Module νDgnSetUnit := νDgnSet νSet.ArityUnit.
 Module νDgnSetBool := νDgnSet νSet.ArityBool.
 
@@ -950,3 +1175,4 @@ Example Cubical1 :=
 
 Print Simplicial1.
 Print Cubical1.
+*)

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -638,31 +638,30 @@ Definition mkReflPaintingsBelow {p k}:
   fun deps extraDeps =>
     (mkReflPaintingsBelowPrefix deps extraDeps; mkReflPaintingBelow deps extraDeps).
 
-(*
-Definition mkCohReflRestrPaintingType {p k}
-  (deps: DepsReflCohs p.+1 k)
-  (extraDeps: DepsReflCohsExtension p.+1 k deps): Type :=
-  forall (ε: arity) i (Hi: i <= k)
-    (d: ReflFrameBase (ReflBelowOfReflCohs deps))
-    (c: ReflPaintingBase (ReflBelowOfReflCohs deps) (RestrExtOfReflCohs deps) d),
-  rew [ReflPaintingBase
-        (toDepsReflBelow deps.(_depsCohs2).(_depsCohs) deps.(_reflFrameDeps))
-        deps.(_depsCohs2).(_depsCohs).(_extraDeps)]
-  deps.(_cohReflRestrFrames).2 i Hi ε d in
-  deps.(_reflPaintingDeps).2 ((RestrOfReflCohs deps).(_restrFrames).2 i Hi ε d)
-    ((CohsOfReflCohs deps).(_restrPaintings).2 i Hi ε d c) =
-  mkRestrPainting (CohsExtOfReflCohs deps.(1)) i (↑ Hi) ε (reflFrame (mkDepsReflBelow deps.(1)) d)
-    (mkReflPainting deps.(1) (deps; extraDeps) d c).
+Definition mkCohReflRestrPaintingBelowInfType {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  (extraDeps: DepsReflCohs2Extension p.+1 k deps): Type :=
+  forall q r (Hq: q <= k) (Hr: r <= q) (ε: arity)
+    (d: FrameBase (RestrOfReflCohs2 deps))
+    (c: PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps) d),
+  rew [PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps)]
+  deps.(_depsReflCohs).(_cohReflRestrFramesBelowInf).2 q r Hq Hr ε d in
+  deps.(_depsReflCohs).(_reflPaintingsBelow).2 q Hq
+    ((RestrOfReflCohs2 deps).(_restrFrames).2 r (Hr ↕ Hq) ε d)
+    ((CohsOfReflCohs2 deps).(_restrPaintings).2 r (Hr ↕ Hq) ε d c) =
+  mkRestrPainting (CohsExtOfReflCohs2 deps.(1)) r (Hr ↕ ↑ Hq) ε
+    (mkReflFrameBelow deps.(_depsReflCohs).(1) q.+1 (⇑ Hq) d)
+    (mkReflPaintingBelow deps.(1) (deps; extraDeps) q.+1 (⇑ Hq) d c).
 
-Fixpoint mkCohReflRestrPaintingTypes {p}:
-  forall {k} (deps: DepsReflCohs p k)
-    (extraDeps: DepsReflCohsExtension p k deps), Type :=
+Fixpoint mkCohReflRestrPaintingBelowInfTypes {p}:
+  forall {k} (deps: DepsReflCohs2 p k)
+    (extraDeps: DepsReflCohs2Extension p k deps), Type :=
   match p with
   | 0 => fun _ _ _ => unit
   | S p =>
     fun k deps extraDeps =>
-    { _: mkCohReflRestrPaintingTypes deps.(1) (deps; extraDeps)
-      &T mkCohReflRestrPaintingType deps extraDeps }
+    { _: mkCohReflRestrPaintingBelowInfTypes deps.(1) (deps; extraDeps)
+      &T mkCohReflRestrPaintingBelowInfType deps extraDeps }
   end.
 
 Fixpoint mkIdReflRestrPainting {p k}

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -607,9 +607,6 @@ Proof.
       rewrite (mkIdReflRestrBelowFrame deps.(_depsReflCohs) 0 leR_O ε d).
       now exact c.
     + refine (rew _ in mkReflPaintingAbove deps extraDeps 0 leR_O d c).
-      f_equal.
-      unfold mkDepsReflAbove, mkDepsReflBelow; simpl. 
-      Fail reflexivity.
       now destruct p.
   - destruct extraDeps; [now contradiction |].
     destruct c as [l c'].
@@ -669,13 +666,12 @@ Fixpoint mkCohReflRestrPaintingBelowInfTypes {p}:
 
 Definition mkCohReflRestrPaintingBelowSupType {p k}
   (deps: DepsReflCohs2 p.+1 k)
-  (extraDeps: DepsReflCohs2Extension p.+1 k deps)
-  (cohFramesBelowSup: mkCohReflRestrFrameBelowSupType deps.(_depsReflCohs)): Type :=
+  (extraDeps: DepsReflCohs2Extension p.+1 k deps): Type :=
   forall q r (Hq: q <= r) (Hr: r <= k) (ε: arity)
     (d: FrameBase (RestrOfReflCohs2 deps))
     (c: PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps) d),
   rew [PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps)]
-    cohFramesBelowSup q r Hq Hr ε d in
+    deps.(_cohReflRestrFramesBelowSup).2 q r Hq Hr ε d in
   deps.(_depsReflCohs).(_reflPaintingsBelow).2 q (Hq ↕ Hr)
     ((RestrOfReflCohs2 deps).(_restrFrames).2 r Hr ε d)
     ((CohsOfReflCohs2 deps).(_restrPaintings).2 r Hr ε d c) =
@@ -685,16 +681,14 @@ Definition mkCohReflRestrPaintingBelowSupType {p k}
 
 Fixpoint mkCohReflRestrPaintingBelowSupTypes {p}:
   forall {k} (deps: DepsReflCohs2 p k)
-    (extraDeps: DepsReflCohs2Extension p k deps)
-    (cohFramesBelowSup: mkCohReflRestrFrameBelowSupTypes deps.(_depsReflCohs)),
+    (extraDeps: DepsReflCohs2Extension p k deps),
   Type :=
   match p with
-  | 0 => fun _ _ _ _ => unit
+  | 0 => fun _ _ _ => unit
   | S p =>
-    fun k deps extraDeps cohFramesBelowSup =>
+    fun k deps extraDeps =>
     { _: mkCohReflRestrPaintingBelowSupTypes deps.(1) (deps; extraDeps)
-        cohFramesBelowSup.1
-      &T mkCohReflRestrPaintingBelowSupType deps extraDeps cohFramesBelowSup.2 }
+      &T mkCohReflRestrPaintingBelowSupType deps extraDeps}
   end.
 
 Definition mkCohReflRestrPaintingAboveSupType {p k}
@@ -765,8 +759,7 @@ Class DepsReflCohs3 p k := {
   _cohReflRestrPaintingsBelowInf:
     mkCohReflRestrPaintingBelowInfTypes _depsReflCohs2 _extraDepsReflCohs2;
   _cohReflRestrPaintingsBelowSup:
-    mkCohReflRestrPaintingBelowSupTypes _depsReflCohs2 _extraDepsReflCohs2
-      _depsReflCohs2.(_cohReflRestrFramesBelowSup);
+    mkCohReflRestrPaintingBelowSupTypes _depsReflCohs2 _extraDepsReflCohs2;
   _cohReflRestrPaintingsAboveSup:
     mkCohReflRestrPaintingAboveSupTypes _depsReflCohs2 _extraDepsReflCohs2;
 }.
@@ -1255,6 +1248,94 @@ Proof.
         deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
     + now apply mkCohReflRestrPaintingBelowInf.
 Defined.
+
+Fixpoint mkCohReflRestrPaintingBelowSup {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingBelowSupType
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
+Proof.
+  intros q r Hq Hr ε d [l c].
+  destruct q.
+  - destruct extraDeps.
+    + destruct r; try contradiction.
+      simpl.
+      admit.
+    + unshelve eapply (eq_existT_curried_dep
+        (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
+      * apply functional_extensionality_dep.
+        intro θ.
+        unfold mkRestrLayer.
+        rewrite <- map_subst_app, <- !map_subst.
+        set (deps' := (CohsOfReflCohs2 (mkDepsReflCohs2 deps.(1))).(_deps)).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+        rewrite 2 rew_compose.
+        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+        rewrite rew_app_rl. now trivial.
+        now apply (deps'.(_frames).2.(UIP)).
+      * admit.
+  - destruct r; try contradiction.
+    destruct extraDeps; try contradiction.
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
+    + now exact (mkCohReflRestrLayerBelowSup deps ε q r (⇓ Hq) (⇓ Hr) d l
+        (mkCohReflRestrFramesBelowSup deps.(1))).
+    + now exact (mkCohReflRestrPaintingBelowSup p.+1 k deps extraDeps
+        q r Hq Hr ε (d; l) c).
+Admitted.
+
+Fixpoint mkCohReflRestrPaintingsBelowSup {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingBelowSupTypes
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflRestrPaintingBelowSup.
+  - unshelve econstructor.
+    + now exact (mkCohReflRestrPaintingsBelowSup p k.+1
+        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
+    + now apply mkCohReflRestrPaintingBelowSup.
+Defined.
+
+Fixpoint mkCohReflRestrPaintingAboveSup {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingAboveSupType
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
+Proof.
+  intros q r Hq Hr ε d [l c].
+  destruct extraDeps.
+  - destruct r; try contradiction.
+    admit.
+  - admit.
+Admitted.
+
+Fixpoint mkCohReflRestrPaintingsAboveSup {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingAboveSupTypes
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflRestrPaintingAboveSup.
+  - unshelve econstructor.
+    + now exact (mkCohReflRestrPaintingsAboveSup p k.+1
+        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
+    + now apply mkCohReflRestrPaintingAboveSup.
+Defined.
+
 
 (*
 Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -39,12 +39,14 @@ Fixpoint mkReflFrameBelowTypes {p k}: DepsRestr p k -> Type :=
           forall i (Hi: i <= k), FramePrev deps -> FrameBase deps }
   end.
 
+Definition mkReflFrameAboveType {p k} (deps: DepsRestr p.+1 k): Type :=
+  forall i (Hi: i <= p) (d: FramePrev deps), PaintingPrev deps d -> mkFrame deps.
+
 Fixpoint mkReflFrameAboveTypes {p k}: DepsRestr p k -> Type :=
   match p with
   | 0 => fun _ => unit
   | p'.+1 => fun deps =>
-    { R: mkReflFrameAboveTypes deps.(1) &T
-          forall i (Hi: i <= p') (d: FramePrev deps), PaintingPrev deps d -> mkFrame deps }
+    { R: mkReflFrameAboveTypes deps.(1) &T mkReflFrameAboveType deps }
   end.
 
 Class DepsReflBelow p k := {
@@ -150,8 +152,7 @@ Fixpoint mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow {p k}:
         let reflFrame0: forall i (Hi: i <= k),
           FramePrev (mkDepsRestr deps) -> FrameBase (mkDepsRestr deps) :=
           fun _ _ d => d in
-        (((tt: mkReflFrameBelowTypes (mkDepsRestr deps).(1)); reflFrame0):
-          mkReflFrameBelowTypes (mkDepsRestr deps))
+        ((tt; reflFrame0): mkReflFrameBelowTypes (mkDepsRestr deps))
     |}
   | S p =>
     fun deps reflFramesBelow reflPaintingsBelow =>
@@ -330,14 +331,16 @@ Defined.
 Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohsInf p k):
   mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps).
   destruct p.
-  - unshelve econstructor. now exact tt. now intros i Hi ε [].
+  - unshelve econstructor.
+    now exact tt.
+    now intros i Hi ε [].
   - set (h := mkIdReflRestrFramesBelow p k.+1 deps.(1)%depsreflcohsinf).
     unshelve econstructor.
     + now apply h.
-    + intros i Hi ε [l c].
+    + intros i Hi ε [d l].
       unshelve eapply eq_existT_curried.
-      * now exact (h.2 i.+1 (⇑ Hi) ε l).
-      * now exact (mkIdReflRestrLayerBelow deps i Hi ε l c h).
+      * now exact (h.2 i.+1 (⇑ Hi) ε d).
+      * now exact (mkIdReflRestrLayerBelow deps i Hi ε d l h).
 Defined.
 
 Definition mkIdReflRestrFrameBelow {p k} (deps: DepsReflCohsInf p k):
@@ -389,19 +392,77 @@ Fixpoint mkReflPaintingAboveTypes {p}:
       mkReflPaintingAboveType deps }
   end.
 
+Definition mkReflLayerAbove0 {p k} (deps: DepsReflCohsInf p k)
+  (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
+  (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsInf deps)) d):
+  mkLayer
+    (paintings := (mkDepsRestr (CohsOfReflCohsInf deps)).(_paintings))
+    (mkDepsRestr (CohsOfReflCohsInf deps)).(_restrFrames)
+    (mkReflFrameBelow deps 0 leR_O d) :=
+  fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c.
+
+Definition mkReflFrameAbove0 {p k} (deps: DepsReflCohsInf p k)
+  (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
+  (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsInf deps)) d):
+  mkFrame (mkDepsRestr (CohsOfReflCohsInf deps)) :=
+  (mkReflFrameBelow deps 0 leR_O d; mkReflLayerAbove0 deps d c).
+
+Definition mkReflFrameAboveTypeS {p k} (deps: DepsRestr p.+1 k): Type :=
+  forall i (Hi: i.+1 <= p) (d: FramePrev deps),
+  PaintingPrev deps d -> mkFrame deps.
+
+Fixpoint mkReflFrameAboveTypesS {p k}: DepsRestr p k -> Type :=
+  match p with
+  | 0 => fun _ => unit
+  | p'.+1 => fun deps =>
+    { R: mkReflFrameAboveTypesS deps.(1) &T mkReflFrameAboveTypeS deps }
+  end.
+
+Definition mkReflFrameAboveOf0AndS {p k} (deps: DepsReflCohsInf p k)
+  (reflFrameAboveS: mkReflFrameAboveTypeS (mkDepsRestr (CohsOfReflCohsInf deps))):
+  mkReflFrameAboveType (mkDepsRestr (CohsOfReflCohsInf deps)) :=
+  fun i =>
+    match i with
+    | 0 => fun _ => mkReflFrameAbove0 deps
+    | i'.+1 => fun Hi => reflFrameAboveS i' Hi
+    end.
+
+Fixpoint mkReflFramesAboveOf0AndSPrefix {p k}:
+  forall (deps: DepsReflCohsInf p k)
+    (reflFramesAboveS: mkReflFrameAboveTypesS (mkDepsRestr (CohsOfReflCohsInf deps)).(1)),
+  mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsInf deps)).(1) :=
+  match p with
+  | 0 => fun _ _ => tt
+  | p'.+1 => fun deps reflFramesAboveS =>
+    (mkReflFramesAboveOf0AndSPrefix deps.(1) reflFramesAboveS.1;
+     mkReflFrameAboveOf0AndS deps.(1) reflFramesAboveS.2)
+  end.
+
+Definition mkReflFramesAboveOf0AndS {p k} (deps: DepsReflCohsInf p k)
+  (reflFramesAboveS: mkReflFrameAboveTypesS (mkDepsRestr (CohsOfReflCohsInf deps))):
+  mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsInf deps)) :=
+  (mkReflFramesAboveOf0AndSPrefix deps reflFramesAboveS.1;
+   mkReflFrameAboveOf0AndS deps reflFramesAboveS.2).
+
 Class CohReflRestrFrameAboveSupTypeBlock {p k} (deps: DepsRestr p k) := {
   CohReflRestrFrameAboveSupTypesDef: Type;
-  ReflFramesAboveDef: CohReflRestrFrameAboveSupTypesDef -> mkReflFrameAboveTypes deps;
+  ReflFramesAboveSDef: CohReflRestrFrameAboveSupTypesDef -> mkReflFrameAboveTypesS deps;
 }.
+
+Definition mkCohReflRestrFrameAboveSupType {p k} (deps: DepsReflCohsInf p.+1 k)
+  (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohsInf deps.(1))))
+  (Q: prev.(CohReflRestrFrameAboveSupTypesDef)): Type :=
+  forall q r (Hq: q <= p) (Hr: r <= k) (ε: arity)
+    (d: FrameBase (RestrOfReflCohsInf deps))
+    (c: PaintingBase (RestrOfReflCohsInf deps) (RestrExtOfReflCohsInf deps) d),
+  let reflFramesAbove := mkReflFramesAboveOf0AndS deps.(1) (prev.(ReflFramesAboveSDef) Q) in
+  deps.(_reflFramesAbove).2 q Hq _ ((CohsOfReflCohsInf deps).(_restrPaintings).2 r Hr ε d c) =
+  mkRestrFrame r Hr ε ((reflFramesAbove.2) q Hq d c).
 
 Definition mkCohReflRestrFrameAboveSupTypesStep {p k} (deps: DepsReflCohsInf p.+1 k)
   (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohsInf deps.(1)))): Type :=
   { Q: prev.(CohReflRestrFrameAboveSupTypesDef) &T
-    forall q r (Hq: q <= p) (Hr: r <= k) (ε: arity)
-      (d: FrameBase (RestrOfReflCohsInf deps))
-      (c: PaintingBase (RestrOfReflCohsInf deps) (RestrExtOfReflCohsInf deps) d),
-    deps.(_reflFramesAbove).2 q Hq _ ((CohsOfReflCohsInf deps).(_restrPaintings).2 r Hr ε d c) =
-    mkRestrFrame r Hr ε (((prev.(ReflFramesAboveDef) Q).2) q Hq d c) }.
+   mkCohReflRestrFrameAboveSupType deps prev Q }.
 
 Definition mkReflLayerAbove {p k} (deps: DepsReflCohsInf p.+1 k)
   (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohsInf deps))
@@ -410,10 +471,11 @@ Definition mkReflLayerAbove {p k} (deps: DepsReflCohsInf p.+1 k)
   i (Hi: i <= p)
   (d: FrameBase (RestrOfReflCohsInf deps))
   (c: PaintingBase (RestrOfReflCohsInf deps) (RestrExtOfReflCohsInf deps) d):
+  let reflFramesAbove := mkReflFramesAboveOf0AndS deps.(1) (prev.(ReflFramesAboveSDef) cohFrames.1) in
   mkLayer
     (paintings := mkPaintings (RestrExtOfReflCohsInf deps))
     (mkDepsRestr (CohsOfReflCohsInf deps)).(_restrFrames)
-    ((prev.(ReflFramesAboveDef) cohFrames.1).2 i Hi d c) :=
+    (reflFramesAbove.2 i Hi d c) :=
   fun ε =>
     rew [(mkDepsRestr (CohsOfReflCohsInf deps)).(_paintings).2]
       cohFrames.2 i 0 Hi leR_O ε d c in
@@ -428,34 +490,23 @@ Fixpoint mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove {p k}:
   | 0 => fun deps reflPaintingsAbove =>
     {|
       CohReflRestrFrameAboveSupTypesDef := unit;
-      ReflFramesAboveDef _ :=
-        let reflFrameAbove i (Hi: i <= 0)
-          (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
-          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsInf deps)) d) :=
-          (mkReflFrameBelow deps 0 leR_O d;
-            fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c) in
-        ((tt; reflFrameAbove): mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsInf deps)))
+      ReflFramesAboveSDef _ :=
+        let reflFrame0: mkReflFrameAboveTypeS (mkDepsRestr (CohsOfReflCohsInf deps)) :=
+          fun i Hi d c => match Hi with end in
+        ((tt; reflFrame0): mkReflFrameAboveTypesS (mkDepsRestr (CohsOfReflCohsInf deps)))
     |}
-  | S p => fun deps reflPaintingsAbove =>
-    let prev := mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(1)
-      reflPaintingsAbove.1 in
+  | p'.+1 => fun deps reflPaintingsAbove =>
+    let prev := mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(1) reflPaintingsAbove.1 in
     {|
       CohReflRestrFrameAboveSupTypesDef := mkCohReflRestrFrameAboveSupTypesStep deps prev;
-      ReflFramesAboveDef Q :=
-        let prevReflFrames := prev.(ReflFramesAboveDef) Q.1 in
-        let reflFrameAbove i (Hi: i <= p.+1)
-          (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
-          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsInf deps)) d) :=
-          match i return i <= p.+1 -> mkFrame (mkDepsRestr (CohsOfReflCohsInf deps)) with
-          | 0 => fun _ =>
-            (mkReflFrameBelow deps 0 leR_O d;
-              fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c)
-          | i.+1 => fun Hi =>
-            (prevReflFrames.2 i Hi d.1 (d.2; c);
-              mkReflLayerAbove deps reflPaintingsAbove prev Q i (⇓ Hi) d.1 (d.2; c))
-          end Hi in
-        (prevReflFrames; reflFrameAbove):
-          mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsInf deps))
+      ReflFramesAboveSDef Q :=
+        let prevReflFrames := prev.(ReflFramesAboveSDef) Q.1 in
+        let reflFramesAbove := mkReflFramesAboveOf0AndS deps.(1) prevReflFrames in
+        let reflFrame i (Hi: i.+1 <= p'.+1) d c :=
+          (reflFramesAbove.2 i Hi d.1 (d.2; c);
+           mkReflLayerAbove deps reflPaintingsAbove prev Q i (⇓ Hi) d.1 (d.2; c)) in
+        (prevReflFrames; reflFrame):
+          mkReflFrameAboveTypesS (mkDepsRestr (CohsOfReflCohsInf deps))
     |}
   end.
 
@@ -516,11 +567,15 @@ Definition CohsExtOfReflCohsSup {p k}
     (CohsOfReflCohsSup depsCohsSup) :=
   CohsExtOfReflCohsInf depsCohsSup.(_depsReflCohsInf).
 
+Definition mkReflFramesAboveS {p k} (deps: DepsReflCohsSup p k):
+  mkReflFrameAboveTypesS (mkDepsRestr (CohsOfReflCohsSup deps)) :=
+  (mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(_depsReflCohsInf)
+    deps.(_reflPaintingsAbove)).(ReflFramesAboveSDef)
+      deps.(_cohReflRestrFramesAboveSup).
+
 Definition mkReflFramesAbove {p k} (deps: DepsReflCohsSup p k):
   mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsSup deps)) :=
-  (mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(_depsReflCohsInf)
-    deps.(_reflPaintingsAbove)).(ReflFramesAboveDef)
-      deps.(_cohReflRestrFramesAboveSup).
+  mkReflFramesAboveOf0AndS deps.(_depsReflCohsInf) (mkReflFramesAboveS deps).
 
 Definition mkReflFrameAbove {p k} (deps: DepsReflCohsSup p k):
   forall i (Hi: i <= p)
@@ -578,7 +633,7 @@ Fixpoint mkReflPaintingsAbovePrefix {p k}:
   forall (deps: DepsReflCohsSup p k) (extraDeps: DepsReflCohsSupExtension p k deps),
   mkReflPaintingAboveTypes ((mkDepsReflAbove deps).(1)) :=
   match p with
-  | 0 => fun _ _ => tt
+  | 0 => fun deps extraDeps => tt
   | S p =>
     fun deps extraDeps =>
       (mkReflPaintingsAbovePrefix deps.(1) (deps; extraDeps);
@@ -596,16 +651,14 @@ Definition mkReflPaintingBelow1 {p k}
   (extraDeps: DepsReflCohsSupExtension p k deps)
   i (Hi: i <= k)
   (d: FramePrev (mkDepsReflBelow deps.(_depsReflCohsInf)).(_depsRestr))
-  (c: PaintingPrev (mkDepsReflBelow deps .(_depsReflCohsInf)) .(_depsRestr) d) :
+  (c: PaintingPrev (mkDepsReflBelow deps.(_depsReflCohsInf)) .(_depsRestr) d) :
   (mkLayer
-    (paintings := (mkDepsReflBelow deps .(_depsReflCohsInf)).(_depsRestr).(_paintings))
-    (mkDepsReflBelow deps .(_depsReflCohsInf)).(_depsRestr).(_restrFrames)
-    ((mkDepsReflBelow deps .(_depsReflCohsInf)).(_reflFramesBelow).2 i Hi d)).
+    (paintings := (mkDepsReflBelow deps.(_depsReflCohsInf)).(_depsRestr).(_paintings))
+    (mkDepsReflBelow deps.(_depsReflCohsInf)).(_depsRestr).(_restrFrames)
+    ((mkDepsReflBelow deps.(_depsReflCohsInf)).(_reflFramesBelow).2 i Hi d)).
 Proof.
   destruct i.
-  - intros ε.
-    rewrite (mkIdReflRestrFrameBelow deps.(_depsReflCohsInf) 0 leR_O ε d).
-    now exact c.
+  - now exact (mkReflLayerAbove0 deps.(_depsReflCohsInf) d c).
   - destruct extraDeps; [now contradiction |].
     destruct c as [l c'].
     now exact (mkReflLayerBelow _ _
@@ -624,8 +677,7 @@ Fixpoint mkReflPaintingBelow2 {p k}
     (mkReflPaintingBelow1 deps extraDeps i Hi d c))).
 Proof.
   destruct i.
-  - refine (rew _ in mkReflPaintingAbove deps extraDeps 0 leR_O d c).
-    now destruct p.
+  - now exact (mkReflPaintingAbove deps extraDeps 0 leR_O d c).
   - destruct extraDeps; [now contradiction |].
     destruct c as [l c'].
     unshelve econstructor.
@@ -1071,11 +1123,7 @@ Proof.
     (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
       0 leR_O θ x).
   rewrite rew_map with
-    (f := fun d1 =>
-      (toDepsReflBelow
-        (ReflCohsInfOfReflCohs2 deps).(_depsCohs2).(_depsCohs)
-        (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')).(_reflFramesBelow).2
-        q Hq d1).
+    (f := fun d1 => (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q Hq d1).
   rewrite rew_map with
     (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
         _deps).(_paintings).2 b)
@@ -1096,7 +1144,9 @@ Fixpoint mkCohReflRestrFramesBelowInf {p k} (deps: DepsReflCohs2 p k):
     (mkReflPaintingsBelow deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
 Proof.
   destruct p.
-  - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
+  - unshelve econstructor.
+    + now exact tt.
+    + now trivial.
   - set (h := mkCohReflRestrFramesBelowInf p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor.
     + now exact h.
@@ -1189,7 +1239,9 @@ Fixpoint mkCohReflRestrFramesBelowSup {p k} (deps: DepsReflCohs2 p k):
   mkCohReflRestrFrameBelowSupTypes (mkDepsReflCohsInf deps).
 Proof.
   destruct p.
-  - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
+  - unshelve econstructor.
+    + now exact tt.
+    + now trivial.
   - set (h := mkCohReflRestrFramesBelowSup p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor.
     + now exact h.
@@ -1201,7 +1253,7 @@ Defined.
 
 Definition mkCohReflRestrLayerAboveSup {p k}
   (deps: DepsReflCohs2 p.+1 k)
-  (ε: arity) q r (Hq: q.+1 <= p.+1) (Hr: r <= k)
+  (ε: arity) q r (Hq: q <= p) (Hr: r <= k)
   (d: mkFrame ((RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(1)))
   (l: mkLayer (RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(_restrFrames) d)
   (c: mkPainting
@@ -1216,7 +1268,7 @@ Definition mkCohReflRestrLayerAboveSup {p k}
   mkReflLayerAbove deps.(_depsReflCohsSup).(_depsReflCohsInf)
     deps.(_depsReflCohsSup).(_reflPaintingsAbove) _
     deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup)
-    q (⇓ Hq)
+    q Hq
     ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).1
     (((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).2;
      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε (d; l) c) =
@@ -1226,7 +1278,7 @@ Definition mkCohReflRestrLayerAboveSup {p k}
     r Hr ε _
     (mkReflLayerAbove (mkDepsReflCohsInf deps).(1)
       (mkReflPaintingsAbove deps.(1).(_depsReflCohsSup) deps.(1).(_extraDepsReflCohsSup)) _
-      prevCohReflRestrFrames q (⇓ Hq) d (l; c)).
+      prevCohReflRestrFrames q Hq d (l; c)).
 Proof.
   apply functional_extensionality_dep.
   intros θ.
@@ -1239,14 +1291,14 @@ Proof.
     0 leR_O θ d (l; c)).
 
   simpl.
-  rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r (⇓ Hq) Hr ε d0 c0).
+  rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r Hq Hr ε d0 c0).
 
   eassert (coh_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     now exact ((CohsOfReflCohs2 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
     now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; c)). }
   rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
-    deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) x.1 x.2) coh_pair_eq tt).
+    deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q Hq x.1 x.2) coh_pair_eq tt).
 
   rewrite rew_map with
     (P := fun b =>
@@ -1264,7 +1316,7 @@ Proof.
     (P := fun x => mkPainting (RestrExtOfReflCohsSup deps.(_depsReflCohsSup)) x)
     (f := fun x =>
       (AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_reflFramesAbove').2
-        q (⇓ Hq) x.1 x.2).
+        q Hq x.1 x.2).
   rewrite 4 rew_compose.
   apply rew_swap with
     (P := fun x => mkPainting (RestrExtOfReflCohsSup deps.(_depsReflCohsSup)) x).
@@ -1272,37 +1324,78 @@ Proof.
   now apply (mkFrame (RestrOfReflCohsSup deps.(_depsReflCohsSup))).(UIP).
 Defined.
 
-Fixpoint mkCohReflRestrFramesAboveSup {p k} (deps: DepsReflCohs2 p k):
+Definition mkCohReflRestrLayerAboveSup0 {p k}
+  (deps: DepsReflCohs2 p k) r (Hr: r <= k) (ε: arity)
+  (d: FrameBase (RestrOfReflCohsInf (mkDepsReflCohsInf deps)))
+  (c: PaintingBase (RestrOfReflCohsInf (mkDepsReflCohsInf deps))
+    (RestrExtOfReflCohsInf (mkDepsReflCohsInf deps)) d):
+  rew [mkLayer _] (mkCohReflRestrFramesBelowSup deps).2 0 r leR_O Hr ε d in
+  mkReflLayerAbove0 (ReflCohsInfOfReflCohs2 deps)
+    (mkRestrFrames.2 r Hr ε d)
+    (mkRestrPainting (CohsExtOfReflCohs2 deps) r Hr ε d c) =
+  mkRestrLayer
+    (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs).(_restrPaintings)
+    (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs).(_cohs) r Hr ε
+    (mkReflFrameAbove0 (mkDepsReflCohsInf deps).(1) d c).1
+    (mkReflFrameAbove0 (mkDepsReflCohsInf deps).(1) d c).2.
+Proof.
+  apply functional_extensionality_dep; intro θ.
+  unfold mkRestrLayer.
+  rewrite <- map_subst_app, <- !map_subst.
+  set (deps' := (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps)).
+  rewrite rew_map with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+  rewrite rew_map with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+  rewrite 2 rew_compose.
+  apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+  rewrite rew_app_rl. now trivial.
+  now apply (deps'.(_frames).2.(UIP)).
+Defined.
+
+Definition mkCohReflRestrFrameAboveSup {p k} (deps: DepsReflCohs2 p k)
+  (cohPrefix:
+    mkCohReflRestrFrameAboveSupTypes
+      (mkDepsReflCohsInf deps).(1)
+      (mkReflPaintingsAbove deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).1):
+  mkCohReflRestrFrameAboveSupType (mkDepsReflCohsInf deps) _ cohPrefix.
+Proof.
+  intros q r Hq Hr ε d c.
+  destruct q.
+  - unshelve eapply eq_existT_curried.
+    + now exact ((mkCohReflRestrFramesBelowSup deps).2 0 r leR_O Hr ε d).
+    + now exact (mkCohReflRestrLayerAboveSup0 deps r Hr ε d c).
+  - destruct p; [now contradiction |].
+    destruct d as [d l].
+    unshelve eapply eq_existT_curried.
+    + now exact (cohPrefix.2 q r.+1 Hq (⇑ Hr) ε d (l; c)).
+    + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l c cohPrefix).
+Defined.
+
+Fixpoint mkCohReflRestrFramesAboveSupPrefix {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflRestrFrameAboveSupTypes
+    ((mkDepsReflCohsInf deps).(1))
+    ((mkReflPaintingsAbove deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).1).
+Proof.
+  destruct p.
+  - now exact tt.
+  - set (h := mkCohReflRestrFramesAboveSupPrefix p k.+1 deps.(1)%depsreflcohs2).
+    unshelve econstructor.
+    + now exact h.
+    + now exact (mkCohReflRestrFrameAboveSup deps.(1) h).
+Defined.
+
+Definition mkCohReflRestrFramesAboveSup {p k} (deps: DepsReflCohs2 p k):
   mkCohReflRestrFrameAboveSupTypes
     (mkDepsReflCohsInf deps)
     (mkReflPaintingsAbove deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
 Proof.
-  destruct p.
-  - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
-  - set (h := mkCohReflRestrFramesAboveSup p k.+1 deps.(1)%depsreflcohs2).
-    unshelve econstructor. now exact h.
-    intros q r Hq Hr ε [d l] c.
-    destruct q.
-    + unshelve eapply eq_existT_curried.
-      * now exact ((mkCohReflRestrFramesBelowSup deps).2 0 r leR_O Hr ε (d; l)).
-      * apply functional_extensionality_dep.
-        intro θ.
-        unfold mkRestrLayer.
-        rewrite <- map_subst_app, <- !map_subst.
-        set (deps' := (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps)).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
-        rewrite 2 rew_compose.
-        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-        rewrite rew_app_rl. now trivial.
-        now apply (deps'.(_frames).2.(UIP)).
-    + unshelve eapply eq_existT_curried.
-      * now exact (h.2 q r.+1 Hq (⇑ Hr) ε d (l; c)).
-      * now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l c h).
+  set (h := mkCohReflRestrFramesAboveSupPrefix deps).
+  unshelve econstructor.
+  - now exact h.
+  - now exact (mkCohReflRestrFrameAboveSup deps h).
 Defined.
 
 Instance mkDepsReflCohsSup {p k} (deps: DepsReflCohs2 p k): DepsReflCohsSup p.+1 k.
@@ -1466,36 +1559,73 @@ Proof.
     (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_frames).2.(UIP)).
 Defined.
 
-Fixpoint mkCohReflAboveBelowFrames {p k} (deps: DepsReflCohs2 p k):
-  mkCohReflAboveBelowFrameTypes (mkDepsReflCohsSup deps).
+Definition mkCohReflAboveBelowLayer0 {p k}
+  (deps: DepsReflCohs2 p k) r (Hr: r <= k)
+  (d: FramePrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)))
+  (c: PaintingPrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) d):
+  rew [mkLayer _] (mkCohReflBelowBelowFrames deps).2 0 r leR_O Hr d in
+  mkReflLayerAbove0
+    (mkDepsReflCohsInf deps).(1)
+    ((mkReflFramesBelow (ReflCohsInfOfReflCohs2 deps)).2 r Hr d)
+    (mkReflPaintingBelow deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) r Hr d c) =
+  mkReflLayerBelow
+    (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs)
+    (mkDepsReflCohsInf deps).(_reflFramesBelow')
+    (mkDepsReflCohsInf deps).(_reflPaintingsBelow) _
+    (mkDepsReflCohsInf deps).(_cohReflRestrFramesBelowInf) r Hr
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).1
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).2.
+Proof.
+  apply functional_extensionality_dep; intro θ.
+  unfold mkReflLayerBelow.
+  rewrite <- map_subst_app, <- !map_subst.
+  set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1))).
+  rewrite rew_map with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+  rewrite rew_map with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr d0).
+  rewrite 2 rew_compose.
+  apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+  rewrite rew_app_rl. now trivial.
+  now apply (deps'.(_frames).2.(UIP)).
+Defined.
+
+Definition mkCohReflAboveBelowFrame {p k} (deps: DepsReflCohs2 p k)
+  (cohPrefix: mkCohReflAboveBelowFrameTypes (mkDepsReflCohsSup deps).(1)):
+  mkCohReflAboveBelowFrameType (mkDepsReflCohsSup deps).
+Proof.
+  intros q r Hq Hr d c.
+  destruct q.
+  - unshelve eapply eq_existT_curried.
+    + now exact ((mkCohReflBelowBelowFrames deps).2 0 r leR_O Hr d).
+    + now exact (mkCohReflAboveBelowLayer0 deps r Hr d c).
+  - destruct p; [now contradiction |].
+    destruct d as [d l].
+    unshelve eapply eq_existT_curried.
+    + now exact (cohPrefix.2 q r.+1 Hq (⇑ Hr) d (l; c)).
+    + now exact (mkCohReflAboveBelowLayer deps q r Hq Hr d l c cohPrefix).
+Defined.
+
+Fixpoint mkCohReflAboveBelowFramesPrefix {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflAboveBelowFrameTypes (mkDepsReflCohsSup deps).(1).
 Proof.
   destruct p.
-  - unshelve econstructor. now exact tt.
-    now intros q r Hq Hr [].
-  - set (h := mkCohReflAboveBelowFrames p k.+1 deps.(1)%depsreflcohs2).
-    unshelve econstructor. now exact h.
-    intros q r Hq Hr [d l] c.
-    destruct q.
-    + unshelve eapply eq_existT_curried.
-      * now exact ((mkCohReflBelowBelowFrames deps).2 0 r leR_O Hr (d; l)).
-      * apply functional_extensionality_dep.
-        intro θ.
-        unfold mkReflLayerBelow.
-        rewrite <- map_subst_app, <- !map_subst.
-        set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1))).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr d0).
-        rewrite 2 rew_compose.
-        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-        rewrite rew_app_rl. now trivial.
-        now apply (deps'.(_frames).2.(UIP)).
-    + unshelve eapply eq_existT_curried.
-      * now exact (h.2 q r.+1 Hq (⇑ Hr) d (l; c)).
-      * now exact (mkCohReflAboveBelowLayer deps q r Hq Hr d l c h).
+  - now exact tt.
+  - set (h := mkCohReflAboveBelowFramesPrefix p k.+1 deps.(1)%depsreflcohs2).
+    unshelve econstructor.
+    + now exact h.
+    + now exact (mkCohReflAboveBelowFrame deps.(1) h).
+Defined.
+
+Definition mkCohReflAboveBelowFrames {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflAboveBelowFrameTypes (mkDepsReflCohsSup deps).
+Proof.
+  set (h := mkCohReflAboveBelowFramesPrefix deps).
+  unshelve econstructor.
+  - now exact h.
+  - now exact (mkCohReflAboveBelowFrame deps h).
 Defined.
 
 Definition mkCohReflAboveAboveLayer {p k}
@@ -1567,56 +1697,84 @@ Proof.
   now apply (mkFrame (RestrOfReflCohsInf (mkDepsReflCohsInf deps))).(UIP).
 Defined.
 
-Fixpoint mkCohReflAboveAboveFrames {p k} (deps: DepsReflCohs2 p k):
-  mkCohReflAboveAboveFrameTypes (mkDepsReflCohsSup deps).
+Definition mkCohReflAboveAboveLayer0 {p k}
+  (deps: DepsReflCohs2 p k) r (Hr: r <= p)
+  (d: FramePrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)))
+  (c: PaintingPrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) d):
+  rew <- [mkLayer _] ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c) in
+  mkReflLayerAbove0
+    (mkDepsReflCohsInf deps)
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r Hr d c)
+    ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r Hr d c) =
+  mkReflLayerAbove
+    (mkDepsReflCohsSup deps).(_depsReflCohsInf)
+    (mkDepsReflCohsSup deps).(_reflPaintingsAbove) _
+    (mkDepsReflCohsSup deps).(_cohReflRestrFramesAboveSup) r Hr
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).1
+    (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).2;
+     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 0 leR_O d c).
 Proof.
   set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps))).
-  destruct p.
-  - unshelve econstructor. now exact tt.
-    intros q r Hq Hr [] c.
-    destruct r; [| now contradiction].
-    destruct q; [| now contradiction].
+  apply functional_extensionality_dep; intro θ.
+  unfold mkReflLayerAbove, mkReflLayerAbove0.
+  unfold eq_rect_r; cbn.
+  rewrite <- map_subst_app.
+  eassert (coh_id_pair_eq: (_;_) = (_;_)).
+  { unshelve eapply eq_existT_curried.
+    - now exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
+    - now exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
+        deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
+  rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
+    deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
+    r Hr x.1 x.2) coh_id_pair_eq tt).
+  rewrite rew_map with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+  rewrite rew_map with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2).
+  rewrite 2 rew_compose.
+  apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+  rewrite rew_app_rl. now trivial.
+  now apply (deps'.(_frames).2.(UIP)).
+Defined.
+
+Definition mkCohReflAboveAboveFrame {p k} (deps: DepsReflCohs2 p k)
+  (cohPrefix: mkCohReflAboveAboveFrameTypes (mkDepsReflCohsSup deps).(1)):
+  mkCohReflAboveAboveFrameType (mkDepsReflCohsSup deps).
+Proof.
+  intros q r Hq Hr d c.
+  destruct q.
+  - unshelve eapply eq_existT_curried.
+    + symmetry.
+      now exact ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c).
+    + now exact (mkCohReflAboveAboveLayer0 deps r Hr d c).
+  - destruct r; [now contradiction |].
+    destruct p; [now contradiction |].
+    destruct d as [d l].
     unshelve eapply eq_existT_curried.
-    + now trivial.
-    + apply functional_extensionality_dep; intro θ.
-      cbn.
-      enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
-      now apply (deps'.(_frames).2.(UIP)).
-  - set (h := mkCohReflAboveAboveFrames p k.+1 deps.(1)%depsreflcohs2).
-    unshelve econstructor. now exact h.
-    intros q r Hq Hr d c.
-    destruct q.
-    + unshelve eapply eq_existT_curried.
-      * symmetry.
-        now exact ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c).
-      * apply functional_extensionality_dep; intro θ.
-        unfold mkReflLayerAbove.
-        rewrite <- map_subst_app.
-        eassert (coh_id_pair_eq: (_;_) = (_;_)).
-        { unshelve eapply eq_existT_curried.
-          - now exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
-          - now exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
-              deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
-        unfold mkDepsReflCohsSup, mkReflPaintingsAbove.
-        cbn [_reflPaintingsAbove projT2].
-        rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
-          deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
-          r Hr x.1 x.2) coh_id_pair_eq tt).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-        rewrite rew_map with
-          (P := fun b => deps'.(_paintings).2 b)
-          (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2).
-        rewrite 2 rew_compose.
-        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-        rewrite rew_app_rl. now trivial.
-        now apply (deps'.(_frames).2.(UIP)).
-    + destruct r; [now contradiction |].
-      destruct d as [d l].
-      unshelve eapply eq_existT_curried.
-      * now exact (h.2 q r Hq Hr d (l; c)).
-      * now exact (mkCohReflAboveAboveLayer deps q r (⇓ Hq) (⇓ Hr) d l c h).
+    + now exact (cohPrefix.2 q r Hq Hr d (l; c)).
+    + now exact (mkCohReflAboveAboveLayer deps q r (⇓ Hq) (⇓ Hr) d l c cohPrefix).
+Defined.
+
+Fixpoint mkCohReflAboveAboveFramesPrefix {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflAboveAboveFrameTypes (mkDepsReflCohsSup deps).(1).
+Proof.
+  destruct p.
+  - now exact tt.
+  - set (h := mkCohReflAboveAboveFramesPrefix p k.+1 deps.(1)%depsreflcohs2).
+    unshelve econstructor.
+    + now exact h.
+    + now exact (mkCohReflAboveAboveFrame deps.(1) h).
+Defined.
+
+Definition mkCohReflAboveAboveFrames {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflAboveAboveFrameTypes (mkDepsReflCohsSup deps).
+Proof.
+  set (h := mkCohReflAboveAboveFramesPrefix deps).
+  unshelve econstructor.
+  - now exact h.
+  - now exact (mkCohReflAboveAboveFrame deps h).
 Defined.
 
 Definition cohReflAboveAboveL {p} (deps: DepsReflCohs2 p 0)
@@ -1748,29 +1906,8 @@ Proof.
   destruct q.
   - unshelve eapply (eq_existT_curried_dep
       (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
-    + apply functional_extensionality_dep.
-      intro θ.
-      unfold mkRestrLayer.
-      rewrite <- map_subst_app, <- !map_subst.
-      set (deps' := (mkDepsRestr (CohsOfReflCohs2 deps))).
-      rewrite rew_map with
-        (P := fun b => deps'.(_paintings).2 b)
-        (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-      rewrite rew_map with
-        (P := fun b => deps'.(_paintings).2 b)
-        (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
-      rewrite 2 rew_compose.
-      apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-      rewrite rew_app_rl. now trivial.
-      now apply (deps'.(_frames).2.(UIP)).
-    + destruct p.
-      * set (h := mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
-        unfold mkRestrPainting in h |- *.
-        rewrite <- h; clear h.
-        destruct d.
-        enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
-        now apply (mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
-      * now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
+    + now exact (mkCohReflRestrLayerAboveSup0 deps r Hr ε d (l; c)).
+    + now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
   - destruct r; [now contradiction |].
     destruct extraDeps; [now contradiction |].
     unshelve eapply (eq_existT_curried_dep
@@ -1842,44 +1979,11 @@ Fixpoint mkCohReflAboveBelowPainting {p k} (deps: DepsReflCohs2 p k)
 Proof.
   intros q r Hq Hr d c.
   destruct r.
-  - unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+  - apply rew_swap with (P := mkPainting _), eq_sym.
+    unshelve eapply (eq_existT_curried_dep (Q := mkPainting
       (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps))))).
-    + apply functional_extensionality_dep; intro θ.
-      unfold mkReflLayerAbove, mkReflPaintingBelow1.
-      rewrite <- map_subst_app.
-      set (deps' := mkExtraDeps (CohsExtOfReflCohs2 deps)).
-      apply rew_swap with (P := fun b => mkPainting deps' b).
-      rewrite rew_map with
-        (P := fun b => mkPainting deps' b)
-        (f := fun x => (mkDepsRestr (CohsOfReflCohsInf
-          (mkDepsReflCohsSup deps).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
-      rewrite 2 rew_compose.
-      unfold mkDepsReflCohsSup, mkReflPaintingsAbove.
-      cbn [_reflPaintingsAbove projT2].
-      eassert (coh_id_pair_eq: (_;_) = (_;_)).
-      { unshelve eapply eq_existT_curried.
-        - exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
-        - exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
-            deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
-      rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
-        deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
-        q Hq x.1 x.2) coh_id_pair_eq tt).
-      rewrite rew_map with
-        (P := fun b => mkPainting deps' b)
-        (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 q Hq x.1 x.2).
-      apply rew_swap with (P := fun b => mkPainting deps' b).
-      rewrite rew_app_rl. now trivial.
-      now apply (mkFrame _).(UIP).
-    + match goal with
-      | |- rew [?P1'] ?H' in ?y = ?x => set (H := H')
-      end.
-      set (h := mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
-      unfold mkReflPaintingAbove in h |- *.
-      destruct p.
-      all: rewrite <- h; clear h.
-      all: rewrite rew_compose.
-      all: enough (h: _ • H = eq_refl) by (now rewrite h).
-      all: now apply (mkFrame (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))).(UIP).
+    + now exact (mkCohReflAboveAboveLayer0 deps q Hq d c).
+    + now exact (mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
   - destruct extraDeps; [now contradiction |].
     destruct c as [l c].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting
@@ -1918,31 +2022,8 @@ Proof.
   destruct q.
   - unshelve eapply (eq_existT_curried_dep (Q := mkPainting
       (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps).(1))))).
-    + apply functional_extensionality_dep; intro θ.
-      unfold mkReflPaintingBelow1, mkReflLayerBelow.
-      rewrite <- map_subst_app, <- !map_subst.
-      set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1))). 
-      rewrite rew_map with
-        (P := fun b => deps'.(_paintings).2 b)
-        (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-      rewrite rew_map with
-        (P := fun b =>
-          PaintingBase _ (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) b)
-        (f := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r (⇑ Hr) d0).
-      rewrite 2 rew_compose.
-      apply rew_swap with (P := fun b =>
-        PaintingBase _ (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) b).
-      rewrite rew_app_rl. now trivial.
-      now apply (FrameBase (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
-    + destruct p.
-      * simpl.
-        set (h := mkCohReflAboveBelowPainting deps extraDeps 0 r leR_O Hr d c).
-        unfold mkReflLayerAbove, mkReflPaintingBelow in h; simpl in h.
-        rewrite <- h; clear h.
-        destruct d.
-        enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
-        now apply (mkFrame (mkDepsRestr (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1))).(UIP).
-      * now exact (mkCohReflAboveBelowPainting deps extraDeps 0 r leR_O Hr d c).
+    + now exact (mkCohReflAboveBelowLayer0 deps r Hr d c).
+    + now exact (mkCohReflAboveBelowPainting deps extraDeps 0 r leR_O Hr d c).
   - destruct r; [now contradiction |].
     destruct extraDeps; [now contradiction |].
     destruct c as [l c].

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1256,23 +1256,24 @@ Fixpoint mkCohReflRestrPaintingAboveSup {p k}
     (mkExtraDepsReflCohs2 deps extraDeps).
 Proof.
   intros q r Hq Hr ε d [l c].
-  destruct q.
+  destruct r.
   - destruct extraDeps.
-    + destruct r; try contradiction.
-      simpl.
-      destruct deps as [deps2 extraDeps2 extraDepsRefl2 ? ? ?].
-      destruct (match_TopReflCoh2Dep extraDepsRefl2) as [L' ->].
+    + destruct deps as [deps2 extraDeps2 extraDepsRefl2 ? ? ?].
       destruct (match_TopCoh2Dep extraDeps2) as [E ->].
-      destruct deps2 as [depsReflCohs ? ? ?].
-      destruct depsReflCohs as [depsCohs2 ? ? ? ? ? ?].
-      destruct depsCohs2 as [depsCohs extraDepsCohs ?].
-      destruct (match_TopCohDep extraDepsCohs) as [E' ->].
       now trivial.
-    + admit.
-  - destruct p; try contradiction.
-    destruct d as [d l'].
-    admit.
-Admitted.
+    + now trivial.
+  - destruct extraDeps; try contradiction.
+    destruct c as [l' c].
+    set (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps))).
+    replace
+      (fun x => (mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))) x).(Dom)) with
+      (fun x => {a &T Q (x; a)}) by reflexivity.
+    unshelve eapply (eq_existT_curried_dep (Q := Q)).
+    + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c
+        (mkCohReflRestrFramesAboveSup deps.(1))).
+    + now exact (mkCohReflRestrPaintingAboveSup p.+1 k deps extraDeps
+        q.+1 r (⇑ Hq) Hr ε (d; l) (l'; c)).
+Defined.
 
 Fixpoint mkCohReflRestrPaintingsAboveSup {p k}
   (deps: DepsReflCohs3 p k)

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -2412,11 +2412,11 @@ Class νDgnSet p (C: νSet p) := {
 
 Definition mkDgnPrefix p {C: νSet p} {D: νDgnSet p C}
   (X: (mkνSet (mkνSet C)).(prefix)): Type :=
-  { L: D.(dgnPrefix) X.1 &T
+  { R: D.(dgnPrefix) X.1 &T
     { dgnL: dgnHasReflFromData
-        (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 L) &T
+        (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 R) &T
       dgnCohLFromData
-        (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 L) dgnL } }.
+        (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 R) dgnL } }.
 
 #[local]
 Definition mkνSetData0: νSetData 0 :=
@@ -2484,18 +2484,18 @@ Fixpoint νDgnSetAt n: νDgnSet n (νSetAt n) :=
 CoInductive νDgnSetFrom n
   (X: (νSetAt n).(prefix))
   (M: νSetFrom n X)
-  (L: (νDgnSetAt n).(dgnPrefix) (X; this n X M)): Type := dcons {
-  dgn: dgnHasReflFromData
+  (R: (νDgnSetAt n).(dgnPrefix) (X; this n X M)): Type := dcons {
+  dgnL: dgnHasReflFromData
     ((νSetAt n).(data) X)
     (this n X M)
     (this n.+1 (X; this n X M) (next n X M))
-    ((νDgnSetAt n).(dgnData) (X; this n X M) L);
+    ((νDgnSetAt n).(dgnData) (X; this n X M) R);
   dgnCohL: dgnCohLFromData
     ((νSetAt n).(data) X)
     (this n X M)
     (this n.+1 (X; this n X M) (next n X M))
-    ((νDgnSetAt n).(dgnData) (X; this n X M) L) dgn;
-  dgnNext: νDgnSetFrom n.+1 (X; this n X M) (next n X M) (L; (dgn; dgnCohL));
+    ((νDgnSetAt n).(dgnData) (X; this n X M) R) dgnL;
+  dgnNext: νDgnSetFrom n.+1 (X; this n X M) (next n X M) (R; (dgnL; dgnCohL));
 }.
 
 Definition νDgnSets (X: νSets) := νDgnSetFrom 0 tt X tt.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -56,7 +56,7 @@ Class DepsReflBelow p k := {
 Instance proj1DepsReflBelow {p k}
   (deps: DepsReflBelow p.+1 k): DepsReflBelow p k.+1 :=
 {|
-  _depsRestr := proj1DepsRestr (deps.(_depsRestr));
+  _depsRestr := deps.(_depsRestr).(1);
   _reflFramesBelow := deps.(_reflFramesBelow).1;
 |}.
 
@@ -783,23 +783,23 @@ Fixpoint mkIdReflRestrPaintingsBelow {p k}:
        mkIdReflRestrPaintingBelow deps extraDeps)
   end.
 
-Definition mkCohReflReflFrameBelowType {p k}
+Definition mkCohReflBelowBelowFrameType {p k}
   (deps: DepsReflCohsInf p.+1 k): Type :=
   forall q r (Hq: q <= r) (Hr: r <= k) (d: FramePrev (RestrOfReflCohsInf deps)),
   (mkReflFrameBelow deps.(1) q (Hq ↕ ↑ Hr) (deps.(_reflFramesBelow').2 r Hr d)) =
   (mkReflFrameBelow deps.(1) r.+1 (⇑ Hr) (deps.(_reflFramesBelow').2 q (Hq ↕ Hr) d)).
 
-Fixpoint mkCohReflReflFrameBelowTypes {p}:
+Fixpoint mkCohReflBelowBelowFrameTypes {p}:
   forall {k} (deps: DepsReflCohsInf p k), Type :=
   match p with
   | 0 => fun _ _ => unit
   | S p =>
     fun k deps =>
-    { _: mkCohReflReflFrameBelowTypes deps.(1) &T
-      mkCohReflReflFrameBelowType deps }
+    { _: mkCohReflBelowBelowFrameTypes deps.(1) &T
+      mkCohReflBelowBelowFrameType deps }
   end.
 
-Definition mkCohReflReflFrameAboveType {p k}
+Definition mkCohReflAboveBelowFrameType {p k}
   (deps: DepsReflCohsSup p.+1 k): Type :=
   forall q r (Hq: q <= p) (Hr: r <= k)
     (d: FramePrev (RestrOfReflCohsSup deps))
@@ -810,64 +810,80 @@ Definition mkCohReflReflFrameAboveType {p k}
   mkReflFrameBelow deps.(_depsReflCohsInf) r Hr
     (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q Hq d c).
 
-Fixpoint mkCohReflReflFrameAboveTypes {p}:
+Fixpoint mkCohReflAboveBelowFrameTypes {p}:
   forall {k} (deps: DepsReflCohsSup p k), Type :=
   match p with
   | 0 => fun _ _ => unit
   | S p =>
     fun k deps =>
-    { _: mkCohReflReflFrameAboveTypes deps.(1) &T
-      mkCohReflReflFrameAboveType deps }
+    { _: mkCohReflAboveBelowFrameTypes deps.(1) &T
+      mkCohReflAboveBelowFrameType deps }
   end.
 
-Definition mkCohReflReflPaintingBelowType {p k}
+Definition mkCohReflAboveAboveFrameType {p k}
+  (deps: DepsReflCohsSup p.+1 k): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= p)
+    (d: FramePrev (RestrOfReflCohsSup deps))
+    (c: PaintingPrev (RestrOfReflCohsSup deps) d),
+  mkReflFrameAbove deps q (Hq ↕ (↑ Hr))
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 r Hr d c)
+    (deps.(_reflPaintingsAbove).2 r Hr d c) =
+  mkReflFrameAbove deps r.+1 (⇑ Hr)
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q (Hq ↕ Hr) d c)
+    (deps.(_reflPaintingsAbove).2 q (Hq ↕ Hr) d c).
+
+Fixpoint mkCohReflAboveAboveFrameTypes {p}:
+  forall {k} (deps: DepsReflCohsSup p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkCohReflAboveAboveFrameTypes deps.(1) &T
+      mkCohReflAboveAboveFrameType deps }
+  end.
+
+Definition mkCohReflBelowBelowPaintingType {p k}
   (deps: DepsReflCohsSup p.+1 k)
   (extraDeps: DepsReflCohsSupExtension p.+1 k deps)
-  (cohReflReflFramesBelow:
-    mkCohReflReflFrameBelowTypes deps.(_depsReflCohsInf)): Type :=
+  (cohReflBelowBelowFrames:
+    mkCohReflBelowBelowFrameTypes deps.(_depsReflCohsInf)): Type :=
   forall q r (Hq: q <= r) (Hr: r <= k)
     (d: FramePrev (RestrOfReflCohsInf deps.(_depsReflCohsInf)))
     (c: PaintingPrev (RestrOfReflCohsInf deps.(_depsReflCohsInf)) d),
   rew [PaintingBase
     (mkDepsRestr (CohsOfReflCohsInf deps.(_depsReflCohsInf).(1)))
     (mkExtraDeps (CohsExtOfReflCohsInf deps.(_depsReflCohsInf).(1)))]
-    cohReflReflFramesBelow.2 q r Hq Hr d in
-  mkReflPaintingBelow
-    deps.(1)%depsreflcohssup
-    (deps; extraDeps)
-    q (Hq ↕ ↑ Hr)
+    cohReflBelowBelowFrames.2 q r Hq Hr d in
+  mkReflPaintingBelow deps.(1) (deps; extraDeps) q (Hq ↕ ↑ Hr)
     (deps.(_depsReflCohsInf).(_reflFramesBelow').2 r Hr d)
     (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 r Hr d c) =
-  mkReflPaintingBelow
-    deps.(1)%depsreflcohssup
-    (deps; extraDeps)
-    r.+1 (⇑ Hr)
+  mkReflPaintingBelow deps.(1) (deps; extraDeps) r.+1 (⇑ Hr)
     (deps.(_depsReflCohsInf).(_reflFramesBelow').2 q (Hq ↕ Hr) d)
     (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 q (Hq ↕ Hr) d c).
 
-Fixpoint mkCohReflReflPaintingBelowTypes {p}:
+Fixpoint mkCohReflBelowBelowPaintingTypes {p}:
   forall {k}
     (deps: DepsReflCohsSup p k)
     (extraDeps: DepsReflCohsSupExtension p k deps)
-    (cohReflReflFramesBelow:
-      mkCohReflReflFrameBelowTypes deps.(_depsReflCohsInf)), Type :=
+    (cohReflBelowBelowFrames:
+      mkCohReflBelowBelowFrameTypes deps.(_depsReflCohsInf)), Type :=
   match p with
   | 0 => fun _ _ _ _ => unit
   | S p =>
-    fun k deps extraDeps cohReflReflFramesBelow =>
-    { _: mkCohReflReflPaintingBelowTypes deps.(1) (deps; extraDeps)
-        cohReflReflFramesBelow.1 &T
-      mkCohReflReflPaintingBelowType deps extraDeps cohReflReflFramesBelow }
+    fun k deps extraDeps cohReflBelowBelowFrames =>
+    { _: mkCohReflBelowBelowPaintingTypes deps.(1) (deps; extraDeps)
+        cohReflBelowBelowFrames.1 &T
+      mkCohReflBelowBelowPaintingType deps extraDeps cohReflBelowBelowFrames }
   end.
 
-Definition mkCohReflReflPaintingAboveType {p k}
+Definition mkCohReflAboveBelowPaintingType {p k}
   (deps: DepsReflCohsSup p.+1 k)
   (extraDeps: DepsReflCohsSupExtension p.+1 k deps)
-  (cohReflReflFramesAbove: mkCohReflReflFrameAboveTypes deps): Type :=
+  (cohReflAboveBelowFrames: mkCohReflAboveBelowFrameTypes deps): Type :=
   forall q r (Hq: q <= p) (Hr: r <= k)
     (d: FramePrev (RestrOfReflCohsSup deps))
     (c: PaintingPrev (RestrOfReflCohsSup deps) d),
-  rew [mkPainting _] cohReflReflFramesAbove.2 q r Hq Hr d c in
+  rew [mkPainting _] cohReflAboveBelowFrames.2 q r Hq Hr d c in
   mkReflPaintingAbove deps.(1) (deps; extraDeps) q Hq
     (deps.(_depsReflCohsInf).(_reflFramesBelow').2 r Hr d)
     (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 r Hr d c) =
@@ -875,18 +891,47 @@ Definition mkCohReflReflPaintingAboveType {p k}
     (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q Hq d c)
     (deps.(_reflPaintingsAbove).2 q Hq d c).
 
-Fixpoint mkCohReflReflPaintingAboveTypes {p}:
+Fixpoint mkCohReflAboveBelowPaintingTypes {p}:
   forall {k}
     (deps: DepsReflCohsSup p k)
     (extraDeps: DepsReflCohsSupExtension p k deps)
-    (cohReflReflFramesAbove : mkCohReflReflFrameAboveTypes deps), Type :=
+    (cohReflAboveBelowFrames: mkCohReflAboveBelowFrameTypes deps), Type :=
   match p with
   | 0 => fun _ _ _ _ => unit
   | S p =>
-    fun k deps extraDeps cohReflReflFramesAbove =>
-    { _: mkCohReflReflPaintingAboveTypes deps.(1) (deps; extraDeps)
-        cohReflReflFramesAbove.1 &T
-      mkCohReflReflPaintingAboveType deps extraDeps cohReflReflFramesAbove }
+    fun k deps extraDeps cohReflAboveBelowFrames =>
+    { _: mkCohReflAboveBelowPaintingTypes deps.(1) (deps; extraDeps)
+        cohReflAboveBelowFrames.1 &T
+      mkCohReflAboveBelowPaintingType deps extraDeps cohReflAboveBelowFrames }
+  end.
+
+Definition mkCohReflAboveAbovePaintingType {p k}
+  (deps: DepsReflCohsSup p.+1 k)
+  (extraDeps: DepsReflCohsSupExtension p.+1 k deps)
+  (cohReflAboveAboveFrames: mkCohReflAboveAboveFrameTypes deps): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= p)
+    (d: FramePrev (RestrOfReflCohsSup deps))
+    (c: PaintingPrev (RestrOfReflCohsSup deps) d),
+  rew [mkPainting _] cohReflAboveAboveFrames.2 q r Hq Hr d c in
+  mkReflPaintingAbove deps extraDeps q (Hq ↕ ↑ Hr)
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 r Hr d c)
+    (deps.(_reflPaintingsAbove).2 r Hr d c) =
+  mkReflPaintingAbove deps extraDeps r.+1 (⇑ Hr)
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q (Hq ↕ Hr) d c)
+    (deps.(_reflPaintingsAbove).2 q (Hq ↕ Hr) d c).
+
+Fixpoint mkCohReflAboveAbovePaintingTypes {p}:
+  forall {k}
+    (deps: DepsReflCohsSup p k)
+    (extraDeps: DepsReflCohsSupExtension p k deps)
+    (cohReflAboveAboveFrames: mkCohReflAboveAboveFrameTypes deps), Type :=
+  match p with
+  | 0 => fun _ _ _ _ => unit
+  | S p =>
+    fun k deps extraDeps cohReflAboveAboveFrames =>
+    { _: mkCohReflAboveAbovePaintingTypes deps.(1) (deps; extraDeps)
+        cohReflAboveAboveFrames.1 &T
+      mkCohReflAboveAbovePaintingType deps extraDeps cohReflAboveAboveFrames }
   end.
 
 Class DepsReflCohs2 p k := {
@@ -899,16 +944,21 @@ Class DepsReflCohs2 p k := {
     mkCohReflRestrPaintingBelowSupTypes _depsReflCohsSup _extraDepsReflCohsSup;
   _cohReflRestrPaintingsAboveSup:
     mkCohReflRestrPaintingAboveSupTypes _depsReflCohsSup _extraDepsReflCohsSup;
-  _cohReflReflFramesBelow:
-    mkCohReflReflFrameBelowTypes _depsReflCohsSup.(_depsReflCohsInf);
-  _cohReflReflPaintingsBelow:
-    mkCohReflReflPaintingBelowTypes
-      _depsReflCohsSup _extraDepsReflCohsSup _cohReflReflFramesBelow;
-  _cohReflReflFramesAbove:
-    mkCohReflReflFrameAboveTypes _depsReflCohsSup;
-  _cohReflReflPaintingsAbove:
-    mkCohReflReflPaintingAboveTypes
-      _depsReflCohsSup _extraDepsReflCohsSup _cohReflReflFramesAbove;
+  _cohReflBelowBelowFrames:
+    mkCohReflBelowBelowFrameTypes _depsReflCohsSup.(_depsReflCohsInf);
+  _cohReflBelowBelowPaintings:
+    mkCohReflBelowBelowPaintingTypes
+      _depsReflCohsSup _extraDepsReflCohsSup _cohReflBelowBelowFrames;
+  _cohReflAboveBelowFrames:
+    mkCohReflAboveBelowFrameTypes _depsReflCohsSup;
+  _cohReflAboveBelowPaintings:
+    mkCohReflAboveBelowPaintingTypes
+      _depsReflCohsSup _extraDepsReflCohsSup _cohReflAboveBelowFrames;
+  _cohReflAboveAboveFrames:
+    mkCohReflAboveAboveFrameTypes _depsReflCohsSup;
+  _cohReflAboveAbovePaintings:
+    mkCohReflAboveAbovePaintingTypes
+      _depsReflCohsSup _extraDepsReflCohsSup _cohReflAboveAboveFrames;
 }.
 
 #[local]
@@ -926,14 +976,18 @@ DepsReflCohs2 p k.+1 :=
     depsCohs2.(_cohReflRestrPaintingsBelowSup).1;
   _cohReflRestrPaintingsAboveSup :=
     depsCohs2.(_cohReflRestrPaintingsAboveSup).1;
-  _cohReflReflFramesBelow :=
-    depsCohs2.(_cohReflReflFramesBelow).1;
-  _cohReflReflPaintingsBelow :=
-    depsCohs2.(_cohReflReflPaintingsBelow).1;
-  _cohReflReflFramesAbove :=
-    depsCohs2.(_cohReflReflFramesAbove).1;
-  _cohReflReflPaintingsAbove :=
-    depsCohs2.(_cohReflReflPaintingsAbove).1;
+  _cohReflBelowBelowFrames :=
+    depsCohs2.(_cohReflBelowBelowFrames).1;
+  _cohReflBelowBelowPaintings :=
+    depsCohs2.(_cohReflBelowBelowPaintings).1;
+  _cohReflAboveBelowFrames :=
+    depsCohs2.(_cohReflAboveBelowFrames).1;
+  _cohReflAboveBelowPaintings :=
+    depsCohs2.(_cohReflAboveBelowPaintings).1;
+  _cohReflAboveAboveFrames :=
+    depsCohs2.(_cohReflAboveAboveFrames).1;
+  _cohReflAboveAbovePaintings :=
+    depsCohs2.(_cohReflAboveAbovePaintings).1;
 |}.
 
 Declare Scope depsreflcohs2_scope.
@@ -1188,7 +1242,7 @@ Proof.
   simpl.
   rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r (⇓ Hq) Hr ε d0 c0).
 
-  eassert (coh_pair_eq : (_;_) = (_;_)).
+  eassert (coh_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     now exact ((CohsOfReflCohs2 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
     now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; c)). }
@@ -1260,14 +1314,14 @@ Proof.
   - now apply mkCohReflRestrFramesAboveSup.
 Defined.
 
-Definition mkCohReflReflLayerBelow {p k}
+Definition mkCohReflBelowBelowLayer {p k}
   (deps: DepsReflCohs2 p.+1 k)
   q r (Hq: q <= r) (Hr: r <= k)
   (d: mkFrame (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))
   (l: mkLayer (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)).(_restrFrames) d)
-  (prevCohReflReflFrames:
-    mkCohReflReflFrameBelowTypes (mkDepsReflCohsInf deps.(1)%depsreflcohs2)):
-  rew [mkLayer _] prevCohReflReflFrames.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) d in
+  (prevCohReflBelowBelowFrames:
+    mkCohReflBelowBelowFrameTypes (mkDepsReflCohsInf deps.(1)%depsreflcohs2)):
+  rew [mkLayer _] prevCohReflBelowBelowFrames.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) d in
   mkReflLayerBelow
     (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))
     (mkDepsReflCohsInf deps).(1).(_reflFramesBelow')
@@ -1302,7 +1356,7 @@ Proof.
   set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))).
   set (deps'' := mkDepsReflCohsInf deps.(1)).
   simpl.
-  rewrite <- (deps.(_cohReflReflPaintingsBelow).2 q r Hq Hr d0 (l θ)).
+  rewrite <- (deps.(_cohReflBelowBelowPaintings).2 q r Hq Hr d0 (l θ)).
   rewrite rew_map with
     (P := fun b => deps'.(1).(_paintings).2 b)
     (f := fun x => deps'.(1).(_restrFrames).2 0 leR_O θ x).
@@ -1318,22 +1372,22 @@ Proof.
   now apply (deps'.(1).(_frames).2.(UIP)).
 Defined.
 
-Fixpoint mkCohReflReflFramesBelow {p k} (deps: DepsReflCohs2 p k):
-  mkCohReflReflFrameBelowTypes (mkDepsReflCohsInf deps).
+Fixpoint mkCohReflBelowBelowFrames {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflBelowBelowFrameTypes (mkDepsReflCohsInf deps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
     now intros q r Hq Hr [].
-  - set (h := mkCohReflReflFramesBelow p k.+1 deps.(1)%depsreflcohs2).
+  - set (h := mkCohReflBelowBelowFrames p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor.
     + now exact h.
     + intros q r Hq Hr [d l].
       unshelve eapply eq_existT_curried.
       * now exact (h.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) d).
-      * now exact (mkCohReflReflLayerBelow deps q r Hq Hr d l h).
+      * now exact (mkCohReflBelowBelowLayer deps q r Hq Hr d l h).
 Defined.
 
-Definition mkCohReflReflLayerAbove {p k}
+Definition mkCohReflAboveBelowLayer {p k}
   (deps: DepsReflCohs2 p.+1 k)
   q r (Hq: q <= p) (Hr: r <= k)
   (d: mkFrame ((RestrOfReflCohs2 deps).(1)))
@@ -1341,9 +1395,9 @@ Definition mkCohReflReflLayerAbove {p k}
     (paintings := (RestrOfReflCohs2 deps).(_paintings))
     (RestrOfReflCohs2 deps).(_restrFrames) d)
   (c: PaintingPrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) (d; l))
-  (prevCohReflReflFrames:
-    mkCohReflReflFrameAboveTypes (mkDepsReflCohsSup deps.(1)%depsreflcohs2)):
-  rew [mkLayer _] prevCohReflReflFrames.2 q r.+1 Hq (⇑ Hr) d (l; c) in
+  (prevCohReflAboveBelowFrames:
+    mkCohReflAboveBelowFrameTypes (mkDepsReflCohsSup deps.(1)%depsreflcohs2)):
+  rew [mkLayer _] prevCohReflAboveBelowFrames.2 q r.+1 Hq (⇑ Hr) d (l; c) in
   mkReflLayerAbove (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf)
     (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove) _
     (mkDepsReflCohsSup deps).(1).(_cohReflRestrFramesAboveSup) q Hq
@@ -1370,7 +1424,7 @@ Proof.
     (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d0;
     (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d0 c0)).
 
-  eassert (coh_below_inf_pair_eq : (_;_) = (_;_)).
+  eassert (coh_below_inf_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact ((ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf).2 r 0 Hr leR_O θ d).
     - now exact (deps.(_cohReflRestrPaintingsBelowInf).2 r 0 Hr leR_O θ d (l; c)). }
@@ -1378,11 +1432,11 @@ Proof.
     (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x.1 x.2)
     coh_below_inf_pair_eq tt).
 
-  rewrite (proj2 (@rew_swap _ _ _ _ (deps.(_cohReflReflFramesAbove).2 q r Hq Hr d0 c0)
+  rewrite (proj2 (@rew_swap _ _ _ _ (deps.(_cohReflAboveBelowFrames).2 q r Hq Hr d0 c0)
     ((mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x0.1 x0.2) _)
-    (deps.(_cohReflReflPaintingsAbove).2 q r Hq Hr d0 c0)).
+    (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr d0 c0)).
 
-  eassert (coh_above_sup_pair_eq : (_;_) = (_;_)).
+  eassert (coh_above_sup_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 Hq leR_O θ d (l; c)).
     - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q 0 Hq leR_O θ d (l; c)). }
@@ -1413,18 +1467,18 @@ Proof.
     (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_frames).2.(UIP)).
 Defined.
 
-Fixpoint mkCohReflReflFramesAbove {p k} (deps: DepsReflCohs2 p k):
-  mkCohReflReflFrameAboveTypes (mkDepsReflCohsSup deps).
+Fixpoint mkCohReflAboveBelowFrames {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflAboveBelowFrameTypes (mkDepsReflCohsSup deps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
     now intros q r Hq Hr [].
-  - set (h := mkCohReflReflFramesAbove p k.+1 deps.(1)%depsreflcohs2).
+  - set (h := mkCohReflAboveBelowFrames p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor. now exact h.
     intros q r Hq Hr [d l] c.
     destruct q.
     + unshelve eapply eq_existT_curried.
-      * now exact ((mkCohReflReflFramesBelow deps).2 0 r leR_O Hr (d; l)).
+      * now exact ((mkCohReflBelowBelowFrames deps).2 0 r leR_O Hr (d; l)).
       * apply functional_extensionality_dep.
         intro θ.
         unfold mkReflLayerBelow.
@@ -1442,24 +1496,154 @@ Proof.
         now apply (deps'.(_frames).2.(UIP)).
     + unshelve eapply eq_existT_curried.
       * now exact (h.2 q r.+1 Hq (⇑ Hr) d (l; c)).
-      * now exact (mkCohReflReflLayerAbove deps q r Hq Hr d l c h).
+      * now exact (mkCohReflAboveBelowLayer deps q r Hq Hr d l c h).
 Defined.
 
-Definition cohReflReflPaintingAboveL {p} (deps: DepsReflCohs2 p 0)
+Definition mkCohReflAboveAboveLayer {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  q r (Hq: q <= r) (Hr: r <= p)
+  (d: mkFrame ((RestrOfReflCohs2 deps).(1)))
+  (l: mkLayer
+    (paintings := (RestrOfReflCohs2 deps).(_paintings))
+    (RestrOfReflCohs2 deps).(_restrFrames) d)
+  (c: PaintingPrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) (d; l))
+  (prevCohReflAboveAboveFrames:
+    mkCohReflAboveAboveFrameTypes (mkDepsReflCohsSup deps.(1)%depsreflcohs2)):
+  rew [mkLayer _] prevCohReflAboveAboveFrames.2 q r Hq Hr d (l; c) in
+  mkReflLayerAbove (mkDepsReflCohsInf deps)
+    (mkDepsReflCohsSup deps).(_reflPaintingsAbove) _
+    (mkDepsReflCohsSup deps).(_cohReflRestrFramesAboveSup) q (Hq ↕ ↑ Hr)
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) (d; l) c).1
+    (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) (d; l) c).2;
+     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) (d; l) c) =
+  mkReflLayerAbove (mkDepsReflCohsInf deps)
+    (mkDepsReflCohsSup deps).(_reflPaintingsAbove) _
+    (mkDepsReflCohsSup deps).(_cohReflRestrFramesAboveSup) r.+1 (⇑ Hr)
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ (Hq ↕ Hr)) (d; l) c).1
+    (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ (Hq ↕ Hr)) (d; l) c).2;
+     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q.+1 (⇑ (Hq ↕ Hr)) (d; l) c).
+Proof.
+  apply functional_extensionality_dep.
+  intro θ.
+  unfold mkReflLayerAbove.
+  rewrite <- map_subst_app.
+
+  set (d0 := (RestrOfReflCohs2 deps).(_restrFrames).2 0 leR_O θ d).
+  set (c0 := (CohsOfReflCohs2 deps).(_restrPaintings).2 0 leR_O θ d (l; c)).
+
+  eassert (coh_above_sup_r_pair_eq: (_;_) = (_;_)).
+  { unshelve eapply eq_existT_curried.
+    - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 r 0 Hr leR_O θ d (l; c)).
+    - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 r 0 Hr leR_O θ d (l; c)). }
+  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
+    (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q (Hq ↕ ↑ Hr) x.1 x.2)
+    coh_above_sup_r_pair_eq tt).
+
+  eassert (coh_above_sup_q_pair_eq: (_;_) = (_;_)).
+  { unshelve eapply eq_existT_curried.
+    - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 (Hq ↕ Hr) leR_O θ d (l; c)).
+    - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q 0 (Hq ↕ Hr) leR_O θ d (l; c)). }
+  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
+    (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) x.1 x.2)
+    coh_above_sup_q_pair_eq tt).
+
+  rewrite (proj2 (@rew_swap _ _ _ _ (deps.(_cohReflAboveAboveFrames).2 q r Hq Hr d0 c0)
+    ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q (Hq ↕ ↑ Hr) _ _) _)
+    (deps.(_cohReflAboveAbovePaintings).2 q r Hq Hr d0 c0)).
+
+  set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps))).
+  set (deps'' := RestrExtOfReflCohsInf (mkDepsReflCohsInf deps)).
+  rewrite rew_map with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+  rewrite rew_map with
+    (P := fun x => mkPainting deps'' x)
+    (f := fun x => (mkDepsReflCohsInf deps).(_reflFramesAbove).2 q (Hq ↕ ↑ Hr) x.1 x.2).
+  rewrite rew_map with
+    (P := fun x => mkPainting deps'' x)
+    (f := fun x => (mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) x.1 x.2).
+  rewrite 4 rew_compose.
+  apply rew_swap with (P := fun x => mkPainting deps'' x).
+  rewrite rew_app_rl. now trivial.
+  now apply (mkFrame (RestrOfReflCohsInf (mkDepsReflCohsInf deps))).(UIP).
+Defined.
+
+Fixpoint mkCohReflAboveAboveFrames {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflAboveAboveFrameTypes (mkDepsReflCohsSup deps).
+Proof.
+  set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps))).
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    intros q r Hq Hr [] c.
+    destruct r; [| now contradiction].
+    destruct q; [| now contradiction].
+    unshelve eapply eq_existT_curried.
+    + now trivial.
+    + apply functional_extensionality_dep; intro θ.
+      cbn.
+      enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
+      now apply (deps'.(_frames).2.(UIP)).
+  - set (h := mkCohReflAboveAboveFrames p k.+1 deps.(1)%depsreflcohs2).
+    unshelve econstructor. now exact h.
+    intros q r Hq Hr d c.
+    destruct q.
+    + unshelve eapply eq_existT_curried.
+      * symmetry.
+        now exact ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c).
+      * apply functional_extensionality_dep; intro θ.
+        unfold mkReflLayerAbove.
+        rewrite <- map_subst_app.
+        eassert (coh_id_pair_eq: (_;_) = (_;_)).
+        { unshelve eapply eq_existT_curried.
+          - now exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
+          - now exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
+              deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
+        unfold mkDepsReflCohsSup, mkReflPaintingsAbove.
+        cbn [_reflPaintingsAbove projT2].
+        rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
+          deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
+          r Hr x.1 x.2) coh_id_pair_eq tt).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2).
+        rewrite 2 rew_compose.
+        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+        rewrite rew_app_rl. now trivial.
+        now apply (deps'.(_frames).2.(UIP)).
+    + destruct r; [now contradiction |].
+      destruct d as [d l].
+      unshelve eapply eq_existT_curried.
+      * now exact (h.2 q r Hq Hr d (l; c)).
+      * now exact (mkCohReflAboveAboveLayer deps q r (⇓ Hq) (⇓ Hr) d l c h).
+Defined.
+
+Definition cohReflAboveAboveL {p} (deps: DepsReflCohs2 p 0)
   (L: HasRefl
     (mkDepsReflCohsSup deps)
     (mkPainting (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps))))): Type :=
-  mkCohReflReflPaintingAboveType
+  mkCohReflAboveAbovePaintingType
     (mkDepsReflCohsSup deps)
     (TopReflCohSupDep L)
-    (mkCohReflReflFramesAbove deps).
+    (mkCohReflAboveAboveFrames deps).
+
+(*
+  L q (Hq ↕ ↑ Hr)
+    ((mkReflFramesAbove _depsReflCohsSup).2 r Hr d c)
+    (L' r Hr d c) =
+  L r.+1 (⇑ Hr)
+    ((mkReflFramesAbove _depsReflCohsSup).2 q (Hq ↕ Hr) d c)
+    (L' q (Hq ↕ Hr) d c)
+*)
 
 Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
 | TopReflCoh2Dep {deps: DepsReflCohs2 p 0}
   (L: HasRefl
     (mkDepsReflCohsSup deps)
     (mkPainting (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps)))))
-  (cohL: cohReflReflPaintingAboveL deps L):
+  (cohL: cohReflAboveAboveL deps L):
   DepsReflCohs2Extension p 0 deps
 | AddReflCoh2Dep {k} (deps: DepsReflCohs2 p.+1 k):
   DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1)%depsreflcohs2.
@@ -1583,7 +1767,7 @@ Proof.
     + destruct p.
       * rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
         destruct d.
-        enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
+        enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
         now apply (mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
       * now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
   - destruct r; [now contradiction |].
@@ -1612,84 +1796,130 @@ Proof.
     + now apply mkCohReflRestrPaintingBelowSup.
 Defined.
 
-Fixpoint mkCohReflReflPaintingAbove {p k} (deps: DepsReflCohs2 p k)
+Fixpoint mkCohReflAboveAbovePainting {p k} (deps: DepsReflCohs2 p k)
   (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflReflPaintingAboveType
+  mkCohReflAboveAbovePaintingType
     (mkDepsReflCohsSup deps)
     (mkExtraDepsReflCohsSup deps extraDeps)
-    (mkCohReflReflFramesAbove deps).
+    (mkCohReflAboveAboveFrames deps).
 Proof.
   intros q r Hq Hr d c.
   destruct extraDeps.
-  now apply cohL.
-  destruct r.
+  - now apply cohL.
   - destruct c as [l c].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting
-      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)))))).
+      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps))))).
+    + now exact (mkCohReflAboveAboveLayer deps q r Hq Hr d l c
+        (mkCohReflAboveAboveFrames deps.(1)%depsreflcohs2)).
+    + now exact (mkCohReflAboveAbovePainting p.+1 k deps extraDeps
+        q.+1 r.+1 (⇑ Hq) (⇑ Hr) (d; l) c).
+Defined.
+
+Fixpoint mkCohReflAboveAbovePaintings {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflAboveAbovePaintingTypes
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps)
+    (mkCohReflAboveAboveFrames deps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflAboveAbovePainting.
+  - unshelve econstructor.
+    + now exact (mkCohReflAboveAbovePaintings p k.+1
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
+    + now apply mkCohReflAboveAbovePainting.
+Defined.
+
+Fixpoint mkCohReflAboveBelowPainting {p k} (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflAboveBelowPaintingType
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps)
+    (mkCohReflAboveBelowFrames deps).
+Proof.
+  intros q r Hq Hr d c.
+  destruct r.
+  - unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps))))).
     + apply functional_extensionality_dep; intro θ.
       unfold mkReflLayerAbove, mkReflPaintingBelow1.
       rewrite <- map_subst_app.
-      set (deps' := mkExtraDeps (CohsExtOfReflCohs2 deps.(1))).
+      set (deps' := mkExtraDeps (CohsExtOfReflCohs2 deps)).
       apply rew_swap with (P := fun b => mkPainting deps' b).
       rewrite rew_map with
         (P := fun b => mkPainting deps' b)
         (f := fun x => (mkDepsRestr (CohsOfReflCohsInf
-          (mkDepsReflCohsSup deps.(1)).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
+          (mkDepsReflCohsSup deps).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
       rewrite 2 rew_compose.
-      eassert (id_pair_eq : (_;_) = (_;_)).
-      { unshelve eapply eq_existT_curried.
-        - exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps.(1)) 0 leR_O θ d).
-        - exact (mkIdReflRestrPaintingBelow deps.(1).(_depsReflCohsSup)
-            deps.(1).(_extraDepsReflCohsSup) 0 leR_O θ d (l; c)). }
       unfold mkDepsReflCohsSup, mkReflPaintingsAbove.
       cbn [_reflPaintingsAbove projT2].
+      eassert (coh_id_pair_eq: (_;_) = (_;_)).
+      { unshelve eapply eq_existT_curried.
+        - exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
+        - exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
+            deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
       rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
-        deps.(1).(_depsReflCohsSup) deps.(1).(_extraDepsReflCohsSup)
-        q Hq x.1 x.2) id_pair_eq tt).
+        deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
+        q Hq x.1 x.2) coh_id_pair_eq tt).
       rewrite rew_map with
         (P := fun b => mkPainting deps' b)
-        (f := fun x => (mkReflFramesAbove deps.(1).(_depsReflCohsSup)).2 q Hq x.1 x.2).
+        (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 q Hq x.1 x.2).
       apply rew_swap with (P := fun b => mkPainting deps' b).
       rewrite rew_app_rl. now trivial.
       now apply (mkFrame _).(UIP).
-    + lazymatch goal with
-      | |- rew [?P'] ?H' in ?X = ?Y =>
-        set (P := P'); set (H := H')
-      end.
-      admit.
-  - destruct c as [l c].
-    destruct extraDeps; [now contradiction |].
+    + unfold mkReflPaintingBelow2; cbn [eq_rect].
+      destruct p.
+      * rewrite <- (mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
+        match goal with
+        | |- rew [?P1'] ?H2' in rew [?P2'] ?H1' in ?y = ?x =>
+          set (H2 := H2'); set (H1 := H1')
+        end.
+        rewrite rew_compose.
+        enough (HEq: H1 • H2 = eq_refl) by (now rewrite HEq).
+        now apply (mkFrame (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))).(UIP).
+      * rewrite <- (mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
+        match goal with
+        | |- rew [?P1'] ?H2' in rew [?P2'] ?H1' in ?y = ?x =>
+          set (H2 := H2'); set (H1 := H1')
+        end.
+        rewrite rew_compose.
+        enough (HEq: H1 • H2 = eq_refl) by (now rewrite HEq).
+        now apply (mkFrame (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))).(UIP).
+  - destruct extraDeps; [now contradiction |].
+    destruct c as [l c].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting
       (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)))))).
-    + now exact (mkCohReflReflLayerAbove deps q r Hq Hr d l c
-        (mkCohReflReflFramesAbove deps.(1)%depsreflcohs2)).
-    + now exact (mkCohReflReflPaintingAbove p.+1 k deps extraDeps
+    + now exact (mkCohReflAboveBelowLayer deps q r Hq Hr d l c
+        (mkCohReflAboveBelowFrames deps.(1)%depsreflcohs2)).
+    + now exact (mkCohReflAboveBelowPainting p.+1 k deps extraDeps
         q.+1 r Hq Hr (d; l) c).
-Admitted.
+Defined.
 
-Fixpoint mkCohReflReflPaintingsAbove {p k}
+Fixpoint mkCohReflAboveBelowPaintings {p k}
   (deps: DepsReflCohs2 p k)
   (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflReflPaintingAboveTypes
+  mkCohReflAboveBelowPaintingTypes
     (mkDepsReflCohsSup deps)
     (mkExtraDepsReflCohsSup deps extraDeps)
-    (mkCohReflReflFramesAbove deps).
+    (mkCohReflAboveBelowFrames deps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
-    now apply mkCohReflReflPaintingAbove.
+    now apply mkCohReflAboveBelowPainting.
   - unshelve econstructor.
-    + now exact (mkCohReflReflPaintingsAbove p k.+1
+    + now exact (mkCohReflAboveBelowPaintings p k.+1
         deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
-    + now apply mkCohReflReflPaintingAbove.
+    + now apply mkCohReflAboveBelowPainting.
 Defined.
 
-Fixpoint mkCohReflReflPaintingBelow {p k} (deps: DepsReflCohs2 p k)
+Fixpoint mkCohReflBelowBelowPainting {p k} (deps: DepsReflCohs2 p k)
   (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflReflPaintingBelowType
+  mkCohReflBelowBelowPaintingType
     (mkDepsReflCohsSup deps)
     (mkExtraDepsReflCohsSup deps extraDeps)
-    (mkCohReflReflFramesBelow deps).
+    (mkCohReflBelowBelowFrames deps).
 Proof.
   intros q r Hq Hr d c.
   destruct q.
@@ -1713,39 +1943,39 @@ Proof.
       now apply (FrameBase (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
     + destruct p.
       * simpl.
-        set (h := mkCohReflReflPaintingAbove deps extraDeps 0 r leR_O Hr d c).
+        set (h := mkCohReflAboveBelowPainting deps extraDeps 0 r leR_O Hr d c).
         unfold mkReflLayerAbove, mkReflPaintingBelow in h; simpl in h.
         rewrite <- h; clear h.
         destruct d.
         enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
         now apply (mkFrame (mkDepsRestr (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1))).(UIP).
-      * now exact (mkCohReflReflPaintingAbove deps extraDeps 0 r leR_O Hr d c).
+      * now exact (mkCohReflAboveBelowPainting deps extraDeps 0 r leR_O Hr d c).
   - destruct r; [now contradiction |].
     destruct extraDeps; [now contradiction |].
     destruct c as [l c].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting
       (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)).(1))))).
-    + now exact (mkCohReflReflLayerBelow deps q r Hq Hr d l
-        (mkCohReflReflFramesBelow deps.(1)%depsreflcohs2)).
-    + now exact (mkCohReflReflPaintingBelow p.+1 k deps extraDeps
+    + now exact (mkCohReflBelowBelowLayer deps q r Hq Hr d l
+        (mkCohReflBelowBelowFrames deps.(1)%depsreflcohs2)).
+    + now exact (mkCohReflBelowBelowPainting p.+1 k deps extraDeps
         q r Hq Hr (d; l) c).
 Defined.
 
-Fixpoint mkCohReflReflPaintingsBelow {p k}
+Fixpoint mkCohReflBelowBelowPaintings {p k}
   (deps: DepsReflCohs2 p k)
   (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflReflPaintingBelowTypes
+  mkCohReflBelowBelowPaintingTypes
     (mkDepsReflCohsSup deps)
     (mkExtraDepsReflCohsSup deps extraDeps)
-    (mkCohReflReflFramesBelow deps).
+    (mkCohReflBelowBelowFrames deps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
-    now apply mkCohReflReflPaintingBelow.
+    now apply mkCohReflBelowBelowPainting.
   - unshelve econstructor.
-    + now exact (mkCohReflReflPaintingsBelow p k.+1
+    + now exact (mkCohReflBelowBelowPaintings p k.+1
         deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
-    + now apply mkCohReflReflPaintingBelow.
+    + now apply mkCohReflBelowBelowPainting.
 Defined.
 
 (*

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1088,6 +1088,8 @@ Proof.
   by reflexivity; rewrite h; clear h.
 
   rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r (⇓ Hq) Hr ε d0 c0).
+  Fail rewrite <- ((Cohs2OfReflCohs3 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; (l'; c))).
+
   rewrite rew_map with
     (P := fun b =>
       (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_paintings).2 b)
@@ -1103,6 +1105,13 @@ Proof.
   rewrite 3 rew_compose.
   apply rew_swap with
     (P := fun x => mkPainting (RestrExtOfReflCohs2 deps.(_depsReflCohs2)) x).
+
+  lazymatch goal with
+  | |- ?e2 = rew <- [?P1] ?H1 in rew [?P2] ?H2 in ?e1 => 
+    set (H := H1); set (H' := H2)
+  end.
+
+  unfold d0, c0.
 
   Fail rewrite rew_app_rl.
   admit.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -887,26 +887,8 @@ Proof.
   intros θ.
   unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- map_subst_app, <- !map_subst.
-
-  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ d).
-
-  assert (h :
-    (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2 r (Hr ↕ ↑ Hq) ε
-      (mkReflFrameBelow (ReflCohsInfOfReflCohs2 deps).(1) q.+1 (⇑ Hq) d0)
-      ((mkReflPaintingsBelow
-        deps.(_depsReflCohsSup).(1)%depsreflcohssup
-        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup).2
-          q.+1 (⇑ Hq) d0 (l θ)) =
-    mkRestrPainting (CohsExtOfReflCohsSup deps.(_depsReflCohsSup).(1)) r (Hr ↕ ↑ Hq) ε
-      ((mkDepsReflBelow (ReflCohsInfOfReflCohs2 deps).(1)).(_reflFramesBelow).2
-        q.+1 (⇑ Hq) d0)
-      (mkReflPaintingBelow
-        deps.(_depsReflCohsSup).(1)%depsreflcohssup
-        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
-        q.+1 (⇑ Hq) d0 (l θ)))
-  by reflexivity; rewrite h; clear h.
-
-  rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε d0 (l θ)).
+  simpl.
+  rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε _ (l θ)).
   rewrite rew_map with
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
     (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
@@ -965,8 +947,8 @@ Defined.
 Definition mkCohReflRestrLayerBelowSup {p k}
   (deps: DepsReflCohs2 p.+1 k)
   (ε: arity) q r (Hq: q <= r) (Hr: r <= k)
-  (d: mkFrame ((RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(1)))
-  (l: mkLayer (RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(_restrFrames) d)
+  (d: mkFrame (mkDepsRestr (CohsOfReflCohs2 deps)).(1).(1))
+  (l: mkLayer (mkDepsRestr (CohsOfReflCohs2 deps)).(1).(_restrFrames) d)
   (prevCohReflRestrFrames:
     mkCohReflRestrFrameBelowSupTypes
       (mkDepsReflCohsInf deps.(1)%depsreflcohs2)):
@@ -1018,6 +1000,7 @@ Proof.
   by reflexivity; rewrite h; clear h.
 
   rewrite <- (deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε d0 (l θ)).
+
   rewrite rew_map with
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
     (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
@@ -1095,61 +1078,15 @@ Proof.
   set (c0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
     0 leR_O θ d (l; c)).
 
-  assert (h :
-    (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε
-      ((AboveOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_reflFramesAbove').2
-        q (⇓ Hq) d0 c0)
-      ((mkReflPaintingsAbove
-        deps.(1).(_depsReflCohsSup)
-        deps.(1).(_extraDepsReflCohsSup)).2 q (⇓ Hq) d0 c0) =
-    mkRestrPainting (CohsExtOfReflCohsSup deps.(_depsReflCohsSup))
-      r Hr ε
-      (mkReflFrameAbove deps.(_depsReflCohsSup).(1) q (⇓ Hq) d0 c0)
-      (mkReflPaintingAbove
-        deps.(_depsReflCohsSup).(1)%depsreflcohssup
-        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
-        q (⇓ Hq) d0 c0))
-  by reflexivity; rewrite h; clear h.
-
+  simpl.
   rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r (⇓ Hq) Hr ε d0 c0).
 
-  set (D := { d1 :
-    (Cohs2OfReflCohs2 deps).(_depsCohs).(_deps).(_frames).2 &T
-    (Cohs2OfReflCohs2 deps).(_depsCohs).(_deps).(_paintings).2 d1 }).
-  set (x0 := (
-    (CohsOfReflCohsSup deps.(_depsReflCohsSup)).(_deps).(_restrFrames).2
-      r Hr ε d0;
-    (CohsOfReflCohsSup deps.(_depsReflCohsSup)).(_restrPaintings).2
-      r Hr ε d0 c0) : D).
-  set (xr := (
-    (CohsOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_deps).(_restrFrames).2
-      0 leR_O θ
-      ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
-        r Hr ε (d; l)).1;
-    (CohsOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_restrPaintings).2
-      0 leR_O θ
-      ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
-        r Hr ε (d; l)).1
-      (((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
-          r Hr ε (d; l)).2;
-       (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2
-         r Hr ε (d; l) c)) : D).
-  set (Q := fun x : D =>
-    mkPainting (AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_extraDeps)
-      ((AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_reflFramesAbove').2
-        q (⇓ Hq) x.1 x.2)).
-  assert (pair_eq : x0 = xr).
-  { unfold x0, xr.
-    unshelve eapply eq_existT_curried.
+  eassert (coh_pair_eq : (_;_) = (_;_)).
+  { unshelve eapply eq_existT_curried.
     now exact ((CohsOfReflCohs2 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
     now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; c)). }
-  assert (map_pair_eq :
-    rew [Q] pair_eq in
-      deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) x0.1 x0.2 =
-    deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) xr.1 xr.2).
-  { now exact (map_subst (P := fun _ : D => unit) (Q := Q) (fun x _ =>
-      deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) x.1 x.2) pair_eq tt). }
-  rewrite <- map_pair_eq.
+  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
+    deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) x.1 x.2) coh_pair_eq tt).
 
   rewrite rew_map with
     (P := fun b =>
@@ -1165,7 +1102,7 @@ Proof.
         r Hr ε d1).
   rewrite rew_map with
     (P := fun x => mkPainting (RestrExtOfReflCohsSup deps.(_depsReflCohsSup)) x)
-    (f := fun x : D =>
+    (f := fun x =>
       (AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_reflFramesAbove').2
         q (⇓ Hq) x.1 x.2).
   rewrite 4 rew_compose.
@@ -1289,12 +1226,8 @@ Fixpoint mkCohReflRestrPaintingAboveSup {p k}
 Proof.
   intros q r Hq Hr ε d [l c].
   destruct r.
-  - destruct extraDeps.
-    + destruct deps as [deps2 extraDeps2 extraDepsRefl2 ? ? ?].
-      destruct (match_TopCoh2Dep extraDeps2) as [E ->].
-      now trivial.
-    + now trivial.
-  - destruct extraDeps; try contradiction.
+  - now trivial.
+  - destruct extraDeps; [now contradiction |].
     unshelve eapply (eq_existT_curried_dep
       (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
     + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l c
@@ -1334,7 +1267,7 @@ Proof.
       intro θ.
       unfold mkRestrLayer.
       rewrite <- map_subst_app, <- !map_subst.
-      set (deps' := (mkDepsRestr (Cohs2OfReflCohs2 deps).(_depsCohs))).
+      set (deps' := (mkDepsRestr (CohsOfReflCohs2 deps))).
       rewrite rew_map with
         (P := fun b => deps'.(_paintings).2 b)
         (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
@@ -1351,8 +1284,8 @@ Proof.
         enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
         now apply (mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
       * now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
-  - destruct r; try contradiction.
-    destruct extraDeps; try contradiction.
+  - destruct r; [now contradiction |].
+    destruct extraDeps; [now contradiction |].
     unshelve eapply (eq_existT_curried_dep
       (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1))))).
     + now exact (mkCohReflRestrLayerBelowSup deps ε q r (⇓ Hq) (⇓ Hr) d l
@@ -1393,9 +1326,30 @@ Fixpoint mkCohReflReflFrameBelowTypes {p}:
       mkCohReflReflFrameBelowType deps }
   end.
 
+Definition mkCohReflReflFrameAboveType {p k}
+  (deps: DepsReflCohsSup p.+1 k): Type :=
+  forall q r (Hq: q <= p) (Hr: r <= k)
+    (d: FramePrev (RestrOfReflCohsSup deps))
+    (c: PaintingPrev (RestrOfReflCohsSup deps) d),
+  mkReflFrameAbove deps.(1)%depsreflcohssup q Hq
+    (deps.(_depsReflCohsInf).(_reflFramesBelow').2 r Hr d)
+    (deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 r Hr d c) =
+  mkReflFrameBelow deps.(_depsReflCohsInf) r Hr
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q Hq d c).
+
+Fixpoint mkCohReflReflFrameAboveTypes {p}:
+  forall {k} (deps: DepsReflCohsSup p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkCohReflReflFrameAboveTypes deps.(1) &T
+      mkCohReflReflFrameAboveType deps }
+  end.
+
 Definition mkCohReflReflPaintingBelowType {p k}
   (deps: DepsReflCohs2 p.+1 k)
-  (cohReflReflFramesBelow :
+  (cohReflReflFramesBelow:
     mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps)): Type :=
   forall q r (Hq: q <= r) (Hr: r <= k)
     (d: FramePrev (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)))
@@ -1405,14 +1359,14 @@ Definition mkCohReflReflPaintingBelowType {p k}
     (mkExtraDeps (CohsExtOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))]
     cohReflReflFramesBelow.2 q r Hq Hr d in
   mkReflPaintingBelow
-    deps.(_depsReflCohsSup).(1)%depsreflcohssup
-    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
+    deps.(_depsReflCohsSup).(1)
+    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))
     q (Hq ↕ ↑ Hr)
     ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d)
     ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d c) =
   mkReflPaintingBelow
-    deps.(_depsReflCohsSup).(1)%depsreflcohssup
-    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
+    deps.(_depsReflCohsSup).(1)
+    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))
     r.+1 (⇑ Hr)
     ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q (Hq ↕ Hr) d)
     ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 q (Hq ↕ Hr) d c).

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -811,6 +811,10 @@ Definition Cohs2OfReflCohs3 {p k}
   (depsCohs3: DepsReflCohs3 p k): DepsCohs2 p k :=
   Cohs2OfReflCohs2 depsCohs3.(_depsReflCohs2).
 
+Definition ReflCohsOfReflCohs3 {p k}
+  (depsCohs3: DepsReflCohs3 p k): DepsReflCohs p k :=
+  depsCohs3.(_depsReflCohs2).(_depsReflCohs).
+
 Definition RestrExtOfReflCohs3 {p k}
   (depsCohs3: DepsReflCohs3 p k): DepsRestrExtension p k
     (RestrOfReflCohs3 depsCohs3) :=
@@ -821,99 +825,110 @@ Definition CohsExtOfReflCohs3 {p k}
     (CohsOfReflCohs3 depsCohs3) :=
   CohsExtOfReflCohs2 depsCohs3.(_depsReflCohs2).
 
-(*
-
-Definition mkCohReflRestrLayer {p k}
-  (deps: DepsReflCohs2 p.+1 k)
-  (ε: arity) i (Hi: i <= k)
+Definition mkCohReflRestrLayerBelowInf {p k}
+  (deps: DepsReflCohs3 p.+1 k)
+  (ε: arity) q r (Hq: q <= k) (Hr: r <= q)
   (d: mkFrame (((toDepsReflBelow
-    (mkDepsCohs (Cohs2OfReflCohs2 deps))
-    (mkReflFrames deps.(_depsReflCohs)))).(_deps).(1).(1)))
+    (mkDepsCohs (Cohs2OfReflCohs3 deps))
+    (mkReflFramesBelow (ReflCohsOfReflCohs3 deps)))).(_depsRestr).(1).(1)))
   (l: mkLayer (toDepsReflBelow
-    (mkDepsCohs (Cohs2OfReflCohs2 deps))
-    (mkReflFrames deps.(_depsReflCohs))).(_deps).(1).(_restrFrames) d)
+    (mkDepsCohs (Cohs2OfReflCohs3 deps))
+    (mkReflFramesBelow (ReflCohsOfReflCohs3 deps))).(_depsRestr).(1).(_restrFrames) d)
   (prevCohReflRestrFrames:
-    mkCohReflRestrFrameTypes (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
-      (mkReflFrames deps.(_depsReflCohs).(1))
-      (mkReflPaintings deps.(_depsReflCohs).(1) (deps.(_depsReflCohs); deps.(_extraDepsRefl)))):
-  rew [mkLayer _] prevCohReflRestrFrames.2 i.+1 (⇑ Hi) ε d in
-  mkReflLayer
-      (CohsOfReflCohs2 deps) deps.(_depsReflCohs).(_reflFrameDeps)
-        deps.(_depsReflCohs).(_reflPaintingDeps) _
-        deps.(_depsReflCohs).(_cohReflRestrFrames) _
+    mkCohReflRestrFrameBelowInfTypes
+      (mkDepsCohs (Cohs2OfReflCohs3 deps).(1))
+      (mkReflFramesBelow (ReflCohsOfReflCohs3 deps)).1
+      (mkReflPaintingsBelow
+        deps.(_depsReflCohs2).(1)%depsreflcohs2
+        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2)):
+  rew [mkLayer _] prevCohReflRestrFrames.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) ε d in
+  mkReflLayerBelow
+    (CohsOfReflCohs3 deps)
+    (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')
+    (ReflCohsOfReflCohs3 deps).(_reflPaintingsBelow) _
+    (ReflCohsOfReflCohs3 deps).(_cohReflRestrFramesBelowInf)
+    q Hq _
     (mkRestrLayer
-      (CohsOfReflCohs2 deps).(_restrPaintings)
-      (CohsOfReflCohs2 deps).(_cohs) i Hi ε d l) =
+      (CohsOfReflCohs3 deps).(_restrPaintings)
+      (CohsOfReflCohs3 deps).(_cohs)
+      r (Hr ↕ Hq) ε d l) =
   mkRestrLayer
-      (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings)
-      (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_cohs) i (↑ Hi) ε _
-    (mkReflLayer
-      (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
-        (mkReflFrames deps.(_depsReflCohs).(1))
-        (mkReflPaintings deps.(_depsReflCohs).(1)
-        (deps.(_depsReflCohs); deps.(_extraDepsRefl))) _
-        prevCohReflRestrFrames d l).
+    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_restrPaintings)
+    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_cohs) r (Hr ↕ ↑ Hq) ε _
+    (mkReflLayerBelow
+      (mkDepsCohs (Cohs2OfReflCohs3 deps).(1))
+      (mkReflFramesBelow (ReflCohsOfReflCohs3 deps)).1
+      (mkReflPaintingsBelow
+        deps.(_depsReflCohs2).(1)%depsreflcohs2
+        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2) _
+      prevCohReflRestrFrames
+      q.+1 (⇑ Hq) d l).
 Proof.
   apply functional_extensionality_dep.
   intros θ.
-  unfold mkRestrLayer, mkReflLayer.
+  unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- map_subst_app, <- !map_subst.
 
-  set (d0 := restrFrame 0 leR_O (toDepsReflBelow
-    (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
-    (mkReflFrames deps.(_depsReflCohs).(1))).(_deps) θ d).
+  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs3 deps).(1)) 0 leR_O θ d).
 
   assert (h :
-    (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2 i (↑ Hi) ε
-      (reflFrame (toDepsReflBelow
-        (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
-        (mkReflFrames deps.(_depsReflCohs).(1))) d0)
-      ((mkReflPaintings deps.(_depsReflCohs).(1)
-        (deps.(_depsReflCohs); deps.(_extraDepsRefl))).2 d0 (l θ)) =
-    mkRestrPainting (CohsExtOfReflCohs deps.(_depsReflCohs).(1)) i  (↑ Hi) ε
-      ((mkDepsReflBelow deps.(_depsReflCohs).(1)).(_reflFrames).2 d0)
-      (mkReflPainting deps.(_depsReflCohs).(1)
-         (deps.(_depsReflCohs); deps.(_extraDepsRefl)) d0 (l θ)))
+    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_restrPaintings).2 r (Hr ↕ ↑ Hq) ε
+      (mkReflFrameBelow (ReflCohsOfReflCohs3 deps).(1) q.+1 (⇑ Hq) d0)
+      ((mkReflPaintingsBelow
+        deps.(_depsReflCohs2).(1)%depsreflcohs2
+        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2).2
+          q.+1 (⇑ Hq) d0 (l θ)) =
+    mkRestrPainting (CohsExtOfReflCohs2 deps.(_depsReflCohs2).(1)) r (Hr ↕ ↑ Hq) ε
+      ((mkDepsReflBelow (ReflCohsOfReflCohs3 deps).(1)).(_reflFramesBelow).2
+        q.+1 (⇑ Hq) d0)
+      (mkReflPaintingBelow
+        deps.(_depsReflCohs2).(1)%depsreflcohs2
+        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2
+        q.+1 (⇑ Hq) d0 (l θ)))
   by reflexivity; rewrite h; clear h.
 
-  rewrite <- (deps.(_cohReflRestrPaintings).2 ε i Hi d0 (l θ)).
+  rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε d0 (l θ)).
   rewrite rew_map with
-    (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
-    (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
+    (P := fun b => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_paintings).2 b)
+    (f := fun x => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_restrFrames).2
       0 leR_O θ x).
   rewrite rew_map with
-    (P := fun rf => ReflPaintingBase _ _ rf)
-    (f := fun d0 => reflFrame (toDepsReflBelow _ _) d0).
+    (f := fun d1 =>
+      (toDepsReflBelow
+        (ReflCohsOfReflCohs3 deps).(_depsCohs2).(_depsCohs)
+        (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')).(_reflFramesBelow).2
+        q Hq d1).
   rewrite rew_map with
-    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
+    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(
         _deps).(_paintings).2 b)
-    (f := fun d0 => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
-      _deps).(_restrFrames).2 i (↑ Hi) ε d0).
+    (f := fun d0 => (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(
+      _deps).(_restrFrames).2 r (Hr ↕ ↑ Hq) ε d0).
   rewrite 4 rew_compose.
   apply rew_swap with
-    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
+    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(
       _deps).(_paintings).2 b).
   rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohs2 deps).(1)).(UIP).
+  now apply (mkFrame (RestrOfReflCohs3 deps).(1)).(UIP).
 Defined.
 
-Fixpoint mkCohReflRestrFrames {p k} (deps: DepsReflCohs2 p k):
-  mkCohReflRestrFrameTypes
-    (mkDepsCohs (Cohs2OfReflCohs2 deps))
-    (mkReflFrames deps.(_depsReflCohs))
-    (mkReflPaintings deps.(_depsReflCohs) deps.(_extraDepsRefl)).
+Fixpoint mkCohReflRestrFramesBelowInf {p k} (deps: DepsReflCohs3 p k):
+  mkCohReflRestrFrameBelowInfTypes
+    (mkDepsCohs (Cohs2OfReflCohs3 deps))
+    (mkReflFramesBelow (ReflCohsOfReflCohs3 deps))
+    (mkReflPaintingsBelow deps.(_depsReflCohs2) deps.(_extraDepsReflCohs2)).
 Proof.
   destruct p.
-  - unshelve econstructor. now exact tt. now intros i Hi ε [].
-  - set (h := mkCohReflRestrFrames p k.+1 deps.(1)%depsreflcohs2).
+  - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
+  - set (h := mkCohReflRestrFramesBelowInf p k.+1 deps.(1)%depsreflcohs3).
     unshelve econstructor.
     + now apply h.
-    + intros i Hi ε [l c].
+    + intros q r Hq Hr ε [l c].
       unshelve eapply eq_existT_curried.
-      * now exact (h.2 i.+1 (⇑ Hi) ε l).
-      * now exact (mkCohReflRestrLayer deps ε i Hi l c h).
+      * now exact (h.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) ε l).
+      * now exact (mkCohReflRestrLayerBelowInf deps ε q r Hq Hr l c h).
 Defined.
 
+(*
 Instance mkDepsReflCohs {p k} (deps: DepsReflCohs2 p k): DepsReflCohs p.+1 k.
 Proof.
   unshelve econstructor.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -2509,10 +2509,9 @@ Definition Simplicial := νDgnSetUnit.νDgnSets.
 Definition Cubical := νDgnSetBool.νDgnSets.
 
 Example Simplicial1 :=
-  Eval lazy in (νDgnSetUnit.νDgnSetAt 1).(νDgnSetUnit.dgnPrefix).
+  Eval lazy -[leR] in (νDgnSetUnit.νDgnSetAt 1).(νDgnSetUnit.dgnPrefix).
 
 Example Cubical1 :=
-  Eval lazy in (νDgnSetBool.νDgnSetAt 1).(νDgnSetBool.dgnPrefix).
+  Eval lazy -[leR] in (νDgnSetBool.νDgnSetAt 1).(νDgnSetBool.dgnPrefix).
 
-Print Simplicial1.
 Print Cubical1.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1163,7 +1163,7 @@ Proof.
     intros q r Hq Hr ε [d l] [l' c].
     destruct q.
     + unshelve eapply eq_existT_curried.
-      * exact ((mkCohReflRestrFramesBelowSup deps).2 0 r leR_O Hr ε (d; l)).
+      * now exact ((mkCohReflRestrFramesBelowSup deps).2 0 r leR_O Hr ε (d; l)).
       * apply functional_extensionality_dep.
         intro θ.
         unfold mkRestrLayer.
@@ -1184,82 +1184,79 @@ Proof.
       * now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c h).
 Defined.
 
-(*
-Instance mkDepsReflCohs {p k} (deps: DepsReflCohs2 p k): DepsReflCohs p.+1 k.
+Instance mkDepsReflCohs2 {p k} (deps: DepsReflCohs3 p k): DepsReflCohs2 p.+1 k.
 Proof.
   unshelve econstructor.
-  - unshelve econstructor.
-    + now exact (mkDepsCohs (Cohs2OfReflCohs2 deps)).
-    + now exact (mkExtraCohs deps.(_extraDepsCohs2)).
-    + now apply mkCohPaintings.
-  - now apply mkReflFrames.
-  - now exact (mkReflPaintings _ (deps.(_extraDepsRefl))).
-  - now apply mkIdReflRestrFrames.
-  - now apply mkIdReflRestrPaintings.
-  - now apply mkCohReflRestrFrames.
+  - now exact (mkReflPaintingsAbove _ deps.(_extraDepsReflCohs2)).
+  - now apply mkCohReflRestrFramesBelowSup.
+  - now apply mkCohReflRestrFramesAboveSup.
 Defined.
 
-Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
-| TopReflCohDep2 {deps: DepsReflCohs2 p 0}
+Inductive DepsReflCohs3Extension p: forall k (deps: DepsReflCohs3 p k), Type :=
+| TopReflCoh3Dep {deps: DepsReflCohs3 p 0}
   (L: HasRefl
-    (mkDepsReflCohs deps)
+    (mkDepsReflCohs2 deps)
     (mkPaintings (mkExtraDeps (CohsExtOfReflCohs (mkDepsReflCohs deps)))).2):
-  DepsReflCohs2Extension p 0 deps
-| AddReflCohDep2 {k} (deps: DepsReflCohs2 p.+1 k):
-  DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1)%depsreflcohs2.
+  DepsReflCohs3Extension p 0 deps
+| AddReflCoh3Dep {k} (deps: DepsReflCohs3 p.+1 k):
+  DepsReflCohs3Extension p.+1 k deps -> DepsReflCohs3Extension p k.+1 deps.(1)%depsreflcohs3.
 
-Arguments TopReflCohDep2 {p deps}.
-Arguments AddReflCohDep2 {p k}.
+Arguments TopReflCoh3Dep {p deps}.
+Arguments AddReflCoh3Dep {p k}.
 
-Declare Scope extra_depsreflcohs2_scope.
-Delimit Scope extra_depsreflcohs2_scope with extradepsreflcohs2.
-Bind Scope extra_depsreflcohs2_scope with DepsReflCohs2Extension.
-Notation "( x ; y )" := (AddReflCohDep2 x y)
-  (at level 0, format "( x ; y )"): extra_depsreflcohs2_scope.
+Declare Scope extra_depsreflcohs3_scope.
+Delimit Scope extra_depsreflcohs3_scope with extradepsreflcohs3.
+Bind Scope extra_depsreflcohs3_scope with DepsReflCohs3Extension.
+Notation "( x ; y )" := (AddReflCoh3Dep x y)
+  (at level 0, format "( x ; y )"): extra_depsreflcohs3_scope.
 
-Fixpoint mkExtraReflCohs {p k} (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  DepsReflCohsExtension p.+1 k (mkDepsReflCohs deps).
+Fixpoint mkExtraDepsReflCohs2 {p k} (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  DepsReflCohs2Extension p.+1 k (mkDepsReflCohs2 deps).
 Proof.
   destruct extraDeps.
-  - now apply TopReflCohDep.
-  - apply (AddReflCohDep (mkDepsReflCohs deps)).
-    now exact (mkExtraReflCohs p.+1 k deps extraDeps).
+  - now apply TopReflCoh2Dep.
+  - apply (AddReflCoh2Dep (mkDepsReflCohs2 deps)).
+    now exact (mkExtraDepsReflCohs2 p.+1 k deps extraDeps).
 Defined.
 
-Fixpoint mkCohReflRestrPainting {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingType (mkDepsReflCohs deps)
-    (mkExtraReflCohs deps extraDeps).
+Fixpoint mkCohReflRestrPaintingBelowInf {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingBelowInfType
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
 Proof.
-  intros ε i Hi d [l c].
-  destruct i.
+  intros q r Hq Hr ε d [l c].
+  destruct r.
   - now trivial.
-  - unfold ReflPaintingBase, PaintingBase, toDepsReflBelow; simpl.
-    destruct extraDeps.
-    + now contradiction.
-    + unshelve eapply (eq_existT_curried_dep
-        (Q := mkPainting (RestrExtOfReflCohs (mkDepsReflCohs deps.(1))))).
-      * now apply (mkCohReflRestrLayer deps ε i (⇓ Hi) d l).
-      * now exact (mkCohReflRestrPainting p.+1 k deps extraDeps ε i (⇓ Hi)
-          (d; l) c).
+  - destruct q; [now contradiction |].
+    destruct extraDeps; [now contradiction |].
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
+    + now exact (mkCohReflRestrLayerBelowInf deps ε q r (⇓ Hq) (⇓ Hr) d l
+        (mkCohReflRestrFramesBelowInf deps.(1))).
+    + now exact (mkCohReflRestrPaintingBelowInf p.+1 k deps extraDeps
+        q r Hq Hr ε (d; l) c).
 Defined.
 
-Fixpoint mkCohReflRestrPaintings {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingTypes (mkDepsReflCohs deps)
-    (mkExtraReflCohs deps extraDeps).
+Fixpoint mkCohReflRestrPaintingsBelowInf {p k}
+  (deps: DepsReflCohs3 p k)
+  (extraDeps: DepsReflCohs3Extension p k deps):
+  mkCohReflRestrPaintingBelowInfTypes
+    (mkDepsReflCohs2 deps)
+    (mkExtraDepsReflCohs2 deps extraDeps).
 Proof.
   destruct p.
-  - unshelve econstructor. now exact tt. now apply mkCohReflRestrPainting.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflRestrPaintingBelowInf.
   - unshelve econstructor.
-    + now exact (mkCohReflRestrPaintings p k.+1 deps.(1)%depsreflcohs2
-      (deps; extraDeps)%extradepsreflcohs2).
-    + now apply mkCohReflRestrPainting.
+    + now exact (mkCohReflRestrPaintingsBelowInf p k.+1
+        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
+    + now apply mkCohReflRestrPaintingBelowInf.
 Defined.
 
+(*
 Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=
   toDepsRestr C.(restrFrames).
 

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -206,7 +206,7 @@ Fixpoint mkIdReflRestrPaintingBelowTypes {p}:
         idReflRestrFrames }
   end.
 
-Class DepsReflCohs p k := {
+Class DepsReflCohsInf p k := {
   _depsCohs2: DepsCohs2 p k;
   _reflFramesBelow': mkReflFrameBelowTypes _depsCohs.(_deps);
   _reflFramesAbove: mkReflFrameAboveTypes _depsCohs.(_deps);
@@ -219,7 +219,7 @@ Class DepsReflCohs p k := {
 }.
 
 #[local]
-Instance proj1DepsReflCohs {p k} (depsCohs: DepsReflCohs p.+1 k): DepsReflCohs p k.+1 :=
+Instance proj1DepsReflCohsInf {p k} (depsCohs: DepsReflCohsInf p.+1 k): DepsReflCohsInf p k.+1 :=
 {|
   _depsCohs2 := (depsCohs.(_depsCohs2)).(1);
   _reflFramesBelow' := depsCohs.(_reflFramesBelow').1;
@@ -230,63 +230,63 @@ Instance proj1DepsReflCohs {p k} (depsCohs: DepsReflCohs p.+1 k): DepsReflCohs p
   _cohReflRestrFramesBelowInf := depsCohs.(_cohReflRestrFramesBelowInf).1;
 |}.
 
-Declare Scope depsreflcohs_scope.
-Delimit Scope depsreflcohs_scope with depsreflcohs.
-Bind Scope depsreflcohs_scope with DepsReflCohs.
-Notation "x .(1)" := (proj1DepsReflCohs x%_depsreflcohs)
-  (at level 1, left associativity, format "x .(1)"): depsreflcohs_scope.
+Declare Scope depsreflcohsinf_scope.
+Delimit Scope depsreflcohsinf_scope with depsreflcohsinf.
+Bind Scope depsreflcohsinf_scope with DepsReflCohsInf.
+Notation "x .(1)" := (proj1DepsReflCohsInf x%_depsreflcohsinf)
+  (at level 1, left associativity, format "x .(1)"): depsreflcohsinf_scope.
 
-Definition ReflBelowOfReflCohs {p k}
-  (depsCohs: DepsReflCohs p k): DepsReflBelow p k :=
+Definition ReflBelowOfReflCohsInf {p k}
+  (depsCohs: DepsReflCohsInf p k): DepsReflBelow p k :=
 {|
   _depsRestr := depsCohs.(_depsCohs2).(_depsCohs).(_deps);
   _reflFramesBelow := depsCohs.(_reflFramesBelow');
 |}.
 
-Definition RestrOfReflCohs {p k}
-  (depsCohs: DepsReflCohs p k): DepsRestr p k :=
-  (ReflBelowOfReflCohs depsCohs).(_depsRestr).
+Definition RestrOfReflCohsInf {p k}
+  (depsCohs: DepsReflCohsInf p k): DepsRestr p k :=
+  (ReflBelowOfReflCohsInf depsCohs).(_depsRestr).
 
-Definition CohsOfReflCohs {p k}
-  (depsCohs: DepsReflCohs p k): DepsCohs p k :=
+Definition CohsOfReflCohsInf {p k}
+  (depsCohs: DepsReflCohsInf p k): DepsCohs p k :=
   depsCohs.(_depsCohs2).(_depsCohs).
 
-Definition RestrExtOfReflCohs {p k}
-  (depsCohs: DepsReflCohs p k): DepsRestrExtension p k
-    (RestrOfReflCohs depsCohs) :=
+Definition RestrExtOfReflCohsInf {p k}
+  (depsCohs: DepsReflCohsInf p k): DepsRestrExtension p k
+    (RestrOfReflCohsInf depsCohs) :=
   depsCohs.(_depsCohs2).(_depsCohs).(_extraDeps).
 
-Definition CohsExtOfReflCohs {p k}
-  (depsCohs: DepsReflCohs p k): DepsCohsExtension p k
-    (CohsOfReflCohs depsCohs) :=
+Definition CohsExtOfReflCohsInf {p k}
+  (depsCohs: DepsReflCohsInf p k): DepsCohsExtension p k
+    (CohsOfReflCohsInf depsCohs) :=
   depsCohs.(_depsCohs2).(_extraDepsCohs).
 
-Definition mkReflFramesBelow {p k} (deps: DepsReflCohs p k):
-  mkReflFrameBelowTypes (mkDepsRestr (CohsOfReflCohs deps)) :=
+Definition mkReflFramesBelow {p k} (deps: DepsReflCohsInf p k):
+  mkReflFrameBelowTypes (mkDepsRestr (CohsOfReflCohsInf deps)) :=
   (mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow
     deps.(_depsCohs2).(_depsCohs)
     deps.(_reflFramesBelow')
     deps.(_reflPaintingsBelow)).(ReflFramesBelowDef) deps.(_cohReflRestrFramesBelowInf).
 
-Definition mkReflFrameBelow {p k} (deps: DepsReflCohs p k):
+Definition mkReflFrameBelow {p k} (deps: DepsReflCohsInf p k):
   forall i (Hi: i <= k),
-  FramePrev (mkDepsRestr (CohsOfReflCohs deps)) ->
-  FrameBase (mkDepsRestr (CohsOfReflCohs deps)) :=
+  FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)) ->
+  FrameBase (mkDepsRestr (CohsOfReflCohsInf deps)) :=
   (mkReflFramesBelow deps).2.
 
-Definition mkDepsReflBelow {p k} (deps: DepsReflCohs p k): DepsReflBelow p.+1 k :=
-  {| _depsRestr := mkDepsRestr (CohsOfReflCohs deps);
+Definition mkDepsReflBelow {p k} (deps: DepsReflCohsInf p k): DepsReflBelow p.+1 k :=
+  {| _depsRestr := mkDepsRestr (CohsOfReflCohsInf deps);
      _reflFramesBelow := mkReflFramesBelow deps
   |}.
 
 Definition mkCohReflRestrFrameBelowSupType {p k}
-  (deps: DepsReflCohs p.+1 k): Type :=
-  forall q r (Hq: q <= r) (Hr: r <= k) (ε: arity) (d: FrameBase (RestrOfReflCohs deps)),
-  deps.(_reflFramesBelow').2 q (Hq ↕ Hr) ((RestrOfReflCohs deps).(_restrFrames).2 r Hr ε d) =
+  (deps: DepsReflCohsInf p.+1 k): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= k) (ε: arity) (d: FrameBase (RestrOfReflCohsInf deps)),
+  deps.(_reflFramesBelow').2 q (Hq ↕ Hr) ((RestrOfReflCohsInf deps).(_restrFrames).2 r Hr ε d) =
   mkRestrFrame r.+1 (⇑ Hr) ε (mkReflFrameBelow deps.(1) q (Hq ↕ ↑ Hr) d).
 
 Fixpoint mkCohReflRestrFrameBelowSupTypes {p}:
-  forall {k} (deps: DepsReflCohs p k), Type :=
+  forall {k} (deps: DepsReflCohsInf p k), Type :=
   match p with
   | 0 => fun _ _ => unit
   | S p =>
@@ -296,17 +296,17 @@ Fixpoint mkCohReflRestrFrameBelowSupTypes {p}:
   end.
 
 Definition mkIdReflRestrLayerBelow {p k}
-  (deps: DepsReflCohs p.+1 k)
+  (deps: DepsReflCohsInf p.+1 k)
   i (Hi: i <= k)
   (ε: arity)
-  (d: FrameBase (RestrOfReflCohs deps))
-  (l: mkLayer (RestrOfReflCohs deps).(_restrFrames) d)
+  (d: FrameBase (RestrOfReflCohsInf deps))
+  (l: mkLayer (RestrOfReflCohsInf deps).(_restrFrames) d)
   (prevIdReflRestrFrames: mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps.(1))):
   rew [mkLayer _] prevIdReflRestrFrames.2 i.+1 (⇑ Hi) ε d in
   mkRestrLayer deps.(_depsCohs2).(_depsCohs).(_restrPaintings)
     (deps.(_depsCohs2).(_depsCohs).(_cohs)) i Hi ε _
       (mkReflLayerBelow deps.(_depsCohs2).(_depsCohs)
-        ((ReflBelowOfReflCohs deps).(_reflFramesBelow)) deps.(_reflPaintingsBelow) _
+        ((ReflBelowOfReflCohsInf deps).(_reflFramesBelow)) deps.(_reflPaintingsBelow) _
           deps.(_cohReflRestrFramesBelowInf) i Hi d l) = l.
 Proof.
   apply functional_extensionality_dep.
@@ -314,7 +314,7 @@ Proof.
   unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- (deps.(_idReflRestrPaintingsBelow).2 i Hi ε _ (l θ)).
   rewrite <- map_subst_app, <- map_subst.
-  unfold toDepsReflBelow, PaintingPrev, FramePrev, RestrOfReflCohs, mkFrame; simpl.
+  unfold toDepsReflBelow, PaintingPrev, FramePrev, RestrOfReflCohsInf, mkFrame; simpl.
   set (deps' := deps.(_depsCohs2).(_depsCohs).(_deps)).
   rewrite rew_map with
     (P := fun x => deps'.(_paintings).2 x)
@@ -325,14 +325,14 @@ Proof.
   rewrite 2 rew_compose.
   apply rew_swap with (P := fun x => deps'.(_paintings).2 x).
   rewrite rew_app_rl. now trivial.
-  now apply (RestrOfReflCohs deps).(_frames).2.(UIP).
+  now apply (RestrOfReflCohsInf deps).(_frames).2.(UIP).
 Defined.
 
-Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohs p k):
+Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohsInf p k):
   mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps).
   destruct p.
   - simpl. unshelve econstructor. now exact tt. now intros i Hi ε [].
-  - set (h := mkIdReflRestrFramesBelow p k.+1 deps.(1)%depsreflcohs).
+  - set (h := mkIdReflRestrFramesBelow p k.+1 deps.(1)%depsreflcohsinf).
     unshelve econstructor.
     + now apply h.
     + intros i Hi ε [l c].
@@ -341,7 +341,7 @@ Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohs p k):
       * now exact (mkIdReflRestrLayerBelow deps i Hi ε l c h).
 Defined.
 
-Definition mkIdReflRestrFrameBelow {p k} (deps: DepsReflCohs p k):
+Definition mkIdReflRestrFrameBelow {p k} (deps: DepsReflCohsInf p k):
   mkIdReflRestrFrameBelowType (mkDepsReflBelow deps) :=
   (mkIdReflRestrFramesBelow deps).2.
 
@@ -366,11 +366,11 @@ Bind Scope depsreflabove_scope with DepsReflAbove.
 Notation "x .(1)" := (proj1DepsReflAbove x%depsreflabove)
   (at level 1, left associativity, format "x .(1)"): depsreflabove_scope.
 
-Definition AboveOfReflCohs {p k}
-  (depsCohs: DepsReflCohs p k): DepsReflAbove p k :=
+Definition AboveOfReflCohsInf {p k}
+  (depsCohs: DepsReflCohsInf p k): DepsReflAbove p k :=
 {|
-  _depsRefl := ReflBelowOfReflCohs depsCohs;
-  _extraDeps := RestrExtOfReflCohs depsCohs;
+  _depsRefl := ReflBelowOfReflCohsInf depsCohs;
+  _extraDeps := RestrExtOfReflCohsInf depsCohs;
   _reflFramesAbove' := depsCohs.(_reflFramesAbove);
 |}.
 
@@ -395,47 +395,47 @@ Class CohReflRestrFrameAboveSupTypeBlock {p k} (deps: DepsRestr p k) := {
   ReflFramesAboveDef: CohReflRestrFrameAboveSupTypesDef -> mkReflFrameAboveTypes deps;
 }.
 
-Definition mkCohReflRestrFrameAboveSupTypesStep {p k} (deps: DepsReflCohs p.+1 k)
-  (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohs deps.(1)))): Type :=
+Definition mkCohReflRestrFrameAboveSupTypesStep {p k} (deps: DepsReflCohsInf p.+1 k)
+  (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohsInf deps.(1)))): Type :=
   { Q: prev.(CohReflRestrFrameAboveSupTypesDef) &T
     forall q r (Hq: q <= p) (Hr: r <= k) (ε: arity)
-      (d: FrameBase (RestrOfReflCohs deps))
-      (c: PaintingBase (RestrOfReflCohs deps) (RestrExtOfReflCohs deps) d),
-    deps.(_reflFramesAbove).2 q Hq _ ((CohsOfReflCohs deps).(_restrPaintings).2 r Hr ε d c) =
+      (d: FrameBase (RestrOfReflCohsInf deps))
+      (c: PaintingBase (RestrOfReflCohsInf deps) (RestrExtOfReflCohsInf deps) d),
+    deps.(_reflFramesAbove).2 q Hq _ ((CohsOfReflCohsInf deps).(_restrPaintings).2 r Hr ε d c) =
     mkRestrFrame r Hr ε (((prev.(ReflFramesAboveDef) Q).2) q Hq d c) }.
 
-Definition mkReflLayerAbove {p k} (deps: DepsReflCohs p.+1 k)
-  (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs deps))
-  (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohs deps.(1))))
+Definition mkReflLayerAbove {p k} (deps: DepsReflCohsInf p.+1 k)
+  (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohsInf deps))
+  (prev: CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohsInf deps.(1))))
   (cohFrames: mkCohReflRestrFrameAboveSupTypesStep deps prev)
   i (Hi: i <= p)
-  (d: FrameBase (RestrOfReflCohs deps))
-  (c: PaintingBase (RestrOfReflCohs deps) (RestrExtOfReflCohs deps) d):
+  (d: FrameBase (RestrOfReflCohsInf deps))
+  (c: PaintingBase (RestrOfReflCohsInf deps) (RestrExtOfReflCohsInf deps) d):
   mkLayer
-    (paintings := mkPaintings (RestrExtOfReflCohs deps))
-    (mkDepsRestr (CohsOfReflCohs deps)).(_restrFrames)
+    (paintings := mkPaintings (RestrExtOfReflCohsInf deps))
+    (mkDepsRestr (CohsOfReflCohsInf deps)).(_restrFrames)
     ((prev.(ReflFramesAboveDef) cohFrames.1).2 i Hi d c) :=
   fun ε =>
-    rew [(mkDepsRestr (CohsOfReflCohs deps)).(_paintings).2]
+    rew [(mkDepsRestr (CohsOfReflCohsInf deps)).(_paintings).2]
       cohFrames.2 i 0 Hi leR_O ε d c in
   reflPaintingsAbove.2 i Hi _
-    ((CohsOfReflCohs deps).(_restrPaintings).2 0 leR_O ε d c).
+    ((CohsOfReflCohsInf deps).(_restrPaintings).2 0 leR_O ε d c).
 
 Fixpoint mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove {p k}:
-  forall (deps: DepsReflCohs p k)
-    (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs deps)),
-    CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohs deps)) :=
+  forall (deps: DepsReflCohsInf p k)
+    (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohsInf deps)),
+    CohReflRestrFrameAboveSupTypeBlock (mkDepsRestr (CohsOfReflCohsInf deps)) :=
   match p with
   | 0 => fun deps reflPaintingsAbove =>
     {|
       CohReflRestrFrameAboveSupTypesDef := unit;
       ReflFramesAboveDef _ :=
         let reflFrameAbove i (Hi: i <= 0)
-          (d: FramePrev (mkDepsRestr (CohsOfReflCohs deps)))
-          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs deps)) d) :=
+          (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
+          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsInf deps)) d) :=
           (mkReflFrameBelow deps 0 leR_O d;
             fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c) in
-        ((tt; reflFrameAbove): mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohs deps)))
+        ((tt; reflFrameAbove): mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsInf deps)))
     |}
   | S p => fun deps reflPaintingsAbove =>
     let prev := mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(1)
@@ -445,9 +445,9 @@ Fixpoint mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove {p k}:
       ReflFramesAboveDef Q :=
         let prevReflFrames := prev.(ReflFramesAboveDef) Q.1 in
         let reflFrameAbove i (Hi: i <= p.+1)
-          (d: FramePrev (mkDepsRestr (CohsOfReflCohs deps)))
-          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs deps)) d) :=
-          match i return i <= p.+1 -> mkFrame (mkDepsRestr (CohsOfReflCohs deps)) with
+          (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
+          (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsInf deps)) d) :=
+          match i return i <= p.+1 -> mkFrame (mkDepsRestr (CohsOfReflCohsInf deps)) with
           | 0 => fun _ =>
             (mkReflFrameBelow deps 0 leR_O d;
               fun ε => rew <- mkIdReflRestrFrameBelow deps 0 leR_O ε d in c)
@@ -456,114 +456,114 @@ Fixpoint mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove {p k}:
               mkReflLayerAbove deps reflPaintingsAbove prev Q i (⇓ Hi) d.1 (d.2; c))
           end Hi in
         (prevReflFrames; reflFrameAbove):
-          mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohs deps))
+          mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsInf deps))
     |}
   end.
 
 Definition mkCohReflRestrFrameAboveSupTypes {p k}
-  (deps: DepsReflCohs p k)
-  (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs deps)): Type :=
+  (deps: DepsReflCohsInf p k)
+  (reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohsInf deps)): Type :=
   (mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps
     reflPaintingsAbove).(CohReflRestrFrameAboveSupTypesDef).
 
-Class DepsReflCohs2 p k := {
-  _depsReflCohs: DepsReflCohs p k;
+Class DepsReflCohsSup p k := {
+  _depsReflCohsInf: DepsReflCohsInf p k;
   _cohReflRestrFramesBelowSup:
-    mkCohReflRestrFrameBelowSupTypes _depsReflCohs;
-  _reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs _depsReflCohs);
+    mkCohReflRestrFrameBelowSupTypes _depsReflCohsInf;
+  _reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohsInf _depsReflCohsInf);
   _cohReflRestrFramesAboveSup:
-    mkCohReflRestrFrameAboveSupTypes _depsReflCohs _reflPaintingsAbove;
+    mkCohReflRestrFrameAboveSupTypes _depsReflCohsInf _reflPaintingsAbove;
 }.
 
 #[local]
-Instance proj1DepsReflCohs2 {p k} (depsCohs2: DepsReflCohs2 p.+1 k):
-  DepsReflCohs2 p k.+1 :=
+Instance proj1DepsReflCohsSup {p k} (depsCohsSup: DepsReflCohsSup p.+1 k):
+  DepsReflCohsSup p k.+1 :=
 {|
-  _depsReflCohs := depsCohs2.(_depsReflCohs).(1)%depsreflcohs;
-  _cohReflRestrFramesBelowSup := depsCohs2.(_cohReflRestrFramesBelowSup).1;
-  _reflPaintingsAbove := depsCohs2.(_reflPaintingsAbove).1;
-  _cohReflRestrFramesAboveSup := depsCohs2.(_cohReflRestrFramesAboveSup).1;
+  _depsReflCohsInf := depsCohsSup.(_depsReflCohsInf).(1)%depsreflcohsinf;
+  _cohReflRestrFramesBelowSup := depsCohsSup.(_cohReflRestrFramesBelowSup).1;
+  _reflPaintingsAbove := depsCohsSup.(_reflPaintingsAbove).1;
+  _cohReflRestrFramesAboveSup := depsCohsSup.(_cohReflRestrFramesAboveSup).1;
 |}.
 
-Declare Scope depsreflcohs2_scope.
-Delimit Scope depsreflcohs2_scope with depsreflcohs2.
-Bind Scope depsreflcohs2_scope with DepsReflCohs2.
-Notation "x .(1)" := (proj1DepsReflCohs2 x%depsreflcohs2)
-  (at level 1, left associativity, format "x .(1)"): depsreflcohs2_scope.
+Declare Scope depsreflcohssup_scope.
+Delimit Scope depsreflcohssup_scope with depsreflcohssup.
+Bind Scope depsreflcohssup_scope with DepsReflCohsSup.
+Notation "x .(1)" := (proj1DepsReflCohsSup x%depsreflcohssup)
+  (at level 1, left associativity, format "x .(1)"): depsreflcohssup_scope.
 
-Definition ReflBelowOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsReflBelow p k :=
-  ReflBelowOfReflCohs depsCohs2.(_depsReflCohs).
+Definition ReflBelowOfReflCohsSup {p k}
+  (depsCohsSup: DepsReflCohsSup p k): DepsReflBelow p k :=
+  ReflBelowOfReflCohsInf depsCohsSup.(_depsReflCohsInf).
 
-Definition RestrOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsRestr p k :=
-  RestrOfReflCohs depsCohs2.(_depsReflCohs).
+Definition RestrOfReflCohsSup {p k}
+  (depsCohsSup: DepsReflCohsSup p k): DepsRestr p k :=
+  RestrOfReflCohsInf depsCohsSup.(_depsReflCohsInf).
 
-Definition CohsOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsCohs p k :=
-  CohsOfReflCohs depsCohs2.(_depsReflCohs).
+Definition CohsOfReflCohsSup {p k}
+  (depsCohsSup: DepsReflCohsSup p k): DepsCohs p k :=
+  CohsOfReflCohsInf depsCohsSup.(_depsReflCohsInf).
 
-Definition Cohs2OfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsCohs2 p k :=
- depsCohs2.(_depsReflCohs).(_depsCohs2).
+Definition Cohs2OfReflCohsSup {p k}
+  (depsCohsSup: DepsReflCohsSup p k): DepsCohs2 p k :=
+ depsCohsSup.(_depsReflCohsInf).(_depsCohs2).
 
-Definition RestrExtOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsRestrExtension p k
-    (RestrOfReflCohs2 depsCohs2) :=
-  RestrExtOfReflCohs depsCohs2.(_depsReflCohs).
+Definition RestrExtOfReflCohsSup {p k}
+  (depsCohsSup: DepsReflCohsSup p k): DepsRestrExtension p k
+    (RestrOfReflCohsSup depsCohsSup) :=
+  RestrExtOfReflCohsInf depsCohsSup.(_depsReflCohsInf).
 
-Definition CohsExtOfReflCohs2 {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsCohsExtension p k
-    (CohsOfReflCohs2 depsCohs2) :=
-  CohsExtOfReflCohs depsCohs2.(_depsReflCohs).
+Definition CohsExtOfReflCohsSup {p k}
+  (depsCohsSup: DepsReflCohsSup p k): DepsCohsExtension p k
+    (CohsOfReflCohsSup depsCohsSup) :=
+  CohsExtOfReflCohsInf depsCohsSup.(_depsReflCohsInf).
 
-Definition mkReflFramesAbove {p k} (deps: DepsReflCohs2 p k):
-  mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohs2 deps)) :=
-  (mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(_depsReflCohs)
+Definition mkReflFramesAbove {p k} (deps: DepsReflCohsSup p k):
+  mkReflFrameAboveTypes (mkDepsRestr (CohsOfReflCohsSup deps)) :=
+  (mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove deps.(_depsReflCohsInf)
     deps.(_reflPaintingsAbove)).(ReflFramesAboveDef)
       deps.(_cohReflRestrFramesAboveSup).
 
-Definition mkReflFrameAbove {p k} (deps: DepsReflCohs2 p k):
+Definition mkReflFrameAbove {p k} (deps: DepsReflCohsSup p k):
   forall i (Hi: i <= p)
-    (d: FramePrev (mkDepsRestr (CohsOfReflCohs2 deps)))
-    (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs2 deps)) d),
-  mkFrame (mkDepsRestr (CohsOfReflCohs2 deps)) :=
+    (d: FramePrev (mkDepsRestr (CohsOfReflCohsSup deps)))
+    (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsSup deps)) d),
+  mkFrame (mkDepsRestr (CohsOfReflCohsSup deps)) :=
   (mkReflFramesAbove deps).2.
 
 Definition mkDepsReflAbove {p k}
-  (depsCohs2: DepsReflCohs2 p k): DepsReflAbove p.+1 k :=
+  (depsCohsSup: DepsReflCohsSup p k): DepsReflAbove p.+1 k :=
 {|
-  _depsRefl := mkDepsReflBelow depsCohs2.(_depsReflCohs);
-  _extraDeps := mkExtraDeps (CohsExtOfReflCohs2 depsCohs2);
-  _reflFramesAbove' := mkReflFramesAbove depsCohs2;
+  _depsRefl := mkDepsReflBelow depsCohsSup.(_depsReflCohsInf);
+  _extraDeps := mkExtraDeps (CohsExtOfReflCohsSup depsCohsSup);
+  _reflFramesAbove' := mkReflFramesAbove depsCohsSup;
 |}.
 
-Definition HasRefl {p} (deps: DepsReflCohs2 p 0)
-  (E: mkFrame (mkDepsRestr (CohsOfReflCohs2 deps)) -> HSet): Type :=
+Definition HasRefl {p} (deps: DepsReflCohsSup p 0)
+  (E: mkFrame (mkDepsRestr (CohsOfReflCohsSup deps)) -> HSet): Type :=
   forall i (Hi: i <= p)
-    (d: FramePrev (mkDepsRestr (CohsOfReflCohs2 deps)))
-    (c: PaintingPrev (mkDepsRestr (CohsOfReflCohs2 deps)) d),
+    (d: FramePrev (mkDepsRestr (CohsOfReflCohsSup deps)))
+    (c: PaintingPrev (mkDepsRestr (CohsOfReflCohsSup deps)) d),
   E (mkReflFrameAbove deps i Hi d c).
 
-Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
-| TopReflCoh2Dep {deps: DepsReflCohs2 p 0}
-  (L: HasRefl deps (mkPaintings (mkExtraDeps (CohsExtOfReflCohs2 deps))).2):
-  DepsReflCohs2Extension p 0 deps
-| AddReflCoh2Dep {k} (deps: DepsReflCohs2 p.+1 k):
-  DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1).
+Inductive DepsReflCohsSupExtension p: forall k (deps: DepsReflCohsSup p k), Type :=
+| TopReflCohSupDep {deps: DepsReflCohsSup p 0}
+  (L: HasRefl deps (mkPaintings (mkExtraDeps (CohsExtOfReflCohsSup deps))).2):
+  DepsReflCohsSupExtension p 0 deps
+| AddReflCohSupDep {k} (deps: DepsReflCohsSup p.+1 k):
+  DepsReflCohsSupExtension p.+1 k deps -> DepsReflCohsSupExtension p k.+1 deps.(1).
 
-Arguments TopReflCoh2Dep {p deps}.
-Arguments AddReflCoh2Dep {p k}.
+Arguments TopReflCohSupDep {p deps}.
+Arguments AddReflCohSupDep {p k}.
 
-Declare Scope extra_depsreflcohs2_scope.
-Delimit Scope extra_depsreflcohs2_scope with extradepsreflcohs2.
-Bind Scope extra_depsreflcohs2_scope with DepsReflCohs2Extension.
-Notation "( x ; y )" := (AddReflCoh2Dep x y)
-  (at level 0, format "( x ; y )"): extra_depsreflcohs2_scope.
+Declare Scope extra_depsreflcohssup_scope.
+Delimit Scope extra_depsreflcohssup_scope with extradepsreflcohssup.
+Bind Scope extra_depsreflcohssup_scope with DepsReflCohsSupExtension.
+Notation "( x ; y )" := (AddReflCohSupDep x y)
+  (at level 0, format "( x ; y )"): extra_depsreflcohssup_scope.
 
 Fixpoint mkReflPaintingAbove {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
+  (deps: DepsReflCohsSup p k)
+  (extraDeps: DepsReflCohsSupExtension p k deps):
   mkReflPaintingAboveType (mkDepsReflAbove deps).
 Proof.
   intros i Hi d c.
@@ -576,7 +576,7 @@ Proof.
 Defined.
 
 Fixpoint mkReflPaintingsAbovePrefix {p k}:
-  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  forall (deps: DepsReflCohsSup p k) (extraDeps: DepsReflCohsSupExtension p k deps),
   mkReflPaintingAboveTypes ((mkDepsReflAbove deps).(1)) :=
   match p with
   | 0 => fun _ _ => tt
@@ -587,41 +587,41 @@ Fixpoint mkReflPaintingsAbovePrefix {p k}:
   end.
 
 Definition mkReflPaintingsAbove {p k}:
-  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  forall (deps: DepsReflCohsSup p k) (extraDeps: DepsReflCohsSupExtension p k deps),
   mkReflPaintingAboveTypes (mkDepsReflAbove deps) :=
   fun deps extraDeps =>
     (mkReflPaintingsAbovePrefix deps extraDeps; mkReflPaintingAbove deps extraDeps).
 
 Definition mkReflPaintingBelow1 {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps)
+  (deps: DepsReflCohsSup p k)
+  (extraDeps: DepsReflCohsSupExtension p k deps)
   i (Hi: i <= k)
-  (d: FramePrev (mkDepsReflBelow deps.(_depsReflCohs)).(_depsRestr))
-  (c: PaintingPrev (mkDepsReflBelow deps .(_depsReflCohs)) .(_depsRestr) d) :
+  (d: FramePrev (mkDepsReflBelow deps.(_depsReflCohsInf)).(_depsRestr))
+  (c: PaintingPrev (mkDepsReflBelow deps .(_depsReflCohsInf)) .(_depsRestr) d) :
   (mkLayer
-    (paintings := (mkDepsReflBelow deps .(_depsReflCohs)).(_depsRestr).(_paintings))
-    (mkDepsReflBelow deps .(_depsReflCohs)).(_depsRestr).(_restrFrames)
-    ((mkDepsReflBelow deps .(_depsReflCohs)).(_reflFramesBelow).2 i Hi d)).
+    (paintings := (mkDepsReflBelow deps .(_depsReflCohsInf)).(_depsRestr).(_paintings))
+    (mkDepsReflBelow deps .(_depsReflCohsInf)).(_depsRestr).(_restrFrames)
+    ((mkDepsReflBelow deps .(_depsReflCohsInf)).(_reflFramesBelow).2 i Hi d)).
 Proof.
   destruct i.
   - intros ε.
-    rewrite (mkIdReflRestrFrameBelow deps.(_depsReflCohs) 0 leR_O ε d).
+    rewrite (mkIdReflRestrFrameBelow deps.(_depsReflCohsInf) 0 leR_O ε d).
     now exact c.
   - destruct extraDeps; [now contradiction |].
     destruct c as [l c'].
     now exact (mkReflLayerBelow _ _
-      deps.(_depsReflCohs).(_reflPaintingsBelow) _ _ i Hi d l).
+      deps.(_depsReflCohsInf).(_reflPaintingsBelow) _ _ i Hi d l).
 Defined.
 
 Fixpoint mkReflPaintingBelow2 {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps)
+  (deps: DepsReflCohsSup p k)
+  (extraDeps: DepsReflCohsSupExtension p k deps)
   i (Hi: i <= k)
-  (d: FramePrev (mkDepsReflBelow deps.(_depsReflCohs)).(_depsRestr))
-  (c: PaintingPrev (mkDepsReflBelow deps .(_depsReflCohs)) .(_depsRestr) d)
+  (d: FramePrev (mkDepsReflBelow deps.(_depsReflCohsInf)).(_depsRestr))
+  (c: PaintingPrev (mkDepsReflBelow deps .(_depsReflCohsInf)) .(_depsRestr) d)
   {struct i} :
-  (mkPainting (mkExtraDeps (CohsExtOfReflCohs2 deps))
-    (mkReflFrameBelow deps.(_depsReflCohs) i Hi d;
+  (mkPainting (mkExtraDeps (CohsExtOfReflCohsSup deps))
+    (mkReflFrameBelow deps.(_depsReflCohsInf) i Hi d;
     (mkReflPaintingBelow1 deps extraDeps i Hi d c))).
 Proof.
   destruct i.
@@ -635,11 +635,11 @@ Proof.
 Defined.
 
 Definition mkReflPaintingBelow {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
+  (deps: DepsReflCohsSup p k)
+  (extraDeps: DepsReflCohsSupExtension p k deps):
   mkReflPaintingBelowType
-    (mkDepsReflBelow deps.(_depsReflCohs))
-    (mkExtraDeps (CohsExtOfReflCohs2 deps)).
+    (mkDepsReflBelow deps.(_depsReflCohsInf))
+    (mkExtraDeps (CohsExtOfReflCohsSup deps)).
 Proof.
   intros i Hi d c.
   unshelve econstructor.
@@ -648,11 +648,11 @@ Proof.
 Defined.
 
 Fixpoint mkReflPaintingsBelowPrefix {p k}:
-  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  forall (deps: DepsReflCohsSup p k) (extraDeps: DepsReflCohsSupExtension p k deps),
   mkReflPaintingBelowTypes
-    ((mkDepsReflBelow deps.(_depsReflCohs)).(1))
-    (mkDepsRestr (CohsOfReflCohs2 deps);
-    mkExtraDeps (CohsExtOfReflCohs2 deps)) :=
+    ((mkDepsReflBelow deps.(_depsReflCohsInf)).(1))
+    (mkDepsRestr (CohsOfReflCohsSup deps);
+    mkExtraDeps (CohsExtOfReflCohsSup deps)) :=
   match p with
   | 0 => fun _ _ => tt
   | S p =>
@@ -662,31 +662,31 @@ Fixpoint mkReflPaintingsBelowPrefix {p k}:
   end.
 
 Definition mkReflPaintingsBelow {p k}:
-  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  forall (deps: DepsReflCohsSup p k) (extraDeps: DepsReflCohsSupExtension p k deps),
   mkReflPaintingBelowTypes
-    (mkDepsReflBelow deps.(_depsReflCohs))
-    (mkExtraDeps (CohsExtOfReflCohs2 deps)) :=
+    (mkDepsReflBelow deps.(_depsReflCohsInf))
+    (mkExtraDeps (CohsExtOfReflCohsSup deps)) :=
   fun deps extraDeps =>
     (mkReflPaintingsBelowPrefix deps extraDeps; mkReflPaintingBelow deps extraDeps).
 
 Definition mkCohReflRestrPaintingBelowInfType {p k}
-  (deps: DepsReflCohs2 p.+1 k)
-  (extraDeps: DepsReflCohs2Extension p.+1 k deps): Type :=
+  (deps: DepsReflCohsSup p.+1 k)
+  (extraDeps: DepsReflCohsSupExtension p.+1 k deps): Type :=
   forall q r (Hq: q <= k) (Hr: r <= q) (ε: arity)
-    (d: FrameBase (RestrOfReflCohs2 deps))
-    (c: PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps) d),
-  rew [PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps)]
-  deps.(_depsReflCohs).(_cohReflRestrFramesBelowInf).2 q r Hq Hr ε d in
-  deps.(_depsReflCohs).(_reflPaintingsBelow).2 q Hq
-    ((RestrOfReflCohs2 deps).(_restrFrames).2 r (Hr ↕ Hq) ε d)
-    ((CohsOfReflCohs2 deps).(_restrPaintings).2 r (Hr ↕ Hq) ε d c) =
-  mkRestrPainting (CohsExtOfReflCohs2 deps.(1)) r (Hr ↕ ↑ Hq) ε
-    (mkReflFrameBelow deps.(_depsReflCohs).(1) q.+1 (⇑ Hq) d)
+    (d: FrameBase (RestrOfReflCohsSup deps))
+    (c: PaintingBase (RestrOfReflCohsSup deps) (RestrExtOfReflCohsSup deps) d),
+  rew [PaintingBase (RestrOfReflCohsSup deps) (RestrExtOfReflCohsSup deps)]
+  deps.(_depsReflCohsInf).(_cohReflRestrFramesBelowInf).2 q r Hq Hr ε d in
+  deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 q Hq
+    ((RestrOfReflCohsSup deps).(_restrFrames).2 r (Hr ↕ Hq) ε d)
+    ((CohsOfReflCohsSup deps).(_restrPaintings).2 r (Hr ↕ Hq) ε d c) =
+  mkRestrPainting (CohsExtOfReflCohsSup deps.(1)) r (Hr ↕ ↑ Hq) ε
+    (mkReflFrameBelow deps.(_depsReflCohsInf).(1) q.+1 (⇑ Hq) d)
     (mkReflPaintingBelow deps.(1) (deps; extraDeps) q.+1 (⇑ Hq) d c).
 
 Fixpoint mkCohReflRestrPaintingBelowInfTypes {p}:
-  forall {k} (deps: DepsReflCohs2 p k)
-    (extraDeps: DepsReflCohs2Extension p k deps), Type :=
+  forall {k} (deps: DepsReflCohsSup p k)
+    (extraDeps: DepsReflCohsSupExtension p k deps), Type :=
   match p with
   | 0 => fun _ _ _ => unit
   | S p =>
@@ -696,23 +696,23 @@ Fixpoint mkCohReflRestrPaintingBelowInfTypes {p}:
   end.
 
 Definition mkCohReflRestrPaintingBelowSupType {p k}
-  (deps: DepsReflCohs2 p.+1 k)
-  (extraDeps: DepsReflCohs2Extension p.+1 k deps): Type :=
+  (deps: DepsReflCohsSup p.+1 k)
+  (extraDeps: DepsReflCohsSupExtension p.+1 k deps): Type :=
   forall q r (Hq: q <= r) (Hr: r <= k) (ε: arity)
-    (d: FrameBase (RestrOfReflCohs2 deps))
-    (c: PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps) d),
-  rew [PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps)]
+    (d: FrameBase (RestrOfReflCohsSup deps))
+    (c: PaintingBase (RestrOfReflCohsSup deps) (RestrExtOfReflCohsSup deps) d),
+  rew [PaintingBase (RestrOfReflCohsSup deps) (RestrExtOfReflCohsSup deps)]
     deps.(_cohReflRestrFramesBelowSup).2 q r Hq Hr ε d in
-  deps.(_depsReflCohs).(_reflPaintingsBelow).2 q (Hq ↕ Hr)
-    ((RestrOfReflCohs2 deps).(_restrFrames).2 r Hr ε d)
-    ((CohsOfReflCohs2 deps).(_restrPaintings).2 r Hr ε d c) =
-  mkRestrPainting (CohsExtOfReflCohs2 deps.(1)) r.+1 (⇑ Hr) ε
-    (mkReflFrameBelow deps.(_depsReflCohs).(1) q (Hq ↕ ↑ Hr) d)
+  deps.(_depsReflCohsInf).(_reflPaintingsBelow).2 q (Hq ↕ Hr)
+    ((RestrOfReflCohsSup deps).(_restrFrames).2 r Hr ε d)
+    ((CohsOfReflCohsSup deps).(_restrPaintings).2 r Hr ε d c) =
+  mkRestrPainting (CohsExtOfReflCohsSup deps.(1)) r.+1 (⇑ Hr) ε
+    (mkReflFrameBelow deps.(_depsReflCohsInf).(1) q (Hq ↕ ↑ Hr) d)
     (mkReflPaintingBelow deps.(1) (deps; extraDeps) q (Hq ↕ ↑ Hr) d c).
 
 Fixpoint mkCohReflRestrPaintingBelowSupTypes {p}:
-  forall {k} (deps: DepsReflCohs2 p k)
-    (extraDeps: DepsReflCohs2Extension p k deps),
+  forall {k} (deps: DepsReflCohsSup p k)
+    (extraDeps: DepsReflCohsSupExtension p k deps),
   Type :=
   match p with
   | 0 => fun _ _ _ => unit
@@ -723,23 +723,23 @@ Fixpoint mkCohReflRestrPaintingBelowSupTypes {p}:
   end.
 
 Definition mkCohReflRestrPaintingAboveSupType {p k}
-  (deps: DepsReflCohs2 p.+1 k)
-  (extraDeps: DepsReflCohs2Extension p.+1 k deps): Type :=
+  (deps: DepsReflCohsSup p.+1 k)
+  (extraDeps: DepsReflCohsSupExtension p.+1 k deps): Type :=
   forall q r (Hq: q <= p) (Hr: r <= k) (ε: arity)
-    (d: FrameBase (RestrOfReflCohs2 deps))
-    (c: PaintingBase (RestrOfReflCohs2 deps) (RestrExtOfReflCohs2 deps) d),
-  rew [mkPainting (RestrExtOfReflCohs2 deps)]
+    (d: FrameBase (RestrOfReflCohsSup deps))
+    (c: PaintingBase (RestrOfReflCohsSup deps) (RestrExtOfReflCohsSup deps) d),
+  rew [mkPainting (RestrExtOfReflCohsSup deps)]
     deps.(_cohReflRestrFramesAboveSup).2 q r Hq Hr ε d c in
   deps.(_reflPaintingsAbove).2 q Hq _
-    ((CohsOfReflCohs2 deps).(_restrPaintings).2 r Hr ε d c) =
-  mkRestrPainting (CohsExtOfReflCohs2 deps) r Hr ε
+    ((CohsOfReflCohsSup deps).(_restrPaintings).2 r Hr ε d c) =
+  mkRestrPainting (CohsExtOfReflCohsSup deps) r Hr ε
     (mkReflFrameAbove deps.(1) q Hq d c)
     (mkReflPaintingAbove deps.(1) (deps; extraDeps) q Hq d c).
 
 Fixpoint mkCohReflRestrPaintingAboveSupTypes {p}:
   forall {k}
-    (deps: DepsReflCohs2 p k)
-    (extraDeps: DepsReflCohs2Extension p k deps), Type :=
+    (deps: DepsReflCohsSup p k)
+    (extraDeps: DepsReflCohsSupExtension p k deps), Type :=
   match p with
   | 0 => fun _ _ _ => unit
   | S p =>
@@ -749,31 +749,31 @@ Fixpoint mkCohReflRestrPaintingAboveSupTypes {p}:
   end.
 
 Fixpoint mkIdReflRestrPaintingBelow {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
+  (deps: DepsReflCohsSup p k)
+  (extraDeps: DepsReflCohsSupExtension p k deps):
   mkIdReflRestrPaintingBelowType
-    (mkDepsCohs (Cohs2OfReflCohs2 deps))
-    (mkReflFramesBelow deps.(_depsReflCohs))
+    (mkDepsCohs (Cohs2OfReflCohsSup deps))
+    (mkReflFramesBelow deps.(_depsReflCohsInf))
     (mkReflPaintingsBelow deps extraDeps)
-    (mkIdReflRestrFramesBelow deps.(_depsReflCohs)).
+    (mkIdReflRestrFramesBelow deps.(_depsReflCohsInf)).
 Proof.
   intros i Hi ε d c.
   destruct i.
   - now rewrite rew_compose, eq_trans_sym_inv_l.
   - destruct extraDeps; [now contradiction |].
-    unshelve eapply (eq_existT_curried_dep (Q := mkPainting (RestrExtOfReflCohs2 deps))).
-    + now apply (mkIdReflRestrLayerBelow deps.(_depsReflCohs) i Hi ε).
+    unshelve eapply (eq_existT_curried_dep (Q := mkPainting (RestrExtOfReflCohsSup deps))).
+    + now apply (mkIdReflRestrLayerBelow deps.(_depsReflCohsInf) i Hi ε).
     + destruct c as [l c].
       now exact (mkIdReflRestrPaintingBelow p.+1 k deps extraDeps i (⇓ Hi) ε (d; l) c).
 Defined.
 
 Fixpoint mkIdReflRestrPaintingsBelow {p k}:
-  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  forall (deps: DepsReflCohsSup p k) (extraDeps: DepsReflCohsSupExtension p k deps),
   mkIdReflRestrPaintingBelowTypes
-    (mkDepsCohs (Cohs2OfReflCohs2 deps))
-    (mkReflFramesBelow deps.(_depsReflCohs))
+    (mkDepsCohs (Cohs2OfReflCohsSup deps))
+    (mkReflFramesBelow deps.(_depsReflCohsInf))
     (mkReflPaintingsBelow deps extraDeps)
-    (mkIdReflRestrFramesBelow deps.(_depsReflCohs)) :=
+    (mkIdReflRestrFramesBelow deps.(_depsReflCohsInf)) :=
   match p with
   | 0 => fun deps extraDeps =>
       (tt; mkIdReflRestrPaintingBelow deps extraDeps)
@@ -783,103 +783,103 @@ Fixpoint mkIdReflRestrPaintingsBelow {p k}:
        mkIdReflRestrPaintingBelow deps extraDeps)
   end.
 
-Class DepsReflCohs3 p k := {
-  _depsReflCohs2: DepsReflCohs2 p k;
-  _extraDepsCohs2: DepsCohs2Extension p k (Cohs2OfReflCohs2 _depsReflCohs2);
-  _extraDepsReflCohs2: DepsReflCohs2Extension p k _depsReflCohs2;
+Class DepsReflCohs2 p k := {
+  _depsReflCohsSup: DepsReflCohsSup p k;
+  _extraDepsCohs2: DepsCohs2Extension p k (Cohs2OfReflCohsSup _depsReflCohsSup);
+  _extraDepsReflCohsSup: DepsReflCohsSupExtension p k _depsReflCohsSup;
   _cohReflRestrPaintingsBelowInf:
-    mkCohReflRestrPaintingBelowInfTypes _depsReflCohs2 _extraDepsReflCohs2;
+    mkCohReflRestrPaintingBelowInfTypes _depsReflCohsSup _extraDepsReflCohsSup;
   _cohReflRestrPaintingsBelowSup:
-    mkCohReflRestrPaintingBelowSupTypes _depsReflCohs2 _extraDepsReflCohs2;
+    mkCohReflRestrPaintingBelowSupTypes _depsReflCohsSup _extraDepsReflCohsSup;
   _cohReflRestrPaintingsAboveSup:
-    mkCohReflRestrPaintingAboveSupTypes _depsReflCohs2 _extraDepsReflCohs2;
+    mkCohReflRestrPaintingAboveSupTypes _depsReflCohsSup _extraDepsReflCohsSup;
 }.
 
 #[local]
-Instance proj1DepsReflCohs3 {p k} (depsCohs3: DepsReflCohs3 p.+1 k):
-DepsReflCohs3 p k.+1 :=
+Instance proj1DepsReflCohs2 {p k} (depsCohs2: DepsReflCohs2 p.+1 k):
+DepsReflCohs2 p k.+1 :=
 {|
-  _depsReflCohs2 := depsCohs3.(_depsReflCohs2).(1);
-  _extraDepsCohs2 := (Cohs2OfReflCohs2 depsCohs3.(_depsReflCohs2);
-    depsCohs3.(_extraDepsCohs2));
-  _extraDepsReflCohs2 := (depsCohs3.(_depsReflCohs2);
-    depsCohs3.(_extraDepsReflCohs2));
+  _depsReflCohsSup := depsCohs2.(_depsReflCohsSup).(1);
+  _extraDepsCohs2 := (Cohs2OfReflCohsSup depsCohs2.(_depsReflCohsSup);
+    depsCohs2.(_extraDepsCohs2));
+  _extraDepsReflCohsSup := (depsCohs2.(_depsReflCohsSup);
+    depsCohs2.(_extraDepsReflCohsSup));
   _cohReflRestrPaintingsBelowInf :=
-    depsCohs3.(_cohReflRestrPaintingsBelowInf).1;
+    depsCohs2.(_cohReflRestrPaintingsBelowInf).1;
   _cohReflRestrPaintingsBelowSup :=
-    depsCohs3.(_cohReflRestrPaintingsBelowSup).1;
+    depsCohs2.(_cohReflRestrPaintingsBelowSup).1;
   _cohReflRestrPaintingsAboveSup :=
-    depsCohs3.(_cohReflRestrPaintingsAboveSup).1;
+    depsCohs2.(_cohReflRestrPaintingsAboveSup).1;
 |}.
 
-Declare Scope depsreflcohs3_scope.
-Delimit Scope depsreflcohs3_scope with depsreflcohs3.
-Bind Scope depsreflcohs3_scope with DepsReflCohs3.
-Notation "x .(1)" := (proj1DepsReflCohs3 x%depsreflcohs3)
-  (at level 1, left associativity, format "x .(1)"): depsreflcohs3_scope.
+Declare Scope depsreflcohs2_scope.
+Delimit Scope depsreflcohs2_scope with depsreflcohs2.
+Bind Scope depsreflcohs2_scope with DepsReflCohs2.
+Notation "x .(1)" := (proj1DepsReflCohs2 x%depsreflcohs2)
+  (at level 1, left associativity, format "x .(1)"): depsreflcohs2_scope.
 
-Definition ReflBelowOfReflCohs3 {p k}
-  (depsCohs3: DepsReflCohs3 p k): DepsReflBelow p k :=
-  ReflBelowOfReflCohs2 depsCohs3.(_depsReflCohs2).
+Definition ReflBelowOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsReflBelow p k :=
+  ReflBelowOfReflCohsSup depsCohs2.(_depsReflCohsSup).
 
-Definition RestrOfReflCohs3 {p k}
-  (depsCohs3: DepsReflCohs3 p k): DepsRestr p k :=
-  RestrOfReflCohs2 depsCohs3.(_depsReflCohs2).
+Definition RestrOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsRestr p k :=
+  RestrOfReflCohsSup depsCohs2.(_depsReflCohsSup).
 
-Definition CohsOfReflCohs3 {p k}
-  (depsCohs3: DepsReflCohs3 p k): DepsCohs p k :=
-  CohsOfReflCohs2 depsCohs3.(_depsReflCohs2).
+Definition CohsOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsCohs p k :=
+  CohsOfReflCohsSup depsCohs2.(_depsReflCohsSup).
 
-Definition Cohs2OfReflCohs3 {p k}
-  (depsCohs3: DepsReflCohs3 p k): DepsCohs2 p k :=
-  Cohs2OfReflCohs2 depsCohs3.(_depsReflCohs2).
+Definition Cohs2OfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsCohs2 p k :=
+  Cohs2OfReflCohsSup depsCohs2.(_depsReflCohsSup).
 
-Definition ReflCohsOfReflCohs3 {p k}
-  (depsCohs3: DepsReflCohs3 p k): DepsReflCohs p k :=
-  depsCohs3.(_depsReflCohs2).(_depsReflCohs).
+Definition ReflCohsInfOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsReflCohsInf p k :=
+  depsCohs2.(_depsReflCohsSup).(_depsReflCohsInf).
 
-Definition RestrExtOfReflCohs3 {p k}
-  (depsCohs3: DepsReflCohs3 p k): DepsRestrExtension p k
-    (RestrOfReflCohs3 depsCohs3) :=
-  RestrExtOfReflCohs2 depsCohs3.(_depsReflCohs2).
+Definition RestrExtOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsRestrExtension p k
+    (RestrOfReflCohs2 depsCohs2) :=
+  RestrExtOfReflCohsSup depsCohs2.(_depsReflCohsSup).
 
-Definition CohsExtOfReflCohs3 {p k}
-  (depsCohs3: DepsReflCohs3 p k): DepsCohsExtension p k
-    (CohsOfReflCohs3 depsCohs3) :=
-  CohsExtOfReflCohs2 depsCohs3.(_depsReflCohs2).
+Definition CohsExtOfReflCohs2 {p k}
+  (depsCohs2: DepsReflCohs2 p k): DepsCohsExtension p k
+    (CohsOfReflCohs2 depsCohs2) :=
+  CohsExtOfReflCohsSup depsCohs2.(_depsReflCohsSup).
 
 Definition mkCohReflRestrLayerBelowInf {p k}
-  (deps: DepsReflCohs3 p.+1 k)
+  (deps: DepsReflCohs2 p.+1 k)
   (ε: arity) q r (Hq: q <= k) (Hr: r <= q)
-  (d: mkFrame (mkDepsRestr (CohsOfReflCohs3 deps)).(1).(1))
-  (l: mkLayer (mkDepsRestr (CohsOfReflCohs3 deps)).(1).(_restrFrames) d)
+  (d: mkFrame (mkDepsRestr (CohsOfReflCohs2 deps)).(1).(1))
+  (l: mkLayer (mkDepsRestr (CohsOfReflCohs2 deps)).(1).(_restrFrames) d)
   (prevCohReflRestrFrames:
     mkCohReflRestrFrameBelowInfTypes
-      (mkDepsCohs (Cohs2OfReflCohs3 deps).(1))
-      (mkReflFramesBelow (ReflCohsOfReflCohs3 deps)).1
+      (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
+      (mkReflFramesBelow (ReflCohsInfOfReflCohs2 deps)).1
       (mkReflPaintingsBelow
-        deps.(_depsReflCohs2).(1)%depsreflcohs2
-        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2)):
+        deps.(_depsReflCohsSup).(1)%depsreflcohssup
+        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup)):
   rew [mkLayer _] prevCohReflRestrFrames.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) ε d in
   mkReflLayerBelow
-    (CohsOfReflCohs3 deps)
-    (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')
-    (ReflCohsOfReflCohs3 deps).(_reflPaintingsBelow) _
-    (ReflCohsOfReflCohs3 deps).(_cohReflRestrFramesBelowInf)
+    (CohsOfReflCohs2 deps)
+    (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')
+    (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow) _
+    (ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf)
     q Hq _
     (mkRestrLayer
-      (CohsOfReflCohs3 deps).(_restrPaintings)
-      (CohsOfReflCohs3 deps).(_cohs)
+      (CohsOfReflCohs2 deps).(_restrPaintings)
+      (CohsOfReflCohs2 deps).(_cohs)
       r (Hr ↕ Hq) ε d l) =
   mkRestrLayer
-    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_restrPaintings)
-    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_cohs) r (Hr ↕ ↑ Hq) ε _
+    (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings)
+    (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_cohs) r (Hr ↕ ↑ Hq) ε _
     (mkReflLayerBelow
-      (mkDepsCohs (Cohs2OfReflCohs3 deps).(1))
-      (mkReflFramesBelow (ReflCohsOfReflCohs3 deps)).1
+      (mkDepsCohs (Cohs2OfReflCohs2 deps).(1))
+      (mkReflFramesBelow (ReflCohsInfOfReflCohs2 deps)).1
       (mkReflPaintingsBelow
-        deps.(_depsReflCohs2).(1)%depsreflcohs2
-        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2) _
+        deps.(_depsReflCohsSup).(1)%depsreflcohssup
+        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup) _
       prevCohReflRestrFrames
       q.+1 (⇑ Hq) d l).
 Proof.
@@ -888,57 +888,57 @@ Proof.
   unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- map_subst_app, <- !map_subst.
 
-  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs3 deps).(1)) 0 leR_O θ d).
+  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ d).
 
   assert (h :
-    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_restrPaintings).2 r (Hr ↕ ↑ Hq) ε
-      (mkReflFrameBelow (ReflCohsOfReflCohs3 deps).(1) q.+1 (⇑ Hq) d0)
+    (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2 r (Hr ↕ ↑ Hq) ε
+      (mkReflFrameBelow (ReflCohsInfOfReflCohs2 deps).(1) q.+1 (⇑ Hq) d0)
       ((mkReflPaintingsBelow
-        deps.(_depsReflCohs2).(1)%depsreflcohs2
-        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2).2
+        deps.(_depsReflCohsSup).(1)%depsreflcohssup
+        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup).2
           q.+1 (⇑ Hq) d0 (l θ)) =
-    mkRestrPainting (CohsExtOfReflCohs2 deps.(_depsReflCohs2).(1)) r (Hr ↕ ↑ Hq) ε
-      ((mkDepsReflBelow (ReflCohsOfReflCohs3 deps).(1)).(_reflFramesBelow).2
+    mkRestrPainting (CohsExtOfReflCohsSup deps.(_depsReflCohsSup).(1)) r (Hr ↕ ↑ Hq) ε
+      ((mkDepsReflBelow (ReflCohsInfOfReflCohs2 deps).(1)).(_reflFramesBelow).2
         q.+1 (⇑ Hq) d0)
       (mkReflPaintingBelow
-        deps.(_depsReflCohs2).(1)%depsreflcohs2
-        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2
+        deps.(_depsReflCohsSup).(1)%depsreflcohssup
+        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
         q.+1 (⇑ Hq) d0 (l θ)))
   by reflexivity; rewrite h; clear h.
 
   rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε d0 (l θ)).
   rewrite rew_map with
-    (P := fun b => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_paintings).2 b)
-    (f := fun x => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_restrFrames).2
+    (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
+    (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
       0 leR_O θ x).
   rewrite rew_map with
     (f := fun d1 =>
       (toDepsReflBelow
-        (ReflCohsOfReflCohs3 deps).(_depsCohs2).(_depsCohs)
-        (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')).(_reflFramesBelow).2
+        (ReflCohsInfOfReflCohs2 deps).(_depsCohs2).(_depsCohs)
+        (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')).(_reflFramesBelow).2
         q Hq d1).
   rewrite rew_map with
-    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(
+    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
         _deps).(_paintings).2 b)
-    (f := fun d0 => (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(
+    (f := fun d0 => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
       _deps).(_restrFrames).2 r (Hr ↕ ↑ Hq) ε d0).
   rewrite 4 rew_compose.
   apply rew_swap with
-    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(
+    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
       _deps).(_paintings).2 b).
   rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohs3 deps).(1)).(UIP).
+  now apply (mkFrame (RestrOfReflCohs2 deps).(1)).(UIP).
 Defined.
 
-Fixpoint mkCohReflRestrFramesBelowInf {p k} (deps: DepsReflCohs3 p k):
+Fixpoint mkCohReflRestrFramesBelowInf {p k} (deps: DepsReflCohs2 p k):
   mkCohReflRestrFrameBelowInfTypes
-    (mkDepsCohs (Cohs2OfReflCohs3 deps))
-    (mkReflFramesBelow (ReflCohsOfReflCohs3 deps))
-    (mkReflPaintingsBelow deps.(_depsReflCohs2) deps.(_extraDepsReflCohs2)).
+    (mkDepsCohs (Cohs2OfReflCohs2 deps))
+    (mkReflFramesBelow (ReflCohsInfOfReflCohs2 deps))
+    (mkReflPaintingsBelow deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
-  - set (h := mkCohReflRestrFramesBelowInf p k.+1 deps.(1)%depsreflcohs3).
+  - set (h := mkCohReflRestrFramesBelowInf p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor.
     + now exact h.
     + intros q r Hq Hr ε [l c].
@@ -947,15 +947,15 @@ Proof.
       * now exact (mkCohReflRestrLayerBelowInf deps ε q r Hq Hr l c h).
 Defined.
 
-Instance mkDepsReflCohs {p k} (deps: DepsReflCohs3 p k): DepsReflCohs p.+1 k.
+Instance mkDepsReflCohsInf {p k} (deps: DepsReflCohs2 p k): DepsReflCohsInf p.+1 k.
 Proof.
   unshelve econstructor.
   - unshelve econstructor.
-    + now exact (mkDepsCohs (Cohs2OfReflCohs3 deps)).
+    + now exact (mkDepsCohs (Cohs2OfReflCohs2 deps)).
     + now exact (mkExtraCohs deps.(_extraDepsCohs2)).
     + now apply mkCohPaintings.
   - now apply mkReflFramesBelow.
-  - now exact (mkReflPaintingsBelow _ deps.(_extraDepsReflCohs2)).
+  - now exact (mkReflPaintingsBelow _ deps.(_extraDepsReflCohsSup)).
   - now apply mkIdReflRestrFramesBelow.
   - now apply mkReflFramesAbove.
   - now apply mkIdReflRestrPaintingsBelow. 
@@ -963,33 +963,33 @@ Proof.
 Defined.
 
 Definition mkCohReflRestrLayerBelowSup {p k}
-  (deps: DepsReflCohs3 p.+1 k)
+  (deps: DepsReflCohs2 p.+1 k)
   (ε: arity) q r (Hq: q <= r) (Hr: r <= k)
-  (d: mkFrame ((RestrOfReflCohs (mkDepsReflCohs deps)).(1).(1)))
-  (l: mkLayer (RestrOfReflCohs (mkDepsReflCohs deps)).(1).(_restrFrames) d)
+  (d: mkFrame ((RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(1)))
+  (l: mkLayer (RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(_restrFrames) d)
   (prevCohReflRestrFrames:
     mkCohReflRestrFrameBelowSupTypes
-      (mkDepsReflCohs deps.(1)%depsreflcohs3)):
+      (mkDepsReflCohsInf deps.(1)%depsreflcohs2)):
   rew [mkLayer _] prevCohReflRestrFrames.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) ε d in
   mkReflLayerBelow
-    (CohsOfReflCohs3 deps)
-    (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')
-    (ReflCohsOfReflCohs3 deps).(_reflPaintingsBelow) _
-    (ReflCohsOfReflCohs3 deps).(_cohReflRestrFramesBelowInf)
+    (CohsOfReflCohs2 deps)
+    (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')
+    (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow) _
+    (ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf)
     q (Hq ↕ Hr) _
     (mkRestrLayer
-      (CohsOfReflCohs3 deps).(_restrPaintings)
-      (CohsOfReflCohs3 deps).(_cohs)
+      (CohsOfReflCohs2 deps).(_restrPaintings)
+      (CohsOfReflCohs2 deps).(_cohs)
       r Hr ε d l) =
   mkRestrLayer
-    (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_restrPaintings)
-    (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_cohs)
+    (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings)
+    (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_cohs)
     r.+1 (⇑ Hr) ε _
     (mkReflLayerBelow
-      (CohsOfReflCohs (mkDepsReflCohs deps).(1))
-      (mkDepsReflCohs deps).(1).(_reflFramesBelow')
-      (mkDepsReflCohs deps).(1).(_reflPaintingsBelow) _
-      (mkDepsReflCohs deps).(1).(_cohReflRestrFramesBelowInf)
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))
+      (mkDepsReflCohsInf deps).(1).(_reflFramesBelow')
+      (mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow) _
+      (mkDepsReflCohsInf deps).(1).(_cohReflRestrFramesBelowInf)
       q (Hq ↕ ↑ Hr) d l).
 Proof.
   apply functional_extensionality_dep.
@@ -997,57 +997,57 @@ Proof.
   unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- map_subst_app, <- !map_subst.
 
-  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs3 deps).(1)) 0 leR_O θ d).
+  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ d).
 
   assert (h :
-    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_restrPaintings).2
+    (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2
       r.+1 (⇑ Hr) ε
-      (mkReflFrameBelow (ReflCohsOfReflCohs3 deps).(1) q (Hq ↕ ↑ Hr) d0)
+      (mkReflFrameBelow (ReflCohsInfOfReflCohs2 deps).(1) q (Hq ↕ ↑ Hr) d0)
       ((mkReflPaintingsBelow
-        deps.(_depsReflCohs2).(1)%depsreflcohs2
-        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2).2
+        deps.(_depsReflCohsSup).(1)%depsreflcohssup
+        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup).2
         q (Hq ↕ ↑ Hr) d0 (l θ)) =
-    mkRestrPainting (CohsExtOfReflCohs2 deps.(_depsReflCohs2).(1))
+    mkRestrPainting (CohsExtOfReflCohsSup deps.(_depsReflCohsSup).(1))
       r.+1 (⇑ Hr) ε
-      ((mkDepsReflBelow (ReflCohsOfReflCohs3 deps).(1)).(_reflFramesBelow).2
+      ((mkDepsReflBelow (ReflCohsInfOfReflCohs2 deps).(1)).(_reflFramesBelow).2
         q (Hq ↕ ↑ Hr) d0)
       (mkReflPaintingBelow
-        deps.(_depsReflCohs2).(1)%depsreflcohs2
-        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2
+        deps.(_depsReflCohsSup).(1)%depsreflcohssup
+        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
         q (Hq ↕ ↑ Hr) d0 (l θ)))
   by reflexivity; rewrite h; clear h.
 
   rewrite <- (deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε d0 (l θ)).
   rewrite rew_map with
-    (P := fun b => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_paintings).2 b)
-    (f := fun x => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_restrFrames).2
+    (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
+    (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
       0 leR_O θ x).
   rewrite rew_map with
     (f := fun d1 =>
       (toDepsReflBelow
-        (ReflCohsOfReflCohs3 deps).(_depsCohs2).(_depsCohs)
-        (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')).(_reflFramesBelow).2
+        (ReflCohsInfOfReflCohs2 deps).(_depsCohs2).(_depsCohs)
+        (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')).(_reflFramesBelow).2
         q (Hq ↕ Hr) d1).
   rewrite rew_map with
     (P := fun b =>
-      (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_paintings).2 b)
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_paintings).2 b)
     (f := fun d1 =>
-      (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_restrFrames).2
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_restrFrames).2
         r.+1 (⇑ Hr) ε d1).
   rewrite 4 rew_compose.
   apply rew_swap with
     (P := fun b =>
-      (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_paintings).2 b).
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_paintings).2 b).
   rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohs3 deps).(1)).(UIP).
+  now apply (mkFrame (RestrOfReflCohs2 deps).(1)).(UIP).
 Defined.
 
-Fixpoint mkCohReflRestrFramesBelowSup {p k} (deps: DepsReflCohs3 p k):
-  mkCohReflRestrFrameBelowSupTypes (mkDepsReflCohs deps).
+Fixpoint mkCohReflRestrFramesBelowSup {p k} (deps: DepsReflCohs2 p k):
+  mkCohReflRestrFrameBelowSupTypes (mkDepsReflCohsInf deps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
-  - set (h := mkCohReflRestrFramesBelowSup p k.+1 deps.(1)%depsreflcohs3).
+  - set (h := mkCohReflRestrFramesBelowSup p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor.
     + now exact h.
     + intros q r Hq Hr ε [l c].
@@ -1057,31 +1057,31 @@ Proof.
 Defined.
 
 Definition mkCohReflRestrLayerAboveSup {p k}
-  (deps: DepsReflCohs3 p.+1 k)
+  (deps: DepsReflCohs2 p.+1 k)
   (ε: arity) q r (Hq: q.+1 <= p.+1) (Hr: r <= k)
-  (d: mkFrame ((RestrOfReflCohs (mkDepsReflCohs deps)).(1).(1)))
-  (l: mkLayer (RestrOfReflCohs (mkDepsReflCohs deps)).(1).(_restrFrames) d)
-  (l': mkLayer (RestrOfReflCohs (mkDepsReflCohs deps)).(_restrFrames) (d; l))
-  (c: mkPainting (RestrExtOfReflCohs (mkDepsReflCohs deps)) ((d; l); l'))
+  (d: mkFrame ((RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(1)))
+  (l: mkLayer (RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(_restrFrames) d)
+  (l': mkLayer (RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrFrames) (d; l))
+  (c: mkPainting (RestrExtOfReflCohsInf (mkDepsReflCohsInf deps)) ((d; l); l'))
   (prevCohReflRestrFrames:
     mkCohReflRestrFrameAboveSupTypes
-      (mkDepsReflCohs deps.(1)%depsreflcohs3)
-      (mkReflPaintingsAbove deps.(1).(_depsReflCohs2)
-        deps.(1).(_extraDepsReflCohs2))):
+      (mkDepsReflCohsInf deps.(1)%depsreflcohs2)
+      (mkReflPaintingsAbove deps.(1).(_depsReflCohsSup)
+        deps.(1).(_extraDepsReflCohsSup))):
   rew [mkLayer _] prevCohReflRestrFrames.2 q r.+1 Hq (⇑ Hr) ε d (l; (l'; c)) in
-  mkReflLayerAbove deps.(_depsReflCohs2).(_depsReflCohs)
-    deps.(_depsReflCohs2).(_reflPaintingsAbove) _
-    deps.(_depsReflCohs2).(_cohReflRestrFramesAboveSup)
+  mkReflLayerAbove deps.(_depsReflCohsSup).(_depsReflCohsInf)
+    deps.(_depsReflCohsSup).(_reflPaintingsAbove) _
+    deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup)
     q (⇓ Hq)
-    ((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).1
-    (((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).2;
-     (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings).2 r Hr ε (d; l) (l'; c)) =
+    ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).1
+    (((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).2;
+     (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε (d; l) (l'; c)) =
   mkRestrLayer
-    (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings)
-    (CohsOfReflCohs (mkDepsReflCohs deps)).(_cohs)
+    (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings)
+    (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_cohs)
     r Hr ε _
-    (mkReflLayerAbove (mkDepsReflCohs deps).(1)
-      (mkReflPaintingsAbove deps.(1).(_depsReflCohs2) deps.(1).(_extraDepsReflCohs2)) _
+    (mkReflLayerAbove (mkDepsReflCohsInf deps).(1)
+      (mkReflPaintingsAbove deps.(1).(_depsReflCohsSup) deps.(1).(_extraDepsReflCohsSup)) _
       prevCohReflRestrFrames
       q (⇓ Hq) d (l; (l'; c))).
 Proof.
@@ -1090,99 +1090,99 @@ Proof.
   unfold mkRestrLayer, mkReflLayerAbove.
   rewrite <- map_subst_app, <- !map_subst.
 
-  set (d0 := (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_restrFrames).2
+  set (d0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_restrFrames).2
     0 leR_O θ d).
-  set (c0 := (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_restrPaintings).2
+  set (c0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
     0 leR_O θ d (l; (l'; c))).
 
   assert (h :
-    (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings).2 r Hr ε
-      ((AboveOfReflCohs (mkDepsReflCohs deps).(1)).(_reflFramesAbove').2
+    (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε
+      ((AboveOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_reflFramesAbove').2
         q (⇓ Hq) d0 c0)
       ((mkReflPaintingsAbove
-        deps.(1).(_depsReflCohs2)
-        deps.(1).(_extraDepsReflCohs2)).2 q (⇓ Hq) d0 c0) =
-    mkRestrPainting (CohsExtOfReflCohs2 deps.(_depsReflCohs2))
+        deps.(1).(_depsReflCohsSup)
+        deps.(1).(_extraDepsReflCohsSup)).2 q (⇓ Hq) d0 c0) =
+    mkRestrPainting (CohsExtOfReflCohsSup deps.(_depsReflCohsSup))
       r Hr ε
-      (mkReflFrameAbove deps.(_depsReflCohs2).(1) q (⇓ Hq) d0 c0)
+      (mkReflFrameAbove deps.(_depsReflCohsSup).(1) q (⇓ Hq) d0 c0)
       (mkReflPaintingAbove
-        deps.(_depsReflCohs2).(1)%depsreflcohs2
-        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2
+        deps.(_depsReflCohsSup).(1)%depsreflcohssup
+        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
         q (⇓ Hq) d0 c0))
   by reflexivity; rewrite h; clear h.
 
   rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r (⇓ Hq) Hr ε d0 c0).
 
   set (D := { d1 :
-    (Cohs2OfReflCohs3 deps).(_depsCohs).(_deps).(_frames).2 &T
-    (Cohs2OfReflCohs3 deps).(_depsCohs).(_deps).(_paintings).2 d1 }).
+    (Cohs2OfReflCohs2 deps).(_depsCohs).(_deps).(_frames).2 &T
+    (Cohs2OfReflCohs2 deps).(_depsCohs).(_deps).(_paintings).2 d1 }).
   set (x0 := (
-    (CohsOfReflCohs2 deps.(_depsReflCohs2)).(_deps).(_restrFrames).2
+    (CohsOfReflCohsSup deps.(_depsReflCohsSup)).(_deps).(_restrFrames).2
       r Hr ε d0;
-    (CohsOfReflCohs2 deps.(_depsReflCohs2)).(_restrPaintings).2
+    (CohsOfReflCohsSup deps.(_depsReflCohsSup)).(_restrPaintings).2
       r Hr ε d0 c0) : D).
   set (xr := (
-    (CohsOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_deps).(_restrFrames).2
+    (CohsOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_deps).(_restrFrames).2
       0 leR_O θ
-      ((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+      ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
         r Hr ε (d; l)).1;
-    (CohsOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_restrPaintings).2
+    (CohsOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_restrPaintings).2
       0 leR_O θ
-      ((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+      ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
         r Hr ε (d; l)).1
-      (((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+      (((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
           r Hr ε (d; l)).2;
-       (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings).2
+       (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2
          r Hr ε (d; l) (l'; c))) : D).
   set (Q := fun x : D =>
-    mkPainting (AboveOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_extraDeps)
-      ((AboveOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_reflFramesAbove').2
+    mkPainting (AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_extraDeps)
+      ((AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_reflFramesAbove').2
         q (⇓ Hq) x.1 x.2)).
   assert (pair_eq : x0 = xr).
   { unfold x0, xr.
     unshelve eapply eq_existT_curried.
-    now exact ((CohsOfReflCohs3 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
-    now exact ((Cohs2OfReflCohs3 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; (l'; c))). }
+    now exact ((CohsOfReflCohs2 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
+    now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; (l'; c))). }
   assert (map_pair_eq :
     rew [Q] pair_eq in
-      deps.(_depsReflCohs2).(_reflPaintingsAbove).2 q (⇓ Hq) x0.1 x0.2 =
-    deps.(_depsReflCohs2).(_reflPaintingsAbove).2 q (⇓ Hq) xr.1 xr.2).
+      deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) x0.1 x0.2 =
+    deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) xr.1 xr.2).
   { now exact (map_subst (P := fun _ : D => unit) (Q := Q) (fun x _ =>
-      deps.(_depsReflCohs2).(_reflPaintingsAbove).2 q (⇓ Hq) x.1 x.2) pair_eq tt). }
+      deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) x.1 x.2) pair_eq tt). }
   rewrite <- map_pair_eq.
 
   rewrite rew_map with
     (P := fun b =>
-      (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_paintings).2 b)
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_paintings).2 b)
     (f := fun x => (mkDepsRestr
-      (CohsOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs))).(_restrFrames).2
+      (CohsOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf))).(_restrFrames).2
       0 leR_O θ x).
   rewrite rew_map with
     (P := fun b =>
-      (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_paintings).2 b)
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_paintings).2 b)
     (f := fun d1 =>
-      (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
         r Hr ε d1).
   rewrite rew_map with
-    (P := fun x => mkPainting (RestrExtOfReflCohs2 deps.(_depsReflCohs2)) x)
+    (P := fun x => mkPainting (RestrExtOfReflCohsSup deps.(_depsReflCohsSup)) x)
     (f := fun x : D =>
-      (AboveOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_reflFramesAbove').2
+      (AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_reflFramesAbove').2
         q (⇓ Hq) x.1 x.2).
   rewrite 4 rew_compose.
   apply rew_swap with
-    (P := fun x => mkPainting (RestrExtOfReflCohs2 deps.(_depsReflCohs2)) x).
+    (P := fun x => mkPainting (RestrExtOfReflCohsSup deps.(_depsReflCohsSup)) x).
   rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohs2 deps.(_depsReflCohs2))).(UIP).
+  now apply (mkFrame (RestrOfReflCohsSup deps.(_depsReflCohsSup))).(UIP).
 Defined.
 
-Fixpoint mkCohReflRestrFramesAboveSup {p k} (deps: DepsReflCohs3 p k):
+Fixpoint mkCohReflRestrFramesAboveSup {p k} (deps: DepsReflCohs2 p k):
   mkCohReflRestrFrameAboveSupTypes
-    (mkDepsReflCohs deps)
-    (mkReflPaintingsAbove deps.(_depsReflCohs2) deps.(_extraDepsReflCohs2)).
+    (mkDepsReflCohsInf deps)
+    (mkReflPaintingsAbove deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
-  - set (h := mkCohReflRestrFramesAboveSup p k.+1 deps.(1)%depsreflcohs3).
+  - set (h := mkCohReflRestrFramesAboveSup p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor. now exact h.
     intros q r Hq Hr ε [d l] [l' c].
     destruct q.
@@ -1192,7 +1192,7 @@ Proof.
         intro θ.
         unfold mkRestrLayer.
         rewrite <- map_subst_app, <- !map_subst.
-        set (deps' := (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps)).
+        set (deps' := (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps)).
         rewrite rew_map with
           (P := fun b => deps'.(_paintings).2 b)
           (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
@@ -1208,48 +1208,48 @@ Proof.
       * now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c h).
 Defined.
 
-Instance mkDepsReflCohs2 {p k} (deps: DepsReflCohs3 p k): DepsReflCohs2 p.+1 k.
+Instance mkDepsReflCohsSup {p k} (deps: DepsReflCohs2 p k): DepsReflCohsSup p.+1 k.
 Proof.
   unshelve econstructor.
-  - now exact (mkReflPaintingsAbove _ deps.(_extraDepsReflCohs2)).
+  - now exact (mkReflPaintingsAbove _ deps.(_extraDepsReflCohsSup)).
   - now apply mkCohReflRestrFramesBelowSup.
   - now apply mkCohReflRestrFramesAboveSup.
 Defined.
 
-Inductive DepsReflCohs3Extension p: forall k (deps: DepsReflCohs3 p k), Type :=
-| TopReflCoh3Dep {deps: DepsReflCohs3 p 0}
+Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
+| TopReflCoh2Dep {deps: DepsReflCohs2 p 0}
   (L: HasRefl
-    (mkDepsReflCohs2 deps)
-    (mkPaintings (mkExtraDeps (CohsExtOfReflCohs (mkDepsReflCohs deps)))).2):
-  DepsReflCohs3Extension p 0 deps
-| AddReflCoh3Dep {k} (deps: DepsReflCohs3 p.+1 k):
-  DepsReflCohs3Extension p.+1 k deps -> DepsReflCohs3Extension p k.+1 deps.(1)%depsreflcohs3.
+    (mkDepsReflCohsSup deps)
+    (mkPaintings (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps)))).2):
+  DepsReflCohs2Extension p 0 deps
+| AddReflCoh2Dep {k} (deps: DepsReflCohs2 p.+1 k):
+  DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1)%depsreflcohs2.
 
-Arguments TopReflCoh3Dep {p deps}.
-Arguments AddReflCoh3Dep {p k}.
+Arguments TopReflCoh2Dep {p deps}.
+Arguments AddReflCoh2Dep {p k}.
 
-Declare Scope extra_depsreflcohs3_scope.
-Delimit Scope extra_depsreflcohs3_scope with extradepsreflcohs3.
-Bind Scope extra_depsreflcohs3_scope with DepsReflCohs3Extension.
-Notation "( x ; y )" := (AddReflCoh3Dep x y)
-  (at level 0, format "( x ; y )"): extra_depsreflcohs3_scope.
+Declare Scope extra_depsreflcohs2_scope.
+Delimit Scope extra_depsreflcohs2_scope with extradepsreflcohs2.
+Bind Scope extra_depsreflcohs2_scope with DepsReflCohs2Extension.
+Notation "( x ; y )" := (AddReflCoh2Dep x y)
+  (at level 0, format "( x ; y )"): extra_depsreflcohs2_scope.
 
-Fixpoint mkExtraDepsReflCohs2 {p k} (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
-  DepsReflCohs2Extension p.+1 k (mkDepsReflCohs2 deps).
+Fixpoint mkExtraDepsReflCohsSup {p k} (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  DepsReflCohsSupExtension p.+1 k (mkDepsReflCohsSup deps).
 Proof.
   destruct extraDeps.
-  - now apply TopReflCoh2Dep.
-  - apply (AddReflCoh2Dep (mkDepsReflCohs2 deps)).
-    now exact (mkExtraDepsReflCohs2 p.+1 k deps extraDeps).
+  - now apply TopReflCohSupDep.
+  - apply (AddReflCohSupDep (mkDepsReflCohsSup deps)).
+    now exact (mkExtraDepsReflCohsSup p.+1 k deps extraDeps).
 Defined.
 
 Fixpoint mkCohReflRestrPaintingBelowInf {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
   mkCohReflRestrPaintingBelowInfType
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
 Proof.
   intros q r Hq Hr ε d [l c].
   destruct r.
@@ -1257,7 +1257,7 @@ Proof.
   - destruct q; [now contradiction |].
     destruct extraDeps; [now contradiction |].
     unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1))))).
     + now exact (mkCohReflRestrLayerBelowInf deps ε q r (⇓ Hq) (⇓ Hr) d l
         (mkCohReflRestrFramesBelowInf deps.(1))).
     + now exact (mkCohReflRestrPaintingBelowInf p.+1 k deps extraDeps
@@ -1265,27 +1265,27 @@ Proof.
 Defined.
 
 Fixpoint mkCohReflRestrPaintingsBelowInf {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
   mkCohReflRestrPaintingBelowInfTypes
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
     now apply mkCohReflRestrPaintingBelowInf.
   - unshelve econstructor.
     + now exact (mkCohReflRestrPaintingsBelowInf p k.+1
-        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
     + now apply mkCohReflRestrPaintingBelowInf.
 Defined.
 
 Fixpoint mkCohReflRestrPaintingAboveSup {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
   mkCohReflRestrPaintingAboveSupType
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
 Proof.
   intros q r Hq Hr ε d [l c].
   destruct r.
@@ -1297,7 +1297,7 @@ Proof.
   - destruct extraDeps; try contradiction.
     destruct c as [l' c].
     unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps)))).
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
     + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c
         (mkCohReflRestrFramesAboveSup deps.(1))).
     + now exact (mkCohReflRestrPaintingAboveSup p.+1 k deps extraDeps
@@ -1305,37 +1305,37 @@ Proof.
 Defined.
 
 Fixpoint mkCohReflRestrPaintingsAboveSup {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
   mkCohReflRestrPaintingAboveSupTypes
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
     now apply mkCohReflRestrPaintingAboveSup.
   - unshelve econstructor.
     + now exact (mkCohReflRestrPaintingsAboveSup p k.+1
-        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
     + now apply mkCohReflRestrPaintingAboveSup.
 Defined.
 
 Fixpoint mkCohReflRestrPaintingBelowSup {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
   mkCohReflRestrPaintingBelowSupType
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
 Proof.
   intros q r Hq Hr ε d [l c].
   destruct q.
   - unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps)))).
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
     + apply functional_extensionality_dep.
       intro θ.
       unfold mkRestrLayer.
       rewrite <- map_subst_app, <- !map_subst.
-      set (deps' := (mkDepsRestr (Cohs2OfReflCohs3 deps).(_depsCohs))).
+      set (deps' := (mkDepsRestr (Cohs2OfReflCohs2 deps).(_depsCohs))).
       rewrite rew_map with
         (P := fun b => deps'.(_paintings).2 b)
         (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
@@ -1350,12 +1350,12 @@ Proof.
       * rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
         destruct d.
         enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
-        now apply (mkFrame (RestrOfReflCohs2 (mkDepsReflCohs2 deps))).(UIP).
+        now apply (mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
       * now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
   - destruct r; try contradiction.
     destruct extraDeps; try contradiction.
     unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))))).
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1))))).
     + now exact (mkCohReflRestrLayerBelowSup deps ε q r (⇓ Hq) (⇓ Hr) d l
         (mkCohReflRestrFramesBelowSup deps.(1))).
     + now exact (mkCohReflRestrPaintingBelowSup p.+1 k deps extraDeps
@@ -1363,18 +1363,18 @@ Proof.
 Defined.
 
 Fixpoint mkCohReflRestrPaintingsBelowSup {p k}
-  (deps: DepsReflCohs3 p k)
-  (extraDeps: DepsReflCohs3Extension p k deps):
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
   mkCohReflRestrPaintingBelowSupTypes
-    (mkDepsReflCohs2 deps)
-    (mkExtraDepsReflCohs2 deps extraDeps).
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
 Proof.
   destruct p.
   - unshelve econstructor. now exact tt.
     now apply mkCohReflRestrPaintingBelowSup.
   - unshelve econstructor.
     + now exact (mkCohReflRestrPaintingsBelowSup p k.+1
-        deps.(1)%depsreflcohs3 (deps; extraDeps)%extradepsreflcohs3).
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
     + now apply mkCohReflRestrPaintingBelowSup.
 Defined.
 
@@ -1406,7 +1406,7 @@ Definition dgnDepsCohs2 {p} (C: νSetData p)
     (extraDepsCohs := TopCohDep (depsCohs := dgnDepsCohs C E) E')
     (C.(cohPaintings) E E').
 
-Definition dgnDepsReflCohs {p} (C: νSetData p)
+Definition dgnDepsReflCohsInf {p} (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
   (reflFrames: mkReflFrameTypes (dgnDepsRestr C))
@@ -1419,7 +1419,7 @@ Definition dgnDepsReflCohs {p} (C: νSetData p)
       reflFrames reflPaintings idReflRestrFrames)
   (cohRestrReflFrames :
     mkCohReflRestrFrameTypes (dgnDepsCohs C E) reflFrames reflPaintings):
-  DepsReflCohs p 0 :=
+  DepsReflCohsInf p 0 :=
   {|
     _depsCohs2 := dgnDepsCohs2 C E E';
     _reflFrameDeps := reflFrames;
@@ -1445,14 +1445,14 @@ Definition dgnHasRefl {p} (C: νSetData p)
     mkCohReflRestrFrameTypes (dgnDepsCohs C E)
       reflFrames reflPaintings): Type :=
   HasRefl
-    (dgnDepsReflCohs C E E'
+    (dgnDepsReflCohsInf C E E'
       reflFrames reflPaintings
       idReflRestrFrames idReflRestrPaintings
       cohRestrReflFrames)
     (mkPaintings
       (mkExtraDeps
-        (CohsExtOfReflCohs
-          (dgnDepsReflCohs C E E'
+        (CohsExtOfReflCohsInf
+          (dgnDepsReflCohsInf C E E'
             reflFrames reflPaintings
             idReflRestrFrames idReflRestrPaintings
             cohRestrReflFrames)))).2.
@@ -1479,12 +1479,12 @@ Class DgnData {p} (C: νSetData p)
     mkCohReflRestrPaintingTypes _ (TopReflCohDep L);
 }.
 
-Definition dgnDepsReflCohsFromData {p}
+Definition dgnDepsReflCohsInfFromData {p}
   (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
-  (D: DgnData C E): DepsReflCohs p 0 :=
-  dgnDepsReflCohs C E E'
+  (D: DgnData C E): DepsReflCohsInf p 0 :=
+  dgnDepsReflCohsInf C E E'
     D.(reflFrames) D.(reflPaintings)
     D.(idReflRestrFrames) D.(idReflRestrPaintings)
     (D.(cohRestrReflFrames) E').
@@ -1499,19 +1499,19 @@ Definition dgnHasReflFromData {p}
     D.(idReflRestrFrames) D.(idReflRestrPaintings)
     (D.(cohRestrReflFrames) E').
 
-Definition dgnDepsReflCohs2FromData {p}
+Definition dgnDepsReflCohsSupFromData {p}
   (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
   (E'': mkFrame (dgnDepsRestr (mkνSetData p.+1 (mkνSetData p C E) E')) -> HSet)
   (D: DgnData C E)
   (L: dgnHasReflFromData C E E' D):
-  DepsReflCohs2 p 0 :=
+  DepsReflCohsSup p 0 :=
   {|
-    _depsReflCohs := dgnDepsReflCohsFromData C E E' D;
+    _depsReflCohsInf := dgnDepsReflCohsInfFromData C E E' D;
     _extraDepsCohs2 := TopCoh2Dep (depsCohs2 := dgnDepsCohs2 C E E') E'';
     _extraDepsRefl := TopReflCohDep
-      (deps := dgnDepsReflCohsFromData C E E' D) L;
+      (deps := dgnDepsReflCohsInfFromData C E E' D) L;
     _cohReflRestrPaintings := D.(cohReflRestrPaintings) E' L;
   |}.
 
@@ -1523,23 +1523,23 @@ Instance mkDgnData {p} (C: νSetData p)
   (L: dgnHasReflFromData C E E' D):
   DgnData (mkνSetData p C E) E' :=
 {|
-  reflFrames := (mkReflFrames (dgnDepsReflCohsFromData C E E' D):
+  reflFrames := (mkReflFrames (dgnDepsReflCohsInfFromData C E E' D):
     mkReflFrameTypes (dgnDepsRestr (mkνSetData p C E)));
   reflPaintings :=
     mkReflPaintings
-      (dgnDepsReflCohsFromData C E E' D)
-      (TopReflCohDep (deps := dgnDepsReflCohsFromData C E E' D) L);
-  idReflRestrFrames := mkIdReflRestrFrames (dgnDepsReflCohsFromData C E E' D);
+      (dgnDepsReflCohsInfFromData C E E' D)
+      (TopReflCohDep (deps := dgnDepsReflCohsInfFromData C E E' D) L);
+  idReflRestrFrames := mkIdReflRestrFrames (dgnDepsReflCohsInfFromData C E E' D);
   idReflRestrPaintings :=
     mkIdReflRestrPaintings
-      (dgnDepsReflCohsFromData C E E' D)
-      (TopReflCohDep (deps := dgnDepsReflCohsFromData C E E' D) L);
+      (dgnDepsReflCohsInfFromData C E E' D)
+      (TopReflCohDep (deps := dgnDepsReflCohsInfFromData C E E' D) L);
   cohRestrReflFrames := fun E'' =>
-    mkCohReflRestrFrames (dgnDepsReflCohs2FromData C E E' E'' D L);
+    mkCohReflRestrFrames (dgnDepsReflCohsSupFromData C E E' E'' D L);
   cohReflRestrPaintings := fun E'' L' =>
     mkCohReflRestrPaintings
-      (dgnDepsReflCohs2FromData C E E' E'' D L)
-      (TopReflCohDep2 (deps := dgnDepsReflCohs2FromData C E E' E'' D L) L');
+      (dgnDepsReflCohsSupFromData C E E' E'' D L)
+      (TopReflCohDep2 (deps := dgnDepsReflCohsSupFromData C E E' E'' D L) L');
 |}.
 
 Class νDgnSet p (C: νSet p) := {

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1621,6 +1621,52 @@ Proof.
       * now exact (mkCohReflReflLayerAbove deps q r Hq Hr d l c h).
 Defined.
 
+Fixpoint mkCohReflReflPaintingAbove {p k} (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflReflPaintingAboveType
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps)
+    (mkCohReflReflFramesAbove deps).
+Proof.
+  intros q r Hq Hr d c.
+  destruct r.
+  - unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps))))).
+    + apply functional_extensionality_dep; intro θ.
+      unfold mkReflLayerAbove, mkReflPaintingBelow1.
+      rewrite <- map_subst_app.
+      set (deps' := mkExtraDeps (CohsExtOfReflCohsSup deps.(_depsReflCohsSup))).
+      apply rew_swap with (P := fun b => mkPainting deps' b).
+      rewrite rew_map with
+        (P := fun b => mkPainting deps' b)
+        (f := fun x => (mkDepsRestr (CohsOfReflCohsInf
+          (mkDepsReflCohsSup deps).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
+      rewrite 2 rew_compose.
+      simpl.
+      eassert (id_pair_eq : (_;_) = (_;_)).
+      { unshelve eapply eq_existT_curried.
+        - exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
+        - exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
+            deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
+      rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
+        deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) q Hq x.1 x.2) id_pair_eq tt).
+      rewrite rew_map with
+        (P := fun b => mkPainting deps' b)
+        (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 q Hq x.1 x.2).
+      apply rew_swap with (P := fun b => mkPainting deps' b).
+      rewrite rew_app_rl. now trivial.
+      now apply (mkFrame _).(UIP).
+    + admit.
+  - destruct extraDeps; [now contradiction |].
+    destruct c as [l c].
+    unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)))))).
+    + now exact (mkCohReflReflLayerAbove deps q r Hq Hr d l c
+        (mkCohReflReflFramesAbove deps.(1)%depsreflcohs2)).
+    + now exact (mkCohReflReflPaintingAbove p.+1 k deps extraDeps
+        q.+1 r Hq Hr (d; l) c). 
+Admitted.
+
 (*
 Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=
   toDepsRestr C.(restrFrames).

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1260,163 +1260,6 @@ Proof.
   - now apply mkCohReflRestrFramesAboveSup.
 Defined.
 
-Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
-| TopReflCoh2Dep {deps: DepsReflCohs2 p 0}
-  (L: HasRefl
-    (mkDepsReflCohsSup deps)
-    (mkPainting (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps))))):
-  DepsReflCohs2Extension p 0 deps
-| AddReflCoh2Dep {k} (deps: DepsReflCohs2 p.+1 k):
-  DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1)%depsreflcohs2.
-
-Arguments TopReflCoh2Dep {p deps}.
-Arguments AddReflCoh2Dep {p k}.
-
-Declare Scope extra_depsreflcohs2_scope.
-Delimit Scope extra_depsreflcohs2_scope with extradepsreflcohs2.
-Bind Scope extra_depsreflcohs2_scope with DepsReflCohs2Extension.
-Notation "( x ; y )" := (AddReflCoh2Dep x y)
-  (at level 0, format "( x ; y )"): extra_depsreflcohs2_scope.
-
-Fixpoint mkExtraDepsReflCohsSup {p k} (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  DepsReflCohsSupExtension p.+1 k (mkDepsReflCohsSup deps).
-Proof.
-  destruct extraDeps.
-  - now apply TopReflCohSupDep.
-  - apply (AddReflCohSupDep (mkDepsReflCohsSup deps)).
-    now exact (mkExtraDepsReflCohsSup p.+1 k deps extraDeps).
-Defined.
-
-Fixpoint mkCohReflRestrPaintingBelowInf {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingBelowInfType
-    (mkDepsReflCohsSup deps)
-    (mkExtraDepsReflCohsSup deps extraDeps).
-Proof.
-  intros q r Hq Hr ε d [l c].
-  destruct r.
-  - now trivial.
-  - destruct q; [now contradiction |].
-    destruct extraDeps; [now contradiction |].
-    unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1))))).
-    + now exact (mkCohReflRestrLayerBelowInf deps ε q r (⇓ Hq) (⇓ Hr) d l
-        (mkCohReflRestrFramesBelowInf deps.(1))).
-    + now exact (mkCohReflRestrPaintingBelowInf p.+1 k deps extraDeps
-        q r Hq Hr ε (d; l) c).
-Defined.
-
-Fixpoint mkCohReflRestrPaintingsBelowInf {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingBelowInfTypes
-    (mkDepsReflCohsSup deps)
-    (mkExtraDepsReflCohsSup deps extraDeps).
-Proof.
-  destruct p.
-  - unshelve econstructor. now exact tt.
-    now apply mkCohReflRestrPaintingBelowInf.
-  - unshelve econstructor.
-    + now exact (mkCohReflRestrPaintingsBelowInf p k.+1
-        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
-    + now apply mkCohReflRestrPaintingBelowInf.
-Defined.
-
-Fixpoint mkCohReflRestrPaintingAboveSup {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingAboveSupType
-    (mkDepsReflCohsSup deps)
-    (mkExtraDepsReflCohsSup deps extraDeps).
-Proof.
-  intros q r Hq Hr ε d [l c].
-  destruct r.
-  - now trivial.
-  - destruct extraDeps; [now contradiction |].
-    unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
-    + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l c
-        (mkCohReflRestrFramesAboveSup deps.(1))).
-    + now exact (mkCohReflRestrPaintingAboveSup p.+1 k deps extraDeps
-        q.+1 r (⇑ Hq) Hr ε (d; l) c).
-Defined.
-
-Fixpoint mkCohReflRestrPaintingsAboveSup {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingAboveSupTypes
-    (mkDepsReflCohsSup deps)
-    (mkExtraDepsReflCohsSup deps extraDeps).
-Proof.
-  destruct p.
-  - unshelve econstructor. now exact tt.
-    now apply mkCohReflRestrPaintingAboveSup.
-  - unshelve econstructor.
-    + now exact (mkCohReflRestrPaintingsAboveSup p k.+1
-        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
-    + now apply mkCohReflRestrPaintingAboveSup.
-Defined.
-
-Fixpoint mkCohReflRestrPaintingBelowSup {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingBelowSupType
-    (mkDepsReflCohsSup deps)
-    (mkExtraDepsReflCohsSup deps extraDeps).
-Proof.
-  intros q r Hq Hr ε d [l c].
-  destruct q.
-  - unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
-    + apply functional_extensionality_dep.
-      intro θ.
-      unfold mkRestrLayer.
-      rewrite <- map_subst_app, <- !map_subst.
-      set (deps' := (mkDepsRestr (CohsOfReflCohs2 deps))).
-      rewrite rew_map with
-        (P := fun b => deps'.(_paintings).2 b)
-        (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-      rewrite rew_map with
-        (P := fun b => deps'.(_paintings).2 b)
-        (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
-      rewrite 2 rew_compose.
-      apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-      rewrite rew_app_rl. now trivial.
-      now apply (deps'.(_frames).2.(UIP)).
-    + destruct p.
-      * rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
-        destruct d.
-        enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
-        now apply (mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
-      * now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
-  - destruct r; [now contradiction |].
-    destruct extraDeps; [now contradiction |].
-    unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1))))).
-    + now exact (mkCohReflRestrLayerBelowSup deps ε q r (⇓ Hq) (⇓ Hr) d l
-        (mkCohReflRestrFramesBelowSup deps.(1))).
-    + now exact (mkCohReflRestrPaintingBelowSup p.+1 k deps extraDeps
-        q r Hq Hr ε (d; l) c).
-Defined.
-
-Fixpoint mkCohReflRestrPaintingsBelowSup {p k}
-  (deps: DepsReflCohs2 p k)
-  (extraDeps: DepsReflCohs2Extension p k deps):
-  mkCohReflRestrPaintingBelowSupTypes
-    (mkDepsReflCohsSup deps)
-    (mkExtraDepsReflCohsSup deps extraDeps).
-Proof.
-  destruct p.
-  - unshelve econstructor. now exact tt.
-    now apply mkCohReflRestrPaintingBelowSup.
-  - unshelve econstructor.
-    + now exact (mkCohReflRestrPaintingsBelowSup p k.+1
-        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
-    + now apply mkCohReflRestrPaintingBelowSup.
-Defined.
-
 Definition mkCohReflReflLayerBelow {p k}
   (deps: DepsReflCohs2 p.+1 k)
   q r (Hq: q <= r) (Hr: r <= k)
@@ -1602,6 +1445,173 @@ Proof.
       * now exact (mkCohReflReflLayerAbove deps q r Hq Hr d l c h).
 Defined.
 
+Definition cohReflReflPaintingAboveL {p} (deps: DepsReflCohs2 p 0)
+  (L: HasRefl
+    (mkDepsReflCohsSup deps)
+    (mkPainting (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps))))): Type :=
+  mkCohReflReflPaintingAboveType
+    (mkDepsReflCohsSup deps)
+    (TopReflCohSupDep L)
+    (mkCohReflReflFramesAbove deps).
+
+Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
+| TopReflCoh2Dep {deps: DepsReflCohs2 p 0}
+  (L: HasRefl
+    (mkDepsReflCohsSup deps)
+    (mkPainting (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps)))))
+  (cohL: cohReflReflPaintingAboveL deps L):
+  DepsReflCohs2Extension p 0 deps
+| AddReflCoh2Dep {k} (deps: DepsReflCohs2 p.+1 k):
+  DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1)%depsreflcohs2.
+
+Arguments TopReflCoh2Dep {p deps}.
+Arguments AddReflCoh2Dep {p k}.
+
+Declare Scope extra_depsreflcohs2_scope.
+Delimit Scope extra_depsreflcohs2_scope with extradepsreflcohs2.
+Bind Scope extra_depsreflcohs2_scope with DepsReflCohs2Extension.
+Notation "( x ; y )" := (AddReflCoh2Dep x y)
+  (at level 0, format "( x ; y )"): extra_depsreflcohs2_scope.
+
+Fixpoint mkExtraDepsReflCohsSup {p k} (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  DepsReflCohsSupExtension p.+1 k (mkDepsReflCohsSup deps).
+Proof.
+  destruct extraDeps.
+  - now apply TopReflCohSupDep.
+  - apply (AddReflCohSupDep (mkDepsReflCohsSup deps)).
+    now exact (mkExtraDepsReflCohsSup p.+1 k deps extraDeps).
+Defined.
+
+Fixpoint mkCohReflRestrPaintingBelowInf {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflRestrPaintingBelowInfType
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
+Proof.
+  intros q r Hq Hr ε d [l c].
+  destruct r.
+  - now trivial.
+  - destruct q; [now contradiction |].
+    destruct extraDeps; [now contradiction |].
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1))))).
+    + now exact (mkCohReflRestrLayerBelowInf deps ε q r (⇓ Hq) (⇓ Hr) d l
+        (mkCohReflRestrFramesBelowInf deps.(1))).
+    + now exact (mkCohReflRestrPaintingBelowInf p.+1 k deps extraDeps
+        q r Hq Hr ε (d; l) c).
+Defined.
+
+Fixpoint mkCohReflRestrPaintingsBelowInf {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflRestrPaintingBelowInfTypes
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflRestrPaintingBelowInf.
+  - unshelve econstructor.
+    + now exact (mkCohReflRestrPaintingsBelowInf p k.+1
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
+    + now apply mkCohReflRestrPaintingBelowInf.
+Defined.
+
+Fixpoint mkCohReflRestrPaintingAboveSup {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflRestrPaintingAboveSupType
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
+Proof.
+  intros q r Hq Hr ε d [l c].
+  destruct r.
+  - now trivial.
+  - destruct extraDeps; [now contradiction |].
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
+    + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l c
+        (mkCohReflRestrFramesAboveSup deps.(1))).
+    + now exact (mkCohReflRestrPaintingAboveSup p.+1 k deps extraDeps
+        q.+1 r (⇑ Hq) Hr ε (d; l) c).
+Defined.
+
+Fixpoint mkCohReflRestrPaintingsAboveSup {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflRestrPaintingAboveSupTypes
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflRestrPaintingAboveSup.
+  - unshelve econstructor.
+    + now exact (mkCohReflRestrPaintingsAboveSup p k.+1
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
+    + now apply mkCohReflRestrPaintingAboveSup.
+Defined.
+
+Fixpoint mkCohReflRestrPaintingBelowSup {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflRestrPaintingBelowSupType
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
+Proof.
+  intros q r Hq Hr ε d [l c].
+  destruct q.
+  - unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
+    + apply functional_extensionality_dep.
+      intro θ.
+      unfold mkRestrLayer.
+      rewrite <- map_subst_app, <- !map_subst.
+      set (deps' := (mkDepsRestr (CohsOfReflCohs2 deps))).
+      rewrite rew_map with
+        (P := fun b => deps'.(_paintings).2 b)
+        (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+      rewrite rew_map with
+        (P := fun b => deps'.(_paintings).2 b)
+        (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+      rewrite 2 rew_compose.
+      apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+      rewrite rew_app_rl. now trivial.
+      now apply (deps'.(_frames).2.(UIP)).
+    + destruct p.
+      * rewrite <- (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
+        destruct d.
+        enough (h : (=eq_refl; _) = eq_refl) by (now rewrite h).
+        now apply (mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
+      * now exact (mkCohReflRestrPaintingAboveSup deps extraDeps 0 r leR_O Hr ε d (l; c)).
+  - destruct r; [now contradiction |].
+    destruct extraDeps; [now contradiction |].
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1))))).
+    + now exact (mkCohReflRestrLayerBelowSup deps ε q r (⇓ Hq) (⇓ Hr) d l
+        (mkCohReflRestrFramesBelowSup deps.(1))).
+    + now exact (mkCohReflRestrPaintingBelowSup p.+1 k deps extraDeps
+        q r Hq Hr ε (d; l) c).
+Defined.
+
+Fixpoint mkCohReflRestrPaintingsBelowSup {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflRestrPaintingBelowSupTypes
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflRestrPaintingBelowSup.
+  - unshelve econstructor.
+    + now exact (mkCohReflRestrPaintingsBelowSup p k.+1
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
+    + now apply mkCohReflRestrPaintingBelowSup.
+Defined.
+
 Fixpoint mkCohReflReflPaintingAbove {p k} (deps: DepsReflCohs2 p k)
   (extraDeps: DepsReflCohs2Extension p k deps):
   mkCohReflReflPaintingAboveType
@@ -1610,42 +1620,51 @@ Fixpoint mkCohReflReflPaintingAbove {p k} (deps: DepsReflCohs2 p k)
     (mkCohReflReflFramesAbove deps).
 Proof.
   intros q r Hq Hr d c.
+  destruct extraDeps.
+  now apply cohL.
   destruct r.
-  - unshelve eapply (eq_existT_curried_dep (Q := mkPainting
-      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps))))).
+  - destruct c as [l c].
+    unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)))))).
     + apply functional_extensionality_dep; intro θ.
       unfold mkReflLayerAbove, mkReflPaintingBelow1.
       rewrite <- map_subst_app.
-      set (deps' := mkExtraDeps (CohsExtOfReflCohsSup deps.(_depsReflCohsSup))).
+      set (deps' := mkExtraDeps (CohsExtOfReflCohs2 deps.(1))).
       apply rew_swap with (P := fun b => mkPainting deps' b).
       rewrite rew_map with
         (P := fun b => mkPainting deps' b)
         (f := fun x => (mkDepsRestr (CohsOfReflCohsInf
-          (mkDepsReflCohsSup deps).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
+          (mkDepsReflCohsSup deps.(1)).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
       rewrite 2 rew_compose.
-      simpl.
       eassert (id_pair_eq : (_;_) = (_;_)).
       { unshelve eapply eq_existT_curried.
-        - exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
-        - exact (mkIdReflRestrPaintingBelow deps.(_depsReflCohsSup)
-            deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
+        - exact (mkIdReflRestrFrameBelow (ReflCohsInfOfReflCohs2 deps.(1)) 0 leR_O θ d).
+        - exact (mkIdReflRestrPaintingBelow deps.(1).(_depsReflCohsSup)
+            deps.(1).(_extraDepsReflCohsSup) 0 leR_O θ d (l; c)). }
+      unfold mkDepsReflCohsSup, mkReflPaintingsAbove.
+      cbn [_reflPaintingsAbove projT2].
       rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
-        deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) q Hq x.1 x.2) id_pair_eq tt).
+        deps.(1).(_depsReflCohsSup) deps.(1).(_extraDepsReflCohsSup)
+        q Hq x.1 x.2) id_pair_eq tt).
       rewrite rew_map with
         (P := fun b => mkPainting deps' b)
-        (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 q Hq x.1 x.2).
+        (f := fun x => (mkReflFramesAbove deps.(1).(_depsReflCohsSup)).2 q Hq x.1 x.2).
       apply rew_swap with (P := fun b => mkPainting deps' b).
       rewrite rew_app_rl. now trivial.
       now apply (mkFrame _).(UIP).
-    + admit.
-  - destruct extraDeps; [now contradiction |].
-    destruct c as [l c].
+    + lazymatch goal with
+      | |- rew [?P'] ?H' in ?X = ?Y =>
+        set (P := P'); set (H := H')
+      end.
+      admit.
+  - destruct c as [l c].
+    destruct extraDeps; [now contradiction |].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting
       (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)))))).
     + now exact (mkCohReflReflLayerAbove deps q r Hq Hr d l c
         (mkCohReflReflFramesAbove deps.(1)%depsreflcohs2)).
     + now exact (mkCohReflReflPaintingAbove p.+1 k deps extraDeps
-        q.+1 r Hq Hr (d; l) c). 
+        q.+1 r Hq Hr (d; l) c).
 Admitted.
 
 Fixpoint mkCohReflReflPaintingsAbove {p k}

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1296,11 +1296,8 @@ Proof.
     + now trivial.
   - destruct extraDeps; try contradiction.
     destruct c as [l' c].
-    set (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps))).
-    replace
-      (fun x => (mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps.(1))) x).(Dom)) with
-      (fun x => {a &T Q (x; a)}) by reflexivity.
-    unshelve eapply (eq_existT_curried_dep (Q := Q)).
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting (RestrExtOfReflCohs2 (mkDepsReflCohs2 deps)))).
     + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c
         (mkCohReflRestrFramesAboveSup deps.(1))).
     + now exact (mkCohReflRestrPaintingAboveSup p.+1 k deps extraDeps

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -828,12 +828,8 @@ Definition CohsExtOfReflCohs3 {p k}
 Definition mkCohReflRestrLayerBelowInf {p k}
   (deps: DepsReflCohs3 p.+1 k)
   (ε: arity) q r (Hq: q <= k) (Hr: r <= q)
-  (d: mkFrame (((toDepsReflBelow
-    (mkDepsCohs (Cohs2OfReflCohs3 deps))
-    (mkReflFramesBelow (ReflCohsOfReflCohs3 deps)))).(_depsRestr).(1).(1)))
-  (l: mkLayer (toDepsReflBelow
-    (mkDepsCohs (Cohs2OfReflCohs3 deps))
-    (mkReflFramesBelow (ReflCohsOfReflCohs3 deps))).(_depsRestr).(1).(_restrFrames) d)
+  (d: mkFrame (mkDepsRestr (CohsOfReflCohs3 deps)).(1).(1))
+  (l: mkLayer (mkDepsRestr (CohsOfReflCohs3 deps)).(1).(_restrFrames) d)
   (prevCohReflRestrFrames:
     mkCohReflRestrFrameBelowInfTypes
       (mkDepsCohs (Cohs2OfReflCohs3 deps).(1))
@@ -921,11 +917,120 @@ Proof.
   - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
   - set (h := mkCohReflRestrFramesBelowInf p k.+1 deps.(1)%depsreflcohs3).
     unshelve econstructor.
-    + now apply h.
+    + now exact h.
     + intros q r Hq Hr ε [l c].
       unshelve eapply eq_existT_curried.
       * now exact (h.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) ε l).
       * now exact (mkCohReflRestrLayerBelowInf deps ε q r Hq Hr l c h).
+Defined.
+
+Instance mkDepsReflCohs {p k} (deps: DepsReflCohs3 p k): DepsReflCohs p.+1 k.
+Proof.
+  unshelve econstructor.
+  - unshelve econstructor.
+    + now exact (mkDepsCohs (Cohs2OfReflCohs3 deps)).
+    + now exact (mkExtraCohs deps.(_extraDepsCohs2)).
+    + now apply mkCohPaintings.
+  - now apply mkReflFramesBelow.
+  - now exact (mkReflPaintingsBelow _ deps.(_extraDepsReflCohs2)).
+  - now apply mkIdReflRestrFramesBelow.
+  - now apply mkReflFramesAbove.
+  - now apply mkIdReflRestrPaintingsBelow. 
+  - now apply mkCohReflRestrFramesBelowInf.
+Defined.
+
+Definition mkCohReflRestrLayerBelowSup {p k}
+  (deps: DepsReflCohs3 p.+1 k)
+  (ε: arity) q r (Hq: q <= r) (Hr: r <= k)
+  (d: mkFrame ((RestrOfReflCohs (mkDepsReflCohs deps)).(1).(1)))
+  (l: mkLayer (RestrOfReflCohs (mkDepsReflCohs deps)).(1).(_restrFrames) d)
+  (prevCohReflRestrFrames:
+    mkCohReflRestrFrameBelowSupTypes
+      (mkDepsReflCohs deps.(1)%depsreflcohs3)):
+  rew [mkLayer _] prevCohReflRestrFrames.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) ε d in
+  mkReflLayerBelow
+    (CohsOfReflCohs3 deps)
+    (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')
+    (ReflCohsOfReflCohs3 deps).(_reflPaintingsBelow) _
+    (ReflCohsOfReflCohs3 deps).(_cohReflRestrFramesBelowInf)
+    q (Hq ↕ Hr) _
+    (mkRestrLayer
+      (CohsOfReflCohs3 deps).(_restrPaintings)
+      (CohsOfReflCohs3 deps).(_cohs)
+      r Hr ε d l) =
+  mkRestrLayer
+    (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_restrPaintings)
+    (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_cohs)
+    r.+1 (⇑ Hr) ε _
+    (mkReflLayerBelow
+      (CohsOfReflCohs (mkDepsReflCohs deps).(1))
+      (mkDepsReflCohs deps).(1).(_reflFramesBelow')
+      (mkDepsReflCohs deps).(1).(_reflPaintingsBelow) _
+      (mkDepsReflCohs deps).(1).(_cohReflRestrFramesBelowInf)
+      q (Hq ↕ ↑ Hr) d l).
+Proof.
+  apply functional_extensionality_dep.
+  intros θ.
+  unfold mkRestrLayer, mkReflLayerBelow.
+  rewrite <- map_subst_app, <- !map_subst.
+
+  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs3 deps).(1)) 0 leR_O θ d).
+
+  assert (h :
+    (mkDepsCohs (Cohs2OfReflCohs3 deps)).(1).(_restrPaintings).2
+      r.+1 (⇑ Hr) ε
+      (mkReflFrameBelow (ReflCohsOfReflCohs3 deps).(1) q (Hq ↕ ↑ Hr) d0)
+      ((mkReflPaintingsBelow
+        deps.(_depsReflCohs2).(1)%depsreflcohs2
+        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2).2
+        q (Hq ↕ ↑ Hr) d0 (l θ)) =
+    mkRestrPainting (CohsExtOfReflCohs2 deps.(_depsReflCohs2).(1))
+      r.+1 (⇑ Hr) ε
+      ((mkDepsReflBelow (ReflCohsOfReflCohs3 deps).(1)).(_reflFramesBelow).2
+        q (Hq ↕ ↑ Hr) d0)
+      (mkReflPaintingBelow
+        deps.(_depsReflCohs2).(1)%depsreflcohs2
+        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2
+        q (Hq ↕ ↑ Hr) d0 (l θ)))
+  by reflexivity; rewrite h; clear h.
+
+  rewrite <- (deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε d0 (l θ)).
+  rewrite rew_map with
+    (P := fun b => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_paintings).2 b)
+    (f := fun x => (mkDepsRestr (CohsOfReflCohs3 deps).(1)).(_restrFrames).2
+      0 leR_O θ x).
+  rewrite rew_map with
+    (f := fun d1 =>
+      (toDepsReflBelow
+        (ReflCohsOfReflCohs3 deps).(_depsCohs2).(_depsCohs)
+        (ReflCohsOfReflCohs3 deps).(_reflFramesBelow')).(_reflFramesBelow).2
+        q (Hq ↕ Hr) d1).
+  rewrite rew_map with
+    (P := fun b =>
+      (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_paintings).2 b)
+    (f := fun d1 =>
+      (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_restrFrames).2
+        r.+1 (⇑ Hr) ε d1).
+  rewrite 4 rew_compose.
+  apply rew_swap with
+    (P := fun b =>
+      (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_paintings).2 b).
+  rewrite rew_app_rl. now trivial.
+  now apply (mkFrame (RestrOfReflCohs3 deps).(1)).(UIP).
+Defined.
+
+Fixpoint mkCohReflRestrFramesBelowSup {p k} (deps: DepsReflCohs3 p k):
+  mkCohReflRestrFrameBelowSupTypes (mkDepsReflCohs deps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
+  - set (h := mkCohReflRestrFramesBelowSup p k.+1 deps.(1)%depsreflcohs3).
+    unshelve econstructor.
+    + now exact h.
+    + intros q r Hq Hr ε [l c].
+      unshelve eapply eq_existT_curried.
+      * now exact (h.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) ε l).
+      * now exact (mkCohReflRestrLayerBelowSup deps ε q r Hq Hr l c h).
 Defined.
 
 (*

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1648,6 +1648,87 @@ Proof.
         q.+1 r Hq Hr (d; l) c). 
 Admitted.
 
+Fixpoint mkCohReflReflPaintingsAbove {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflReflPaintingAboveTypes
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps)
+    (mkCohReflReflFramesAbove deps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflReflPaintingAbove.
+  - unshelve econstructor.
+    + now exact (mkCohReflReflPaintingsAbove p k.+1
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
+    + now apply mkCohReflReflPaintingAbove.
+Defined.
+
+Fixpoint mkCohReflReflPaintingBelow {p k} (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflReflPaintingBelowType
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps)
+    (mkCohReflReflFramesBelow deps).
+Proof.
+  intros q r Hq Hr d c.
+  destruct q.
+  - unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps).(1))))).
+    + apply functional_extensionality_dep; intro θ.
+      unfold mkReflPaintingBelow1, mkReflLayerBelow.
+      rewrite <- map_subst_app, <- !map_subst.
+      set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1))). 
+      rewrite rew_map with
+        (P := fun b => deps'.(_paintings).2 b)
+        (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+      rewrite rew_map with
+        (P := fun b =>
+          PaintingBase _ (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) b)
+        (f := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r (⇑ Hr) d0).
+      rewrite 2 rew_compose.
+      apply rew_swap with (P := fun b =>
+        PaintingBase _ (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) b).
+      rewrite rew_app_rl. now trivial.
+      now apply (FrameBase (RestrOfReflCohsSup (mkDepsReflCohsSup deps))).(UIP).
+    + destruct p.
+      * simpl.
+        set (h := mkCohReflReflPaintingAbove deps extraDeps 0 r leR_O Hr d c).
+        unfold mkReflLayerAbove, mkReflPaintingBelow in h; simpl in h.
+        rewrite <- h; clear h.
+        destruct d.
+        enough (h: (=eq_refl; _) = eq_refl) by (now rewrite h).
+        now apply (mkFrame (mkDepsRestr (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1))).(UIP).
+      * now exact (mkCohReflReflPaintingAbove deps extraDeps 0 r leR_O Hr d c).
+  - destruct r; [now contradiction |].
+    destruct extraDeps; [now contradiction |].
+    destruct c as [l c].
+    unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+      (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)).(1))))).
+    + now exact (mkCohReflReflLayerBelow deps q r Hq Hr d l
+        (mkCohReflReflFramesBelow deps.(1)%depsreflcohs2)).
+    + now exact (mkCohReflReflPaintingBelow p.+1 k deps extraDeps
+        q r Hq Hr (d; l) c).
+Defined.
+
+Fixpoint mkCohReflReflPaintingsBelow {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkCohReflReflPaintingBelowTypes
+    (mkDepsReflCohsSup deps)
+    (mkExtraDepsReflCohsSup deps extraDeps)
+    (mkCohReflReflFramesBelow deps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now apply mkCohReflReflPaintingBelow.
+  - unshelve econstructor.
+    + now exact (mkCohReflReflPaintingsBelow p k.+1
+        deps.(1)%depsreflcohs2 (deps; extraDeps)%extradepsreflcohs2).
+    + now apply mkCohReflReflPaintingBelow.
+Defined.
+
 (*
 Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=
   toDepsRestr C.(restrFrames).

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1088,7 +1088,44 @@ Proof.
   by reflexivity; rewrite h; clear h.
 
   rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r (⇓ Hq) Hr ε d0 c0).
-  Fail rewrite <- ((Cohs2OfReflCohs3 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; (l'; c))).
+
+  set (D := { d1 :
+    (Cohs2OfReflCohs3 deps).(_depsCohs).(_deps).(_frames).2 &T
+    (Cohs2OfReflCohs3 deps).(_depsCohs).(_deps).(_paintings).2 d1 }).
+  set (x0 := (
+    (CohsOfReflCohs2 deps.(_depsReflCohs2)).(_deps).(_restrFrames).2
+      r Hr ε d0;
+    (CohsOfReflCohs2 deps.(_depsReflCohs2)).(_restrPaintings).2
+      r Hr ε d0 c0) : D).
+  set (xr := (
+    (CohsOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_deps).(_restrFrames).2
+      0 leR_O θ
+      ((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+        r Hr ε (d; l)).1;
+    (CohsOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_restrPaintings).2
+      0 leR_O θ
+      ((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+        r Hr ε (d; l)).1
+      (((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+          r Hr ε (d; l)).2;
+       (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings).2
+         r Hr ε (d; l) (l'; c))) : D).
+  set (Q := fun x : D =>
+    mkPainting (AboveOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_extraDeps)
+      ((AboveOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_reflFramesAbove').2
+        q (⇓ Hq) x.1 x.2)).
+  assert (pair_eq : x0 = xr).
+  { unfold x0, xr.
+    unshelve eapply eq_existT_curried.
+    now exact ((CohsOfReflCohs3 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
+    now exact ((Cohs2OfReflCohs3 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; (l'; c))). }
+  assert (map_pair_eq :
+    rew [Q] pair_eq in
+      deps.(_depsReflCohs2).(_reflPaintingsAbove).2 q (⇓ Hq) x0.1 x0.2 =
+    deps.(_depsReflCohs2).(_reflPaintingsAbove).2 q (⇓ Hq) xr.1 xr.2).
+  { now exact (map_subst (P := fun _ : D => unit) (Q := Q) (fun x _ =>
+      deps.(_depsReflCohs2).(_reflPaintingsAbove).2 q (⇓ Hq) x.1 x.2) pair_eq tt). }
+  rewrite <- map_pair_eq.
 
   rewrite rew_map with
     (P := fun b =>
@@ -1102,20 +1139,17 @@ Proof.
     (f := fun d1 =>
       (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
         r Hr ε d1).
-  rewrite 3 rew_compose.
+  rewrite rew_map with
+    (P := fun x => mkPainting (RestrExtOfReflCohs2 deps.(_depsReflCohs2)) x)
+    (f := fun x : D =>
+      (AboveOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs)).(_reflFramesAbove').2
+        q (⇓ Hq) x.1 x.2).
+  rewrite 4 rew_compose.
   apply rew_swap with
     (P := fun x => mkPainting (RestrExtOfReflCohs2 deps.(_depsReflCohs2)) x).
-
-  lazymatch goal with
-  | |- ?e2 = rew <- [?P1] ?H1 in rew [?P2] ?H2 in ?e1 => 
-    set (H := H1); set (H' := H2)
-  end.
-
-  unfold d0, c0.
-
-  Fail rewrite rew_app_rl.
-  admit.
-Admitted.
+  rewrite rew_app_rl. now trivial.
+  now apply (mkFrame (RestrOfReflCohs2 deps.(_depsReflCohs2))).(UIP).
+Defined.
 
 Fixpoint mkCohReflRestrFramesAboveSup {p k} (deps: DepsReflCohs3 p k):
   mkCohReflRestrFrameAboveSupTypes

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1032,6 +1032,115 @@ Proof.
       * now exact (mkCohReflRestrLayerBelowSup deps ε q r Hq Hr l c h).
 Defined.
 
+Definition mkCohReflRestrLayerAboveSup {p k}
+  (deps: DepsReflCohs3 p.+1 k)
+  (ε: arity) q r (Hq: q.+1 <= p.+1) (Hr: r <= k)
+  (d: mkFrame ((RestrOfReflCohs (mkDepsReflCohs deps)).(1).(1)))
+  (l: mkLayer (RestrOfReflCohs (mkDepsReflCohs deps)).(1).(_restrFrames) d)
+  (l': mkLayer (RestrOfReflCohs (mkDepsReflCohs deps)).(_restrFrames) (d; l))
+  (c: mkPainting (RestrExtOfReflCohs (mkDepsReflCohs deps)) ((d; l); l'))
+  (prevCohReflRestrFrames:
+    mkCohReflRestrFrameAboveSupTypes
+      (mkDepsReflCohs deps.(1)%depsreflcohs3)
+      (mkReflPaintingsAbove deps.(1).(_depsReflCohs2)
+        deps.(1).(_extraDepsReflCohs2))):
+  rew [mkLayer _] prevCohReflRestrFrames.2 q r.+1 Hq (⇑ Hr) ε d (l; (l'; c)) in
+  mkReflLayerAbove deps.(_depsReflCohs2).(_depsReflCohs)
+    deps.(_depsReflCohs2).(_reflPaintingsAbove) _
+    deps.(_depsReflCohs2).(_cohReflRestrFramesAboveSup)
+    q (⇓ Hq)
+    ((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).1
+    (((CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).2;
+     (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings).2 r Hr ε (d; l) (l'; c)) =
+  mkRestrLayer
+    (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings)
+    (CohsOfReflCohs (mkDepsReflCohs deps)).(_cohs)
+    r Hr ε _
+    (mkReflLayerAbove (mkDepsReflCohs deps).(1)
+      (mkReflPaintingsAbove deps.(1).(_depsReflCohs2) deps.(1).(_extraDepsReflCohs2)) _
+      prevCohReflRestrFrames
+      q (⇓ Hq) d (l; (l'; c))).
+Proof.
+  apply functional_extensionality_dep.
+  intros θ.
+  unfold mkRestrLayer, mkReflLayerAbove.
+  rewrite <- map_subst_app, <- !map_subst.
+
+  set (d0 := (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_deps).(_restrFrames).2
+    0 leR_O θ d).
+  set (c0 := (CohsOfReflCohs (mkDepsReflCohs deps).(1)).(_restrPaintings).2
+    0 leR_O θ d (l; (l'; c))).
+
+  assert (h :
+    (CohsOfReflCohs (mkDepsReflCohs deps)).(_restrPaintings).2 r Hr ε
+      ((AboveOfReflCohs (mkDepsReflCohs deps).(1)).(_reflFramesAbove').2
+        q (⇓ Hq) d0 c0)
+      ((mkReflPaintingsAbove
+        deps.(1).(_depsReflCohs2)
+        deps.(1).(_extraDepsReflCohs2)).2 q (⇓ Hq) d0 c0) =
+    mkRestrPainting (CohsExtOfReflCohs2 deps.(_depsReflCohs2))
+      r Hr ε
+      (mkReflFrameAbove deps.(_depsReflCohs2).(1) q (⇓ Hq) d0 c0)
+      (mkReflPaintingAbove
+        deps.(_depsReflCohs2).(1)%depsreflcohs2
+        (deps.(_depsReflCohs2); deps.(_extraDepsReflCohs2))%extradepsreflcohs2
+        q (⇓ Hq) d0 c0))
+  by reflexivity; rewrite h; clear h.
+
+  rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r (⇓ Hq) Hr ε d0 c0).
+  rewrite rew_map with
+    (P := fun b =>
+      (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_paintings).2 b)
+    (f := fun x => (mkDepsRestr
+      (CohsOfReflCohs deps.(_depsReflCohs2).(_depsReflCohs))).(_restrFrames).2
+      0 leR_O θ x).
+  rewrite rew_map with
+    (P := fun b =>
+      (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_paintings).2 b)
+    (f := fun d1 =>
+      (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps).(_restrFrames).2
+        r Hr ε d1).
+  rewrite 3 rew_compose.
+  apply rew_swap with
+    (P := fun x => mkPainting (RestrExtOfReflCohs2 deps.(_depsReflCohs2)) x).
+
+  Fail rewrite rew_app_rl.
+  admit.
+Admitted.
+
+Fixpoint mkCohReflRestrFramesAboveSup {p k} (deps: DepsReflCohs3 p k):
+  mkCohReflRestrFrameAboveSupTypes
+    (mkDepsReflCohs deps)
+    (mkReflPaintingsAbove deps.(_depsReflCohs2) deps.(_extraDepsReflCohs2)).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
+  - set (h := mkCohReflRestrFramesAboveSup p k.+1 deps.(1)%depsreflcohs3).
+    unshelve econstructor. now exact h.
+    intros q r Hq Hr ε [d l] [l' c].
+    destruct q.
+    + unshelve eapply eq_existT_curried.
+      * exact ((mkCohReflRestrFramesBelowSup deps).2 0 r leR_O Hr ε (d; l)).
+      * apply functional_extensionality_dep.
+        intro θ.
+        unfold mkRestrLayer.
+        rewrite <- map_subst_app, <- !map_subst.
+        set (deps' := (CohsOfReflCohs (mkDepsReflCohs deps)).(_deps)).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
+        rewrite rew_map with
+          (P := fun b => deps'.(_paintings).2 b)
+          (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+        rewrite 2 rew_compose.
+        apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
+        rewrite rew_app_rl. now trivial.
+        now apply (deps'.(_frames).2.(UIP)).
+    + unshelve eapply eq_existT_curried.
+      * now exact (h.2 q r.+1 Hq (⇑ Hr) ε d (l; (l'; c))).
+      * now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c h).
+Defined.
+
 (*
 Instance mkDepsReflCohs {p k} (deps: DepsReflCohs2 p k): DepsReflCohs p.+1 k.
 Proof.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -315,16 +315,15 @@ Proof.
   rewrite <- (deps.(_idReflRestrPaintingsBelow).2 i Hi ε _ (l θ)).
   rewrite <- map_subst_app, <- map_subst.
   unfold toDepsReflBelow, PaintingPrev, FramePrev, RestrOfReflCohs, mkFrame; simpl.
+  set (deps' := deps.(_depsCohs2).(_depsCohs).(_deps)).
   rewrite rew_map with
-    (P := fun x => deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x)
-    (f := fun x => (deps.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).2 0 leR_O θ x)).
+    (P := fun x => deps'.(_paintings).2 x)
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
   rewrite rew_map with
-    (P := fun x => deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x)
-    (f := fun x => ((deps.(_depsCohs2).(_depsCohs).(_deps).(
-      _restrFrames).2 i Hi ε x))).
+    (P := fun x => deps'.(_paintings).2 x)
+    (f := fun x => deps'.(_restrFrames).2 i Hi ε x).
   rewrite 2 rew_compose.
-  apply rew_swap with (P := fun x =>
-    deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x).
+  apply rew_swap with (P := fun x => deps'.(_paintings).2 x).
   rewrite rew_app_rl. now trivial.
   now apply (RestrOfReflCohs deps).(_frames).2.(UIP).
 Defined.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1377,6 +1377,141 @@ Proof.
     + now apply mkCohReflRestrPaintingBelowSup.
 Defined.
 
+Definition mkCohReflReflFrameBelowType {p k}
+  (deps: DepsReflCohsInf p.+1 k): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= k) (d: FramePrev (RestrOfReflCohsInf deps)),
+  (mkReflFrameBelow deps.(1) q (Hq ↕ ↑ Hr) (deps.(_reflFramesBelow').2 r Hr d)) =
+  (mkReflFrameBelow deps.(1) r.+1 (⇑ Hr) (deps.(_reflFramesBelow').2 q (Hq ↕ Hr) d)).
+
+Fixpoint mkCohReflReflFrameBelowTypes {p}:
+  forall {k} (deps: DepsReflCohsInf p k), Type :=
+  match p with
+  | 0 => fun _ _ => unit
+  | S p =>
+    fun k deps =>
+    { _: mkCohReflReflFrameBelowTypes deps.(1) &T
+      mkCohReflReflFrameBelowType deps }
+  end.
+
+Definition mkCohReflReflPaintingBelowType {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  (cohReflReflFramesBelow :
+    mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps)): Type :=
+  forall q r (Hq: q <= r) (Hr: r <= k)
+    (d: FramePrev (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)))
+    (c: PaintingPrev (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)) d),
+  rew [PaintingBase
+    (mkDepsRestr (CohsOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))
+    (mkExtraDeps (CohsExtOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))]
+    cohReflReflFramesBelow.2 q r Hq Hr d in
+  mkReflPaintingBelow
+    deps.(_depsReflCohsSup).(1)%depsreflcohssup
+    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
+    q (Hq ↕ ↑ Hr)
+    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d)
+    ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d c) =
+  mkReflPaintingBelow
+    deps.(_depsReflCohsSup).(1)%depsreflcohssup
+    (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
+    r.+1 (⇑ Hr)
+    ((ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q (Hq ↕ Hr) d)
+    ((ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 q (Hq ↕ Hr) d c).
+
+Fixpoint mkCohReflReflPaintingBelowTypes {p}:
+  forall {k} (deps: DepsReflCohs2 p k)
+    (cohReflReflFramesBelow :
+      mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps)), Type :=
+  match p with
+  | 0 => fun _ _ _ => unit
+  | S p =>
+    fun k deps cohReflReflFramesBelow =>
+    { _: mkCohReflReflPaintingBelowTypes deps.(1) cohReflReflFramesBelow.1 &T
+      mkCohReflReflPaintingBelowType deps cohReflReflFramesBelow }
+  end.
+
+Definition mkCohReflReflLayerBelow {p k}
+  (deps: DepsReflCohs2 p.+1 k)
+  (cohReflReflFramesBelow:
+    mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps))
+  (cohReflReflPaintingsBelow:
+    mkCohReflReflPaintingBelowTypes deps cohReflReflFramesBelow)
+  q r (Hq: q <= r) (Hr: r <= k)
+  (d: mkFrame (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps).(1)))
+  (l: mkLayer (RestrOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)).(_restrFrames) d)
+  (prevCohReflReflFrames:
+    mkCohReflReflFrameBelowTypes (mkDepsReflCohsInf deps.(1)%depsreflcohs2)):
+  rew [mkLayer _] prevCohReflReflFrames.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) d in
+  mkReflLayerBelow
+    (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))
+    (mkDepsReflCohsInf deps).(1).(_reflFramesBelow')
+    (mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow) _
+    (mkDepsReflCohsInf deps).(1).(_cohReflRestrFramesBelowInf)
+    q (Hq ↕ ↑ Hr) _
+    (mkReflLayerBelow
+      (CohsOfReflCohsInf (ReflCohsInfOfReflCohs2 deps))
+      (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')
+      (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow) _
+      (ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf)
+      r Hr d l) =
+  mkReflLayerBelow
+    (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))
+    (mkDepsReflCohsInf deps).(1).(_reflFramesBelow')
+    (mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow) _
+    (mkDepsReflCohsInf deps).(1).(_cohReflRestrFramesBelowInf)
+    r.+1 (⇑ Hr) _
+    (mkReflLayerBelow
+      (CohsOfReflCohsInf (ReflCohsInfOfReflCohs2 deps))
+      (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')
+      (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow) _
+      (ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf)
+      q (Hq ↕ Hr) d l).
+Proof.
+  apply functional_extensionality_dep.
+  intro θ.
+  unfold mkReflLayerBelow.
+  rewrite <- map_subst_app, <- !map_subst.
+  set (d0 := (CohsOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)).(_deps)
+    .(_restrFrames).2 0 leR_O θ d).
+  set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))).
+  set (deps'' := (toDepsReflBelow
+    (mkDepsReflCohsInf deps).(1).(_depsCohs2).(_depsCohs)
+    (mkDepsReflCohsInf deps).(1).(_reflFramesBelow'))).
+  simpl.
+  rewrite <- (cohReflReflPaintingsBelow.2 q r Hq Hr d0 (l θ)).
+  rewrite rew_map with
+    (P := fun b => deps'.(1).(_paintings).2 b)
+    (f := fun x => deps'.(1).(_restrFrames).2 0 leR_O θ x).
+  rewrite rew_map with
+    (P := fun b => deps'.(1).(_paintings).2 b)
+    (f := fun d0 => deps''.(_reflFramesBelow).2 q (Hq ↕ ↑ Hr) d0).
+  rewrite rew_map with
+    (P := fun b => deps'.(1).(_paintings).2 b)
+    (f := fun d1 => deps''.(_reflFramesBelow).2 r.+1 (⇑ Hr) d1).
+  rewrite 4 rew_compose.
+  apply rew_swap with (P := fun b => deps'.(1).(_paintings).2 b).
+  rewrite rew_app_rl. now trivial.
+  now apply (deps'.(1).(_frames).2.(UIP)).
+Defined.
+
+Fixpoint mkCohReflReflFramesBelow {p k} (deps: DepsReflCohs2 p k)
+  (cohReflReflFramesBelow: mkCohReflReflFrameBelowTypes (ReflCohsInfOfReflCohs2 deps))
+  (cohReflReflPaintingsBelow: mkCohReflReflPaintingBelowTypes deps cohReflReflFramesBelow):
+  mkCohReflReflFrameBelowTypes (mkDepsReflCohsInf deps).
+Proof.
+  destruct p.
+  - unshelve econstructor. now exact tt.
+    now intros q r Hq Hr [].
+  - set (h := mkCohReflReflFramesBelow p k.+1 deps.(1)%depsreflcohs2
+      cohReflReflFramesBelow.1 cohReflReflPaintingsBelow.1).
+    unshelve econstructor.
+    + now exact h.
+    + intros q r Hq Hr [d l].
+      unshelve eapply eq_existT_curried.
+      * now exact (h.2 q.+1 r.+1 (⇑ Hq) (⇑ Hr) d).
+      * now exact (mkCohReflReflLayerBelow deps cohReflReflFramesBelow
+          cohReflReflPaintingsBelow q r Hq Hr d l h).
+Defined.
+
 (*
 Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=
   toDepsRestr C.(restrFrames).

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -469,6 +469,8 @@ Definition mkCohReflRestrFrameAboveSupTypes {p k}
 
 Class DepsReflCohs2 p k := {
   _depsReflCohs: DepsReflCohs p k;
+  _cohReflRestrFramesBelowSup:
+    mkCohReflRestrFrameBelowSupTypes _depsReflCohs;
   _reflPaintingsAbove: mkReflPaintingAboveTypes (AboveOfReflCohs _depsReflCohs);
   _cohReflRestrFramesAboveSup:
     mkCohReflRestrFrameAboveSupTypes _depsReflCohs _reflPaintingsAbove;
@@ -479,6 +481,7 @@ Instance proj1DepsReflCohs2 {p k} (depsCohs2: DepsReflCohs2 p.+1 k):
   DepsReflCohs2 p k.+1 :=
 {|
   _depsReflCohs := depsCohs2.(_depsReflCohs).(1)%depsreflcohs;
+  _cohReflRestrFramesBelowSup := depsCohs2.(_cohReflRestrFramesBelowSup).1;
   _reflPaintingsAbove := depsCohs2.(_reflPaintingsAbove).1;
   _cohReflRestrFramesAboveSup := depsCohs2.(_cohReflRestrFramesAboveSup).1;
 |}.
@@ -759,13 +762,11 @@ Class DepsReflCohs3 p k := {
   _depsReflCohs2: DepsReflCohs2 p k;
   _extraDepsCohs2: DepsCohs2Extension p k (Cohs2OfReflCohs2 _depsReflCohs2);
   _extraDepsReflCohs2: DepsReflCohs2Extension p k _depsReflCohs2;
-  _cohReflRestrFramesBelowSup:
-    mkCohReflRestrFrameBelowSupTypes _depsReflCohs2.(_depsReflCohs);
   _cohReflRestrPaintingsBelowInf:
     mkCohReflRestrPaintingBelowInfTypes _depsReflCohs2 _extraDepsReflCohs2;
   _cohReflRestrPaintingsBelowSup:
     mkCohReflRestrPaintingBelowSupTypes _depsReflCohs2 _extraDepsReflCohs2
-      _cohReflRestrFramesBelowSup;
+      _depsReflCohs2.(_cohReflRestrFramesBelowSup);
   _cohReflRestrPaintingsAboveSup:
     mkCohReflRestrPaintingAboveSupTypes _depsReflCohs2 _extraDepsReflCohs2;
 }.
@@ -779,8 +780,6 @@ DepsReflCohs3 p k.+1 :=
     depsCohs3.(_extraDepsCohs2));
   _extraDepsReflCohs2 := (depsCohs3.(_depsReflCohs2);
     depsCohs3.(_extraDepsReflCohs2));
-  _cohReflRestrFramesBelowSup :=
-    depsCohs3.(_cohReflRestrFramesBelowSup).1;
   _cohReflRestrPaintingsBelowInf :=
     depsCohs3.(_cohReflRestrPaintingsBelowInf).1;
   _cohReflRestrPaintingsBelowSup :=

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1061,29 +1061,29 @@ Definition mkCohReflRestrLayerAboveSup {p k}
   (ε: arity) q r (Hq: q.+1 <= p.+1) (Hr: r <= k)
   (d: mkFrame ((RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(1)))
   (l: mkLayer (RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(1).(_restrFrames) d)
-  (l': mkLayer (RestrOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrFrames) (d; l))
-  (c: mkPainting (RestrExtOfReflCohsInf (mkDepsReflCohsInf deps)) ((d; l); l'))
+  (c: mkPainting
+        (mkDepsRestr (CohsOfReflCohs2 deps); mkExtraDeps (CohsExtOfReflCohs2 deps))
+        (d; l))
   (prevCohReflRestrFrames:
     mkCohReflRestrFrameAboveSupTypes
       (mkDepsReflCohsInf deps.(1)%depsreflcohs2)
       (mkReflPaintingsAbove deps.(1).(_depsReflCohsSup)
         deps.(1).(_extraDepsReflCohsSup))):
-  rew [mkLayer _] prevCohReflRestrFrames.2 q r.+1 Hq (⇑ Hr) ε d (l; (l'; c)) in
+  rew [mkLayer _] prevCohReflRestrFrames.2 q r.+1 Hq (⇑ Hr) ε d (l; c) in
   mkReflLayerAbove deps.(_depsReflCohsSup).(_depsReflCohsInf)
     deps.(_depsReflCohsSup).(_reflPaintingsAbove) _
     deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup)
     q (⇓ Hq)
     ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).1
     (((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2 r Hr ε (d; l)).2;
-     (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε (d; l) (l'; c)) =
+     (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε (d; l) c) =
   mkRestrLayer
     (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings)
     (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_cohs)
     r Hr ε _
     (mkReflLayerAbove (mkDepsReflCohsInf deps).(1)
       (mkReflPaintingsAbove deps.(1).(_depsReflCohsSup) deps.(1).(_extraDepsReflCohsSup)) _
-      prevCohReflRestrFrames
-      q (⇓ Hq) d (l; (l'; c))).
+      prevCohReflRestrFrames q (⇓ Hq) d (l; c)).
 Proof.
   apply functional_extensionality_dep.
   intros θ.
@@ -1093,7 +1093,7 @@ Proof.
   set (d0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_restrFrames).2
     0 leR_O θ d).
   set (c0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
-    0 leR_O θ d (l; (l'; c))).
+    0 leR_O θ d (l; c)).
 
   assert (h :
     (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε
@@ -1133,7 +1133,7 @@ Proof.
       (((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
           r Hr ε (d; l)).2;
        (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2
-         r Hr ε (d; l) (l'; c))) : D).
+         r Hr ε (d; l) c)) : D).
   set (Q := fun x : D =>
     mkPainting (AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_extraDeps)
       ((AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_reflFramesAbove').2
@@ -1142,7 +1142,7 @@ Proof.
   { unfold x0, xr.
     unshelve eapply eq_existT_curried.
     now exact ((CohsOfReflCohs2 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
-    now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; (l'; c))). }
+    now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; c)). }
   assert (map_pair_eq :
     rew [Q] pair_eq in
       deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q (⇓ Hq) x0.1 x0.2 =
@@ -1184,7 +1184,7 @@ Proof.
   - unshelve econstructor. now exact tt. now intros q r Hq Hr ε [].
   - set (h := mkCohReflRestrFramesAboveSup p k.+1 deps.(1)%depsreflcohs2).
     unshelve econstructor. now exact h.
-    intros q r Hq Hr ε [d l] [l' c].
+    intros q r Hq Hr ε [d l] c.
     destruct q.
     + unshelve eapply eq_existT_curried.
       * now exact ((mkCohReflRestrFramesBelowSup deps).2 0 r leR_O Hr ε (d; l)).
@@ -1204,8 +1204,8 @@ Proof.
         rewrite rew_app_rl. now trivial.
         now apply (deps'.(_frames).2.(UIP)).
     + unshelve eapply eq_existT_curried.
-      * now exact (h.2 q r.+1 Hq (⇑ Hr) ε d (l; (l'; c))).
-      * now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c h).
+      * now exact (h.2 q r.+1 Hq (⇑ Hr) ε d (l; c)).
+      * now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l c h).
 Defined.
 
 Instance mkDepsReflCohsSup {p k} (deps: DepsReflCohs2 p k): DepsReflCohsSup p.+1 k.
@@ -1295,13 +1295,12 @@ Proof.
       now trivial.
     + now trivial.
   - destruct extraDeps; try contradiction.
-    destruct c as [l' c].
     unshelve eapply (eq_existT_curried_dep
       (Q := mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)))).
-    + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l l' c
+    + now exact (mkCohReflRestrLayerAboveSup deps ε q r Hq Hr d l c
         (mkCohReflRestrFramesAboveSup deps.(1))).
     + now exact (mkCohReflRestrPaintingAboveSup p.+1 k deps extraDeps
-        q.+1 r (⇑ Hq) Hr ε (d; l) (l'; c)).
+        q.+1 r (⇑ Hq) Hr ε (d; l) c).
 Defined.
 
 Fixpoint mkCohReflRestrPaintingsAboveSup {p k}

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1978,15 +1978,14 @@ Proof.
     + now apply mkCohReflBelowBelowPainting.
 Defined.
 
-(*
 Definition dgnDepsRestr {p} (C: νSetData p): DepsRestr p 0 :=
   toDepsRestr C.(restrFrames).
 
-Definition dgnDepsRefl {p} (C: νSetData p)
-  (reflFrames: mkReflFrameTypes (dgnDepsRestr C)): DepsReflBelow p 0 :=
+Definition dgnDepsReflBelow {p} (C: νSetData p)
+  (reflFramesBelow: mkReflFrameBelowTypes (dgnDepsRestr C)): DepsReflBelow p 0 :=
   {|
-    _deps := dgnDepsRestr C;
-    _reflFrames := reflFrames;
+    _depsRestr := dgnDepsRestr C;
+    _reflFramesBelow := reflFramesBelow;
   |}.
 
 Definition dgnDepsCohs {p} (C: νSetData p)
@@ -2009,74 +2008,298 @@ Definition dgnDepsCohs2 {p} (C: νSetData p)
 Definition dgnDepsReflCohsInf {p} (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
-  (reflFrames: mkReflFrameTypes (dgnDepsRestr C))
-  (reflPaintings: mkReflPaintingTypes
-    (dgnDepsRefl C reflFrames)
+  (reflFramesBelow: mkReflFrameBelowTypes (dgnDepsRestr C))
+  (reflFramesAbove: mkReflFrameAboveTypes (dgnDepsRestr C))
+  (reflPaintingsBelow: mkReflPaintingBelowTypes
+    (dgnDepsReflBelow C reflFramesBelow)
     (TopRestrDep (deps := dgnDepsRestr C) E))
-  (idReflRestrFrames: mkIdReflRestrFrameTypes (dgnDepsRefl C reflFrames))
-  (idReflRestrPaintings :
-    mkIdReflRestrPaintingTypes (dgnDepsCohs C E)
-      reflFrames reflPaintings idReflRestrFrames)
-  (cohRestrReflFrames :
-    mkCohReflRestrFrameTypes (dgnDepsCohs C E) reflFrames reflPaintings):
+  (idReflRestrFramesBelow:
+    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
+  (idReflRestrPaintingsBelow:
+    mkIdReflRestrPaintingBelowTypes (dgnDepsCohs C E)
+      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow)
+  (cohReflRestrFramesBelowInf:
+    mkCohReflRestrFrameBelowInfTypes
+      (dgnDepsCohs C E) reflFramesBelow reflPaintingsBelow):
   DepsReflCohsInf p 0 :=
   {|
     _depsCohs2 := dgnDepsCohs2 C E E';
-    _reflFrameDeps := reflFrames;
-    _reflPaintingDeps := reflPaintings;
-    _idReflRestrFrames := idReflRestrFrames;
-    _idReflRestrPaintings := idReflRestrPaintings;
-    _cohReflRestrFrames := cohRestrReflFrames;
+    _reflFramesBelow' := reflFramesBelow;
+    _reflFramesAbove := reflFramesAbove;
+    _reflPaintingsBelow := reflPaintingsBelow;
+    _idReflRestrFramesBelow := idReflRestrFramesBelow;
+    _idReflRestrPaintingsBelow := idReflRestrPaintingsBelow;
+    _cohReflRestrFramesBelowInf := cohReflRestrFramesBelowInf;
+  |}.
+
+Definition dgnDepsReflCohsSup {p} (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (reflFramesBelow: mkReflFrameBelowTypes (dgnDepsRestr C))
+  (reflFramesAbove: mkReflFrameAboveTypes (dgnDepsRestr C))
+  (reflPaintingsBelow: mkReflPaintingBelowTypes
+    (dgnDepsReflBelow C reflFramesBelow)
+    (TopRestrDep (deps := dgnDepsRestr C) E))
+  (idReflRestrFramesBelow:
+    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
+  (idReflRestrPaintingsBelow:
+    mkIdReflRestrPaintingBelowTypes (dgnDepsCohs C E)
+      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow)
+  (cohReflRestrFramesBelowInf:
+    mkCohReflRestrFrameBelowInfTypes
+      (dgnDepsCohs C E) reflFramesBelow reflPaintingsBelow)
+  (cohReflRestrFramesBelowSup:
+    mkCohReflRestrFrameBelowSupTypes
+      (dgnDepsReflCohsInf C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        cohReflRestrFramesBelowInf))
+  (reflPaintingsAbove:
+    mkReflPaintingAboveTypes
+      (AboveOfReflCohsInf
+        (dgnDepsReflCohsInf C E E'
+          reflFramesBelow reflFramesAbove reflPaintingsBelow
+          idReflRestrFramesBelow idReflRestrPaintingsBelow
+          cohReflRestrFramesBelowInf)))
+  (cohReflRestrFramesAboveSup:
+    mkCohReflRestrFrameAboveSupTypes
+      (dgnDepsReflCohsInf C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        cohReflRestrFramesBelowInf)
+      reflPaintingsAbove):
+  DepsReflCohsSup p 0 :=
+  {|
+    _depsReflCohsInf := dgnDepsReflCohsInf C E E'
+      reflFramesBelow reflFramesAbove reflPaintingsBelow
+      idReflRestrFramesBelow idReflRestrPaintingsBelow
+      cohReflRestrFramesBelowInf;
+    _cohReflRestrFramesBelowSup := cohReflRestrFramesBelowSup;
+    _reflPaintingsAbove := reflPaintingsAbove;
+    _cohReflRestrFramesAboveSup := cohReflRestrFramesAboveSup;
   |}.
 
 Definition dgnHasRefl {p} (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
-  (reflFrames: mkReflFrameTypes (dgnDepsRestr C))
-  (reflPaintings :
-    mkReflPaintingTypes
-      (dgnDepsRefl C reflFrames)
-      (TopRestrDep (deps := dgnDepsRestr C) E))
-  (idReflRestrFrames: mkIdReflRestrFrameTypes (dgnDepsRefl C reflFrames))
-  (idReflRestrPaintings :
-    mkIdReflRestrPaintingTypes (dgnDepsCohs C E)
-      reflFrames reflPaintings idReflRestrFrames)
-  (cohRestrReflFrames :
-    mkCohReflRestrFrameTypes (dgnDepsCohs C E)
-      reflFrames reflPaintings): Type :=
+  (reflFramesBelow: mkReflFrameBelowTypes (dgnDepsRestr C))
+  (reflFramesAbove: mkReflFrameAboveTypes (dgnDepsRestr C))
+  (reflPaintingsBelow: mkReflPaintingBelowTypes
+    (dgnDepsReflBelow C reflFramesBelow)
+    (TopRestrDep (deps := dgnDepsRestr C) E))
+  (idReflRestrFramesBelow:
+    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow))
+  (idReflRestrPaintingsBelow:
+    mkIdReflRestrPaintingBelowTypes (dgnDepsCohs C E)
+      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow)
+  (cohReflRestrFramesBelowInf:
+    mkCohReflRestrFrameBelowInfTypes
+      (dgnDepsCohs C E) reflFramesBelow reflPaintingsBelow)
+  (cohReflRestrFramesBelowSup:
+    mkCohReflRestrFrameBelowSupTypes
+      (dgnDepsReflCohsInf C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        cohReflRestrFramesBelowInf))
+  (reflPaintingsAbove:
+    mkReflPaintingAboveTypes
+      (AboveOfReflCohsInf
+        (dgnDepsReflCohsInf C E E'
+          reflFramesBelow reflFramesAbove reflPaintingsBelow
+          idReflRestrFramesBelow idReflRestrPaintingsBelow
+          cohReflRestrFramesBelowInf)))
+  (cohReflRestrFramesAboveSup:
+    mkCohReflRestrFrameAboveSupTypes
+      (dgnDepsReflCohsInf C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        cohReflRestrFramesBelowInf)
+      reflPaintingsAbove): Type :=
   HasRefl
-    (dgnDepsReflCohsInf C E E'
-      reflFrames reflPaintings
-      idReflRestrFrames idReflRestrPaintings
-      cohRestrReflFrames)
-    (mkPaintings
-      (mkExtraDeps
-        (CohsExtOfReflCohsInf
-          (dgnDepsReflCohsInf C E E'
-            reflFrames reflPaintings
-            idReflRestrFrames idReflRestrPaintings
-            cohRestrReflFrames)))).2.
+    (dgnDepsReflCohsSup C E E'
+      reflFramesBelow reflFramesAbove reflPaintingsBelow
+      idReflRestrFramesBelow idReflRestrPaintingsBelow
+      cohReflRestrFramesBelowInf
+      cohReflRestrFramesBelowSup
+      reflPaintingsAbove
+      cohReflRestrFramesAboveSup)
+    E'.
+
+Class DgnDataCore {p} (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet) := {
+  reflFramesBelow: mkReflFrameBelowTypes (dgnDepsRestr C);
+  reflFramesAbove: mkReflFrameAboveTypes (dgnDepsRestr C);
+  reflPaintingsBelow:
+    mkReflPaintingBelowTypes
+      (dgnDepsReflBelow C reflFramesBelow)
+      (TopRestrDep (deps := dgnDepsRestr C) E);
+  idReflRestrFramesBelow:
+    mkIdReflRestrFrameBelowTypes (dgnDepsReflBelow C reflFramesBelow);
+  idReflRestrPaintingsBelow:
+    mkIdReflRestrPaintingBelowTypes
+      (dgnDepsCohs C E)
+      reflFramesBelow reflPaintingsBelow idReflRestrFramesBelow;
+  cohReflRestrFramesBelowInf
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
+    mkCohReflRestrFrameBelowInfTypes
+      (dgnDepsCohs C E) reflFramesBelow reflPaintingsBelow;
+  cohReflRestrFramesBelowSup
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
+    mkCohReflRestrFrameBelowSupTypes
+      (dgnDepsReflCohsInf C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        (cohReflRestrFramesBelowInf E'));
+  reflPaintingsAbove
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
+    mkReflPaintingAboveTypes
+      (AboveOfReflCohsInf
+        (dgnDepsReflCohsInf C E E'
+          reflFramesBelow reflFramesAbove reflPaintingsBelow
+          idReflRestrFramesBelow idReflRestrPaintingsBelow
+          (cohReflRestrFramesBelowInf E')));
+  cohReflRestrFramesAboveSup
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
+    mkCohReflRestrFrameAboveSupTypes
+      (dgnDepsReflCohsInf C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        (cohReflRestrFramesBelowInf E'))
+      (reflPaintingsAbove E');
+  cohReflBelowBelowFrames
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
+    mkCohReflBelowBelowFrameTypes
+      (dgnDepsReflCohsInf C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        (cohReflRestrFramesBelowInf E'));
+  cohReflAboveBelowFrames
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
+    mkCohReflAboveBelowFrameTypes
+      (dgnDepsReflCohsSup C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        (cohReflRestrFramesBelowInf E')
+        (cohReflRestrFramesBelowSup E')
+        (reflPaintingsAbove E')
+        (cohReflRestrFramesAboveSup E'));
+  cohReflAboveAboveFrames
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
+    mkCohReflAboveAboveFrameTypes
+      (dgnDepsReflCohsSup C E E'
+        reflFramesBelow reflFramesAbove reflPaintingsBelow
+        idReflRestrFramesBelow idReflRestrPaintingsBelow
+        (cohReflRestrFramesBelowInf E')
+        (cohReflRestrFramesBelowSup E')
+        (reflPaintingsAbove E')
+        (cohReflRestrFramesAboveSup E'));
+}.
+
+Definition dgnDepsReflCohsInfFromBase {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (D: DgnDataCore C E): DepsReflCohsInf p 0 :=
+  dgnDepsReflCohsInf C E E'
+    D.(reflFramesBelow) D.(reflFramesAbove)
+    D.(reflPaintingsBelow)
+    D.(idReflRestrFramesBelow) D.(idReflRestrPaintingsBelow)
+    (D.(cohReflRestrFramesBelowInf) E').
+
+Definition dgnDepsReflCohsSupFromBase {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (D: DgnDataCore C E): DepsReflCohsSup p 0 :=
+  {|
+    _depsReflCohsInf := dgnDepsReflCohsInfFromBase C E E' D;
+    _cohReflRestrFramesBelowSup := D.(cohReflRestrFramesBelowSup) E';
+    _reflPaintingsAbove := D.(reflPaintingsAbove) E';
+    _cohReflRestrFramesAboveSup := D.(cohReflRestrFramesAboveSup) E';
+  |}.
+
+Definition dgnHasReflFromBase {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (D: DgnDataCore C E): Type :=
+  dgnHasRefl C E E'
+    D.(reflFramesBelow) D.(reflFramesAbove)
+    D.(reflPaintingsBelow)
+    D.(idReflRestrFramesBelow) D.(idReflRestrPaintingsBelow)
+    (D.(cohReflRestrFramesBelowInf) E')
+    (D.(cohReflRestrFramesBelowSup) E')
+    (D.(reflPaintingsAbove) E')
+    (D.(cohReflRestrFramesAboveSup) E').
+
+Definition dgnExtraDepsReflCohsSupFromBase {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (D: DgnDataCore C E)
+  (L: dgnHasReflFromBase C E E' D):
+  DepsReflCohsSupExtension p 0 (dgnDepsReflCohsSupFromBase C E E' D) :=
+  TopReflCohSupDep (deps := dgnDepsReflCohsSupFromBase C E E' D) L.
+
+Definition dgnCohLFromBase {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (D: DgnDataCore C E)
+  (L: dgnHasReflFromBase C E E' D): Type :=
+  mkCohReflAboveAbovePaintingTypes
+    (dgnDepsReflCohsSupFromBase C E E' D)
+    (dgnExtraDepsReflCohsSupFromBase C E E' D L)
+    (D.(cohReflAboveAboveFrames) E').
 
 Class DgnData {p} (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet) := {
-  reflFrames: mkReflFrameTypes (dgnDepsRestr C);
-  reflPaintings :
-    mkReflPaintingTypes
-      (dgnDepsRefl C reflFrames)
-      (TopRestrDep (deps := dgnDepsRestr C) E);
-  idReflRestrFrames: mkIdReflRestrFrameTypes (dgnDepsRefl C reflFrames);
-  idReflRestrPaintings :
-    mkIdReflRestrPaintingTypes
-      (dgnDepsCohs C E) reflFrames reflPaintings idReflRestrFrames;
-  cohRestrReflFrames (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet):
-    mkCohReflRestrFrameTypes (dgnDepsCohs C E) reflFrames reflPaintings;
-  cohReflRestrPaintings
+  dgnDataCore: DgnDataCore C E;
+  cohReflRestrPaintingsBelowInf
     (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
-    (L: dgnHasRefl C E E'
-      reflFrames reflPaintings
-      idReflRestrFrames idReflRestrPaintings
-      (cohRestrReflFrames E')):
-    mkCohReflRestrPaintingTypes _ (TopReflCohDep L);
+    (L: dgnHasReflFromBase C E E' dgnDataCore)
+    (cohL: dgnCohLFromBase C E E' dgnDataCore L):
+    mkCohReflRestrPaintingBelowInfTypes
+      (dgnDepsReflCohsSupFromBase C E E' dgnDataCore)
+      (dgnExtraDepsReflCohsSupFromBase C E E' dgnDataCore L);
+  cohReflRestrPaintingsBelowSup
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+    (L: dgnHasReflFromBase C E E' dgnDataCore)
+    (cohL: dgnCohLFromBase C E E' dgnDataCore L):
+    mkCohReflRestrPaintingBelowSupTypes
+      (dgnDepsReflCohsSupFromBase C E E' dgnDataCore)
+      (dgnExtraDepsReflCohsSupFromBase C E E' dgnDataCore L);
+  cohReflRestrPaintingsAboveSup
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+    (L: dgnHasReflFromBase C E E' dgnDataCore)
+    (cohL: dgnCohLFromBase C E E' dgnDataCore L):
+    mkCohReflRestrPaintingAboveSupTypes
+      (dgnDepsReflCohsSupFromBase C E E' dgnDataCore)
+      (dgnExtraDepsReflCohsSupFromBase C E E' dgnDataCore L);
+  cohReflBelowBelowPaintings
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+    (L: dgnHasReflFromBase C E E' dgnDataCore)
+    (cohL: dgnCohLFromBase C E E' dgnDataCore L):
+    mkCohReflBelowBelowPaintingTypes
+      (dgnDepsReflCohsSupFromBase C E E' dgnDataCore)
+      (dgnExtraDepsReflCohsSupFromBase C E E' dgnDataCore L)
+      (dgnDataCore.(cohReflBelowBelowFrames) E');
+  cohReflAboveBelowPaintings
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+    (L: dgnHasReflFromBase C E E' dgnDataCore)
+    (cohL: dgnCohLFromBase C E E' dgnDataCore L):
+    mkCohReflAboveBelowPaintingTypes
+      (dgnDepsReflCohsSupFromBase C E E' dgnDataCore)
+      (dgnExtraDepsReflCohsSupFromBase C E E' dgnDataCore L)
+      (dgnDataCore.(cohReflAboveBelowFrames) E');
+  cohReflAboveAbovePaintings
+    (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+    (L: dgnHasReflFromBase C E E' dgnDataCore)
+    (cohL: dgnCohLFromBase C E E' dgnDataCore L):
+    mkCohReflAboveAbovePaintingTypes
+      (dgnDepsReflCohsSupFromBase C E E' dgnDataCore)
+      (dgnExtraDepsReflCohsSupFromBase C E E' dgnDataCore L)
+      (dgnDataCore.(cohReflAboveAboveFrames) E');
 }.
 
 Definition dgnDepsReflCohsInfFromData {p}
@@ -2084,63 +2307,110 @@ Definition dgnDepsReflCohsInfFromData {p}
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
   (D: DgnData C E): DepsReflCohsInf p 0 :=
-  dgnDepsReflCohsInf C E E'
-    D.(reflFrames) D.(reflPaintings)
-    D.(idReflRestrFrames) D.(idReflRestrPaintings)
-    (D.(cohRestrReflFrames) E').
+  dgnDepsReflCohsInfFromBase C E E' D.(dgnDataCore).
 
 Definition dgnHasReflFromData {p}
   (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
   (D: DgnData C E): Type :=
-  dgnHasRefl C E E'
-    D.(reflFrames) D.(reflPaintings)
-    D.(idReflRestrFrames) D.(idReflRestrPaintings)
-    (D.(cohRestrReflFrames) E').
+  dgnHasReflFromBase C E E' D.(dgnDataCore).
 
 Definition dgnDepsReflCohsSupFromData {p}
   (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
-  (E'': mkFrame (dgnDepsRestr (mkνSetData p.+1 (mkνSetData p C E) E')) -> HSet)
+  (D: DgnData C E):
+  DepsReflCohsSup p 0 :=
+  dgnDepsReflCohsSupFromBase C E E' D.(dgnDataCore).
+
+Definition dgnCohLFromData {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (D: DgnData C E)
+  (L: dgnHasReflFromData C E E' D): Type :=
+  dgnCohLFromBase C E E' D.(dgnDataCore) L.
+
+Definition dgnExtraDepsReflCohsSupFromData {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
   (D: DgnData C E)
   (L: dgnHasReflFromData C E E' D):
-  DepsReflCohsSup p 0 :=
-  {|
-    _depsReflCohsInf := dgnDepsReflCohsInfFromData C E E' D;
-    _extraDepsCohs2 := TopCoh2Dep (depsCohs2 := dgnDepsCohs2 C E E') E'';
-    _extraDepsRefl := TopReflCohDep
-      (deps := dgnDepsReflCohsInfFromData C E E' D) L;
-    _cohReflRestrPaintings := D.(cohReflRestrPaintings) E' L;
-  |}.
+  DepsReflCohsSupExtension p 0 (dgnDepsReflCohsSupFromData C E E' D) :=
+  dgnExtraDepsReflCohsSupFromBase C E E' D.(dgnDataCore) L.
+
+Definition dgnDepsReflCohs2FromData {p}
+  (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (E'': mkFrame (dgnDepsRestr (mkνSetData p.+1 (mkνSetData p C E) E')) -> HSet)
+  (D: DgnData C E)
+  (L: dgnHasReflFromData C E E' D)
+  (cohL: dgnCohLFromData C E E' D L):
+  DepsReflCohs2 p 0 :=
+{|
+  _depsReflCohsSup := dgnDepsReflCohsSupFromData C E E' D;
+  _extraDepsCohs2 := TopCoh2Dep (depsCohs2 := dgnDepsCohs2 C E E') E'';
+  _extraDepsReflCohsSup := TopReflCohSupDep
+    (deps := dgnDepsReflCohsSupFromData C E E' D) L;
+  _cohReflRestrPaintingsBelowInf :=
+    D.(cohReflRestrPaintingsBelowInf) E' L cohL;
+  _cohReflRestrPaintingsBelowSup :=
+    D.(cohReflRestrPaintingsBelowSup) E' L cohL;
+  _cohReflRestrPaintingsAboveSup :=
+    D.(cohReflRestrPaintingsAboveSup) E' L cohL;
+  _cohReflBelowBelowFrames := D.(dgnDataCore).(cohReflBelowBelowFrames) E';
+  _cohReflBelowBelowPaintings :=
+    D.(cohReflBelowBelowPaintings) E' L cohL;
+  _cohReflAboveBelowFrames := D.(dgnDataCore).(cohReflAboveBelowFrames) E';
+  _cohReflAboveBelowPaintings :=
+    D.(cohReflAboveBelowPaintings) E' L cohL;
+  _cohReflAboveAboveFrames := D.(dgnDataCore).(cohReflAboveAboveFrames) E';
+  _cohReflAboveAbovePaintings :=
+    D.(cohReflAboveAbovePaintings) E' L cohL;
+|}.
 
 #[local]
 Instance mkDgnData {p} (C: νSetData p)
   (E: mkFrame (dgnDepsRestr C) -> HSet)
   (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
   (D: DgnData C E)
-  (L: dgnHasReflFromData C E E' D):
+  (L: dgnHasReflFromData C E E' D)
+  (cohL: dgnCohLFromData C E E' D L):
   DgnData (mkνSetData p C E) E' :=
-{|
-  reflFrames := (mkReflFrames (dgnDepsReflCohsInfFromData C E E' D):
-    mkReflFrameTypes (dgnDepsRestr (mkνSetData p C E)));
-  reflPaintings :=
-    mkReflPaintings
-      (dgnDepsReflCohsInfFromData C E E' D)
-      (TopReflCohDep (deps := dgnDepsReflCohsInfFromData C E E' D) L);
-  idReflRestrFrames := mkIdReflRestrFrames (dgnDepsReflCohsInfFromData C E E' D);
-  idReflRestrPaintings :=
-    mkIdReflRestrPaintings
-      (dgnDepsReflCohsInfFromData C E E' D)
-      (TopReflCohDep (deps := dgnDepsReflCohsInfFromData C E E' D) L);
-  cohRestrReflFrames := fun E'' =>
-    mkCohReflRestrFrames (dgnDepsReflCohsSupFromData C E E' E'' D L);
-  cohReflRestrPaintings := fun E'' L' =>
-    mkCohReflRestrPaintings
-      (dgnDepsReflCohsSupFromData C E E' E'' D L)
-      (TopReflCohDep2 (deps := dgnDepsReflCohsSupFromData C E E' E'' D L) L');
-|}.
+  let depsInf := dgnDepsReflCohsInfFromData C E E' D in
+  let depsSup := dgnDepsReflCohsSupFromData C E E' D in
+  let deps2 E'' := dgnDepsReflCohs2FromData C E E' E'' D L cohL in
+  let extraSup := dgnExtraDepsReflCohsSupFromData C E E' D L in
+  let base := @Build_DgnDataCore p.+1 (mkνSetData p C E) E'
+    (mkReflFramesBelow depsInf)
+    (mkReflFramesAbove depsSup)
+    (mkReflPaintingsBelow depsSup extraSup)
+    (mkIdReflRestrFramesBelow depsInf)
+    (mkIdReflRestrPaintingsBelow depsSup extraSup)
+    (fun E'' => mkCohReflRestrFramesBelowInf (deps2 E''))
+    (fun E'' => mkCohReflRestrFramesBelowSup (deps2 E''))
+    (fun _ => mkReflPaintingsAbove depsSup extraSup)
+    (fun E'' => mkCohReflRestrFramesAboveSup (deps2 E''))
+    (fun E'' => mkCohReflBelowBelowFrames (deps2 E''))
+    (fun E'' => mkCohReflAboveBelowFrames (deps2 E''))
+    (fun E'' => mkCohReflAboveAboveFrames (deps2 E'')) in
+  @Build_DgnData p.+1 (mkνSetData p C E) E'
+    base
+    (fun E'' L' cohL' => mkCohReflRestrPaintingsBelowInf (deps2 E'')
+      (TopReflCoh2Dep (deps := deps2 E'') L' cohL'.2))
+    (fun E'' L' cohL' => mkCohReflRestrPaintingsBelowSup (deps2 E'')
+      (TopReflCoh2Dep (deps := deps2 E'') L' cohL'.2))
+    (fun E'' L' cohL' => mkCohReflRestrPaintingsAboveSup (deps2 E'')
+      (TopReflCoh2Dep (deps := deps2 E'') L' cohL'.2))
+    (fun E'' L' cohL' => mkCohReflBelowBelowPaintings (deps2 E'')
+      (TopReflCoh2Dep (deps := deps2 E'') L' cohL'.2))
+    (fun E'' L' cohL' => mkCohReflAboveBelowPaintings (deps2 E'')
+      (TopReflCoh2Dep (deps := deps2 E'') L' cohL'.2))
+    (fun E'' L' cohL' => mkCohReflAboveAbovePaintings (deps2 E'')
+      (TopReflCoh2Dep (deps := deps2 E'') L' cohL'.2)).
 
 Class νDgnSet p (C: νSet p) := {
   dgnPrefix: (mkνSet C).(prefix) -> Type;
@@ -2150,7 +2420,10 @@ Class νDgnSet p (C: νSet p) := {
 Definition mkDgnPrefix p {C: νSet p} {D: νDgnSet p C}
   (X: (mkνSet (mkνSet C)).(prefix)): Type :=
   { L: D.(dgnPrefix) X.1 &T
-    dgnHasReflFromData (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 L) }.
+    { dgnL: dgnHasReflFromData
+        (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 L) &T
+      dgnCohLFromData
+        (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 L) dgnL } }.
 
 #[local]
 Definition mkνSetData0: νSetData 0 :=
@@ -2168,14 +2441,27 @@ Definition mkνSetData0: νSetData 0 :=
 Definition mkDgnData0
   (E: mkFrame (dgnDepsRestr mkνSetData0) -> HSet):
   DgnData mkνSetData0 E :=
-  {|
-    reflFrames := (tt: mkReflFrameTypes (dgnDepsRestr mkνSetData0));
-    reflPaintings := tt;
-    idReflRestrFrames := tt;
-    idReflRestrPaintings := tt;
-    cohRestrReflFrames := fun _ => tt;
-    cohReflRestrPaintings := fun _ _ => tt;
-  |}.
+  let base := @Build_DgnDataCore 0 mkνSetData0 E
+    (tt: mkReflFrameBelowTypes (dgnDepsRestr mkνSetData0))
+    (tt: mkReflFrameAboveTypes (dgnDepsRestr mkνSetData0))
+    tt
+    tt
+    tt
+    (fun _ => tt)
+    (fun _ => tt)
+    (fun _ => tt)
+    (fun _ => tt)
+    (fun _ => tt)
+    (fun _ => tt)
+    (fun _ => tt) in
+  @Build_DgnData 0 mkνSetData0 E
+    base
+    (fun _ _ _ => tt)
+    (fun _ _ _ => tt)
+    (fun _ _ _ => tt)
+    (fun _ _ _ => tt)
+    (fun _ _ _ => tt)
+    (fun _ _ _ => tt).
 
 #[local]
 Instance mkνDgnSet0: νDgnSet 0 mkνSet0 :=
@@ -2193,7 +2479,7 @@ Instance mkνDgnSetSn {p} (C: νSet p) (D: νDgnSet p C):
   {|
     dgnPrefix := fun X => mkDgnPrefix p (C := C) (D := D) X;
     dgnData := fun X L =>
-      mkDgnData (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 L.1) L.2;
+      mkDgnData (C.(data) X.1.1) X.1.2 X.2 (D.(dgnData) X.1 L.1) L.2.1 L.2.2;
   |}.
 
 Fixpoint νDgnSetAt n: νDgnSet n (νSetAt n) :=
@@ -2211,15 +2497,18 @@ CoInductive νDgnSetFrom n
     (this n X M)
     (this n.+1 (X; this n X M) (next n X M))
     ((νDgnSetAt n).(dgnData) (X; this n X M) L);
-  dgnNext: νDgnSetFrom n.+1 (X; this n X M) (next n X M) (L; dgn);
+  dgnCohL: dgnCohLFromData
+    ((νSetAt n).(data) X)
+    (this n X M)
+    (this n.+1 (X; this n X M) (next n X M))
+    ((νDgnSetAt n).(dgnData) (X; this n X M) L) dgn;
+  dgnNext: νDgnSetFrom n.+1 (X; this n X M) (next n X M) (L; (dgn; dgnCohL));
 }.
 
 Definition νDgnSets (X: νSets) := νDgnSetFrom 0 tt X tt.
-*)
 
 End νDgnSet.
 
-(*
 Module νDgnSetUnit := νDgnSet νSet.ArityUnit.
 Module νDgnSetBool := νDgnSet νSet.ArityBool.
 
@@ -2234,4 +2523,3 @@ Example Cubical1 :=
 
 Print Simplicial1.
 Print Cubical1.
-*)

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -547,7 +547,7 @@ Definition HasRefl {p} (deps: DepsReflCohsSup p 0)
 
 Inductive DepsReflCohsSupExtension p: forall k (deps: DepsReflCohsSup p k), Type :=
 | TopReflCohSupDep {deps: DepsReflCohsSup p 0}
-  (L: HasRefl deps (mkPaintings (mkExtraDeps (CohsExtOfReflCohsSup deps))).2):
+  (L: HasRefl deps (mkPainting (mkExtraDeps (CohsExtOfReflCohsSup deps)))):
   DepsReflCohsSupExtension p 0 deps
 | AddReflCohSupDep {k} (deps: DepsReflCohsSup p.+1 k):
   DepsReflCohsSupExtension p.+1 k deps -> DepsReflCohsSupExtension p k.+1 deps.(1).
@@ -1105,25 +1105,8 @@ Proof.
 
   set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ d).
 
-  assert (h :
-    (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2
-      r.+1 (⇑ Hr) ε
-      (mkReflFrameBelow (ReflCohsInfOfReflCohs2 deps).(1) q (Hq ↕ ↑ Hr) d0)
-      ((mkReflPaintingsBelow
-        deps.(_depsReflCohsSup).(1)%depsreflcohssup
-        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup).2
-        q (Hq ↕ ↑ Hr) d0 (l θ)) =
-    mkRestrPainting (CohsExtOfReflCohsSup deps.(_depsReflCohsSup).(1))
-      r.+1 (⇑ Hr) ε
-      ((mkDepsReflBelow (ReflCohsInfOfReflCohs2 deps).(1)).(_reflFramesBelow).2
-        q (Hq ↕ ↑ Hr) d0)
-      (mkReflPaintingBelow
-        deps.(_depsReflCohsSup).(1)%depsreflcohssup
-        (deps.(_depsReflCohsSup); deps.(_extraDepsReflCohsSup))%extradepsreflcohssup
-        q (Hq ↕ ↑ Hr) d0 (l θ)))
-  by reflexivity; rewrite h; clear h.
-
-  rewrite <- (deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε d0 (l θ)).
+  set (h := deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε d0 (l θ)).
+  simpl in h |- *; rewrite <- h; clear h.
 
   rewrite rew_map with
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
@@ -1281,7 +1264,7 @@ Inductive DepsReflCohs2Extension p: forall k (deps: DepsReflCohs2 p k), Type :=
 | TopReflCoh2Dep {deps: DepsReflCohs2 p 0}
   (L: HasRefl
     (mkDepsReflCohsSup deps)
-    (mkPaintings (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps)))).2):
+    (mkPainting (mkExtraDeps (CohsExtOfReflCohsInf (mkDepsReflCohsInf deps))))):
   DepsReflCohs2Extension p 0 deps
 | AddReflCoh2Dep {k} (deps: DepsReflCohs2 p.+1 k):
   DepsReflCohs2Extension p.+1 k deps -> DepsReflCohs2Extension p k.+1 deps.(1)%depsreflcohs2.
@@ -1474,9 +1457,7 @@ Proof.
   set (d0 := (CohsOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)).(_deps)
     .(_restrFrames).2 0 leR_O θ d).
   set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))).
-  set (deps'' := (toDepsReflBelow
-    (mkDepsReflCohsInf deps).(1).(_depsCohs2).(_depsCohs)
-    (mkDepsReflCohsInf deps).(1).(_reflFramesBelow'))).
+  set (deps'' := mkDepsReflCohsInf deps.(1)).
   simpl.
   rewrite <- (deps.(_cohReflReflPaintingsBelow).2 q r Hq Hr d0 (l θ)).
   rewrite rew_map with
@@ -1484,10 +1465,10 @@ Proof.
     (f := fun x => deps'.(1).(_restrFrames).2 0 leR_O θ x).
   rewrite rew_map with
     (P := fun b => deps'.(1).(_paintings).2 b)
-    (f := fun d0 => deps''.(_reflFramesBelow).2 q (Hq ↕ ↑ Hr) d0).
+    (f := fun d0 => deps''.(_reflFramesBelow').2 q (Hq ↕ ↑ Hr) d0).
   rewrite rew_map with
     (P := fun b => deps'.(1).(_paintings).2 b)
-    (f := fun d1 => deps''.(_reflFramesBelow).2 r.+1 (⇑ Hr) d1).
+    (f := fun d1 => deps''.(_reflFramesBelow').2 r.+1 (⇑ Hr) d1).
   rewrite 4 rew_compose.
   apply rew_swap with (P := fun b => deps'.(1).(_paintings).2 b).
   rewrite rew_app_rl. now trivial.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -314,7 +314,6 @@ Proof.
   unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- (deps.(_idReflRestrPaintingsBelow).2 i Hi ε _ (l θ)).
   rewrite <- map_subst_app, <- map_subst.
-  unfold toDepsReflBelow, PaintingPrev, FramePrev, RestrOfReflCohsInf, mkFrame; simpl.
   set (deps' := deps.(_depsCohs2).(_depsCohs).(_deps)).
   rewrite rew_map with
     (P := fun x => deps'.(_paintings).2 x)
@@ -331,7 +330,7 @@ Defined.
 Fixpoint mkIdReflRestrFramesBelow {p k} (deps: DepsReflCohsInf p k):
   mkIdReflRestrFrameBelowTypes (mkDepsReflBelow deps).
   destruct p.
-  - simpl. unshelve econstructor. now exact tt. now intros i Hi ε [].
+  - unshelve econstructor. now exact tt. now intros i Hi ε [].
   - set (h := mkIdReflRestrFramesBelow p k.+1 deps.(1)%depsreflcohsinf).
     unshelve econstructor.
     + now apply h.
@@ -1871,28 +1870,16 @@ Proof.
       apply rew_swap with (P := fun b => mkPainting deps' b).
       rewrite rew_app_rl. now trivial.
       now apply (mkFrame _).(UIP).
-    + unfold mkReflPaintingBelow2; cbn [eq_rect].
+    + match goal with
+      | |- rew [?P1'] ?H' in ?y = ?x => set (H := H')
+      end.
+      set (h := mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
+      unfold mkReflPaintingAbove in h |- *.
       destruct p.
-      * set (h := mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
-        unfold mkReflPaintingAbove in h |- *.
-        rewrite <- h; clear h.
-        match goal with
-        | |- rew [?P1'] ?H2' in rew [?P2'] ?H1' in ?y = ?x =>
-          set (H2 := H2'); set (H1 := H1')
-        end.
-        rewrite rew_compose.
-        enough (HEq: H1 • H2 = eq_refl) by (now rewrite HEq).
-        now apply (mkFrame (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))).(UIP).
-      * set (h := mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).
-        unfold mkReflPaintingAbove in h |- *.
-        rewrite <- h; clear h.
-        match goal with
-        | |- rew [?P1'] ?H2' in rew [?P2'] ?H1' in ?y = ?x =>
-          set (H2 := H2'); set (H1 := H1')
-        end.
-        rewrite rew_compose.
-        enough (HEq: H1 • H2 = eq_refl) by (now rewrite HEq).
-        now apply (mkFrame (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))).(UIP).
+      all: rewrite <- h; clear h.
+      all: rewrite rew_compose.
+      all: enough (h: _ • H = eq_refl) by (now rewrite h).
+      all: now apply (mkFrame (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))).(UIP).
   - destruct extraDeps; [now contradiction |].
     destruct c as [l c].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -664,44 +664,42 @@ Fixpoint mkCohReflRestrPaintingBelowInfTypes {p}:
       &T mkCohReflRestrPaintingBelowInfType deps extraDeps }
   end.
 
-Fixpoint mkIdReflRestrPainting {p k}
-  (deps: DepsReflCohs p k)
-  (extraDeps: DepsReflCohsExtension p k deps):
-  mkIdReflRestrPaintingType
-    (mkDepsCohs deps.(_depsCohs2))
-    (mkReflFrames deps)
-    (mkReflPaintings deps extraDeps)
-    (mkIdReflRestrFrames deps).
+Fixpoint mkIdReflRestrPaintingBelow {p k}
+  (deps: DepsReflCohs2 p k)
+  (extraDeps: DepsReflCohs2Extension p k deps):
+  mkIdReflRestrPaintingBelowType
+    (mkDepsCohs (Cohs2OfReflCohs2 deps))
+    (mkReflFramesBelow deps.(_depsReflCohs))
+    (mkReflPaintingsBelow deps extraDeps)
+    (mkIdReflRestrFramesBelow deps.(_depsReflCohs)).
 Proof.
-  intros ε d c.
-  destruct extraDeps.
-  - rewrite rew_compose.
-    set (e := (mkIdReflRestrFrames _).2 ε d).
-    enough (eq_sym e • e = eq_refl) as ->. now trivial.
-    now apply (mkFrame _).(UIP).
-  - unshelve eapply (eq_existT_curried_dep
-      (Q := mkPainting deps .(_depsCohs2) .(_depsCohs) .(_extraDeps))).
-    * now apply mkIdReflRestrLayer.
-    * destruct c as [l c].
-      now exact (mkIdReflRestrPainting p.+1 k deps extraDeps ε (d; l) c).
+  intros i Hi ε d c.
+  destruct i.
+  - now rewrite rew_compose, eq_trans_sym_inv_l.
+  - destruct extraDeps; [now contradiction |].
+    unshelve eapply (eq_existT_curried_dep (Q := mkPainting (RestrExtOfReflCohs2 deps))).
+    + now apply (mkIdReflRestrLayerBelow deps.(_depsReflCohs) i Hi ε).
+    + destruct c as [l c].
+      now exact (mkIdReflRestrPaintingBelow p.+1 k deps extraDeps i (⇓ Hi) ε (d; l) c).
 Defined.
 
-Fixpoint mkIdReflRestrPaintings {p k}
-  (deps: DepsReflCohs p k)
-  (extraDeps: DepsReflCohsExtension p k deps):
-  mkIdReflRestrPaintingTypes
-    (mkDepsCohs deps.(_depsCohs2))
-    (mkReflFrames deps)
-    (mkReflPaintings deps extraDeps)
-    (mkIdReflRestrFrames deps).
-Proof.
-  destruct p.
-  - unshelve econstructor. now exact tt. now apply mkIdReflRestrPainting.
-  - unshelve econstructor.
-    + now exact (mkIdReflRestrPaintings p k.+1 deps.(1)%depsreflcohs
-      (deps; extraDeps)%extradepsreflcohs).
-    + now apply mkIdReflRestrPainting.
-Defined.
+Fixpoint mkIdReflRestrPaintingsBelow {p k}:
+  forall (deps: DepsReflCohs2 p k) (extraDeps: DepsReflCohs2Extension p k deps),
+  mkIdReflRestrPaintingBelowTypes
+    (mkDepsCohs (Cohs2OfReflCohs2 deps))
+    (mkReflFramesBelow deps.(_depsReflCohs))
+    (mkReflPaintingsBelow deps extraDeps)
+    (mkIdReflRestrFramesBelow deps.(_depsReflCohs)) :=
+  match p with
+  | 0 => fun deps extraDeps =>
+      (tt; mkIdReflRestrPaintingBelow deps extraDeps)
+  | S p =>
+      fun deps extraDeps =>
+      (mkIdReflRestrPaintingsBelow deps.(1) (deps; extraDeps);
+       mkIdReflRestrPaintingBelow deps extraDeps)
+  end.
+
+(*
 
 Class DepsReflCohs2 p k := {
   _depsReflCohs: DepsReflCohs p k;


### PR DESCRIPTION
This PR extends construction of degeneracies to all directions.

This is a port of Alice's construction of degeneracies (built on top of old `νSet` construction) to the new `νSet` construction:
[https://github.com/alicelaroche/bonak/blob/e4ee6f999312c5317392497dc0de9a4150f54b8c/theories/νType/νType.v#L1438](https://github.com/alicelaroche/bonak/blob/e4ee6f999312c5317392497dc0de9a4150f54b8c/theories/%CE%BDType/%CE%BDType.v#L1438)

The construction is done in two stages - "below" and "above". In terms of Alice's construction, it can be explained as follows. The “below” operation just reflects the existing frame, producing a `p`-frame in dimension `n+1`. Once the prefix has reached or passed the direction `q` (`q ≤ p`), the “above” operation inserts the original painting as the repeated constant layer, so it takes both the frame `d` and painting `c` and produces a `(p + 1)`-frame.

Within the new `νSet` construction that follows a "zipper" pattern, `p` is the prefix height and `k` is the number of directions still above it. The dimension `n` is computed as `p + k`. Within this construction, "below" degeneracy is indexed by a relative direction `q ≤ k` and "above" degeneracy is indexed by a direction already inside the prefix, `q ≤ p`. For frames, we first define degeneracies "below" and then degeneracies "above", while for paintings it is the other way around.

We prove the following face-degeneracy coherence equations (here `refl↓` means degeneracies "below" and `refl↑` means degeneracies "above"):

```
restr-refl↓-id q ε (q ≤ k): restr q ε ∘ refl↓ q = id
refl↓-restr-inf q r ε (r ≤ q ≤ k): refl↓ q ∘ restr r ε = restr r ε ∘ refl↓ (q+1)
refl↓-restr-sup q r ε (q ≤ r ≤ k): refl↓ q ∘ restr r ε = restr (r+1) ε ∘ refl↓ q
refl↑-restr-sup q r ε (q ≤ p) (r ≤ k): refl↑ q ∘ restr r ε = restr r ε ∘ refl↑ q
```

The type of `refl↓-restr-inf` for frames is built mutually-recursively with the definition of `refl↓` for frames, while the type of `refl↑-restr-sup` for frames is built mutually-recursively with the definition of `refl↑` for frames. For frames, `refl-restr-sup` is first proved for `refl↓` and then for `refl↑`, while for paintings it is the other way around.

Additionally, we also prove the degeneracy-degeneracy coherence equation. This is done in 3 stages - "below-below", "above-below" and "above-above":

```
refl↓-refl↓ q r (q ≤ r ≤ k): refl↓ q ∘ refl↓ r = refl↓ (r+1) ∘ refl↓ q
refl↑-refl↓ q r (q ≤ p) (r ≤ k): refl↑ q ∘ refl↓ r = refl↓ r ∘ refl↑ q
refl↑-refl↑ q r (q ≤ r ≤ p): refl↑ q ∘ refl↑ r = refl↑ (r+1) ∘ refl↑ q
```

For frames, we first prove `refl↓-refl↓`, then `refl↑-refl↓` and finally `refl↑-refl↑`. For paintings, again, the order is reversed: `refl↑-refl↑` is proved first, then `refl↑-refl↓` and finally `refl↓-refl↓`.

P.S. Here are some diagrams of 2-dimensional coherences that we are closing with `UIP`:
https://olympichek.dev/bonak-higher-cohs/higher-coherences.pdf
https://github.com/olympichek/bonak-higher-cohs