### PR TITLE
νDgnSet: orient all coherences in the direction they are consumed

### DIFF
--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -71,7 +71,7 @@ Notation "x .(1)" := (proj1DepsReflBelow x%depsreflbelow)
 Definition mkIdRestrReflFrameBelowType {p k}
   (deps: DepsReflBelow p.+1 k): Type :=
   forall i (Hi: i <= k) ε (d: FramePrev deps.(_depsRestr)),
-  deps.(_depsRestr).(_restrFrames).2 i Hi ε (deps.(_reflFramesBelow).2 i Hi d) = d.
+  d = deps.(_depsRestr).(_restrFrames).2 i Hi ε (deps.(_reflFramesBelow).2 i Hi d).
 
 Fixpoint mkIdRestrReflFrameBelowTypes {p}:
   forall {k} (deps: DepsReflBelow p k), Type :=
@@ -187,9 +187,9 @@ Definition mkIdRestrReflPaintingBelowType {p k}
   forall i (Hi: i <= k) (ε: arity)
     (d: FramePrev deps.(_deps))
     (c: PaintingPrev deps.(_deps) d),
-  rew [PaintingPrev deps.(_deps)] idRestrReflFrames.2 i Hi ε d in
+  rew [PaintingPrev deps.(_deps)] idRestrReflFrames.2 i Hi ε d in c =
   deps.(_restrPaintings).2 i Hi ε
-    (reflFramesBelow.2 i Hi d) (reflPaintingsBelow.2 i Hi d c) = c.
+    (reflFramesBelow.2 i Hi d) (reflPaintingsBelow.2 i Hi d c).
 
 Fixpoint mkIdRestrReflPaintingBelowTypes {p}:
   forall {k} (deps: DepsCohs p k)
@@ -303,18 +303,18 @@ Definition mkIdRestrReflLayerBelow {p k}
   (d: FrameBase (RestrOfReflCohsInf deps))
   (l: mkLayer (RestrOfReflCohsInf deps).(_restrFrames) d)
   (prevIdRestrReflFrames: mkIdRestrReflFrameBelowTypes (mkDepsReflBelow deps.(1))):
-  rew [mkLayer _] prevIdRestrReflFrames.2 i.+1 (⇑ Hi) ε d in
+  rew [mkLayer _] prevIdRestrReflFrames.2 i.+1 (⇑ Hi) ε d in l =
   mkRestrLayer deps.(_depsCohs2).(_depsCohs).(_restrPaintings)
     (deps.(_depsCohs2).(_depsCohs).(_cohs)) i Hi ε _
       (mkReflLayerBelow deps.(_depsCohs2).(_depsCohs)
         ((ReflBelowOfReflCohsInf deps).(_reflFramesBelow)) deps.(_reflPaintingsBelow) _
-          deps.(_cohReflRestrFramesBelowInf) i Hi d l) = l.
+          deps.(_cohReflRestrFramesBelowInf) i Hi d l).
 Proof.
   apply functional_extensionality_dep.
   intros θ.
   unfold mkRestrLayer, mkReflLayerBelow.
-  rewrite <- (deps.(_idRestrReflPaintingsBelow).2 i Hi ε _ (l θ)).
   rewrite <- map_subst_app, <- map_subst.
+  rewrite <- (deps.(_idRestrReflPaintingsBelow).2 i Hi ε _ (l θ)).
   set (deps' := deps.(_depsCohs2).(_depsCohs).(_deps)).
   rewrite rew_map with
     (P := fun x => deps'.(_paintings).2 x)
@@ -399,7 +399,7 @@ Definition mkReflLayerAbove0 {p k} (deps: DepsReflCohsInf p k)
     (paintings := (mkDepsRestr (CohsOfReflCohsInf deps)).(_paintings))
     (mkDepsRestr (CohsOfReflCohsInf deps)).(_restrFrames)
     (mkReflFrameBelow deps 0 leR_O d) :=
-  fun ε => rew <- mkIdRestrReflFrameBelow deps 0 leR_O ε d in c.
+  fun ε => rew mkIdRestrReflFrameBelow deps 0 leR_O ε d in c.
 
 Definition mkReflFrameAbove0 {p k} (deps: DepsReflCohsInf p k)
   (d: FramePrev (mkDepsRestr (CohsOfReflCohsInf deps)))
@@ -810,7 +810,7 @@ Fixpoint mkIdRestrReflPaintingBelow {p k}
 Proof.
   intros i Hi ε d c.
   destruct i.
-  - now rewrite rew_compose, eq_trans_sym_inv_l.
+  - now trivial.
   - destruct extraDeps; [now contradiction |].
     unshelve eapply (eq_existT_curried_dep (Q := mkPainting (RestrExtOfReflCohsSup deps))).
     + now apply (mkIdRestrReflLayerBelow deps.(_depsReflCohsInf) i Hi ε).
@@ -876,12 +876,12 @@ Definition mkCohReflAboveAboveFrameType {p k}
   forall q r (Hq: q <= r) (Hr: r <= p)
     (d: FramePrev (RestrOfReflCohsSup deps))
     (c: PaintingPrev (RestrOfReflCohsSup deps) d),
-  mkReflFrameAbove deps q (Hq ↕ (↑ Hr))
-    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 r Hr d c)
-    (deps.(_reflPaintingsAbove).2 r Hr d c) =
   mkReflFrameAbove deps r.+1 (⇑ Hr)
     (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q (Hq ↕ Hr) d c)
-    (deps.(_reflPaintingsAbove).2 q (Hq ↕ Hr) d c).
+    (deps.(_reflPaintingsAbove).2 q (Hq ↕ Hr) d c) =
+  mkReflFrameAbove deps q (Hq ↕ (↑ Hr))
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 r Hr d c)
+    (deps.(_reflPaintingsAbove).2 r Hr d c).
 
 Fixpoint mkCohReflAboveAboveFrameTypes {p}:
   forall {k} (deps: DepsReflCohsSup p k), Type :=
@@ -964,12 +964,12 @@ Definition mkCohReflAboveAbovePaintingType {p k}
     (d: FramePrev (RestrOfReflCohsSup deps))
     (c: PaintingPrev (RestrOfReflCohsSup deps) d),
   rew [mkPainting _] cohReflAboveAboveFrames.2 q r Hq Hr d c in
-  mkReflPaintingAbove deps extraDeps q (Hq ↕ ↑ Hr)
-    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 r Hr d c)
-    (deps.(_reflPaintingsAbove).2 r Hr d c) =
   mkReflPaintingAbove deps extraDeps r.+1 (⇑ Hr)
     (deps.(_depsReflCohsInf).(_reflFramesAbove).2 q (Hq ↕ Hr) d c)
-    (deps.(_reflPaintingsAbove).2 q (Hq ↕ Hr) d c).
+    (deps.(_reflPaintingsAbove).2 q (Hq ↕ Hr) d c) =
+  mkReflPaintingAbove deps extraDeps q (Hq ↕ ↑ Hr)
+    (deps.(_depsReflCohsInf).(_reflFramesAbove).2 r Hr d c)
+    (deps.(_reflPaintingsAbove).2 r Hr d c).
 
 Fixpoint mkCohReflAboveAbovePaintingTypes {p}:
   forall {k}
@@ -1116,7 +1116,7 @@ Proof.
   intros θ.
   unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- map_subst_app, <- !map_subst.
-  simpl.
+  simpl ((mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2 r (Hr ↕ ↑ Hq) ε _ _).
   rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε _ (l θ)).
   rewrite rew_map with
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
@@ -1290,7 +1290,7 @@ Proof.
   set (c0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
     0 leR_O θ d (l; c)).
 
-  simpl.
+  simpl ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε _ _).
   rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r Hq Hr ε d0 c0).
 
   eassert (coh_pair_eq: (_;_) = (_;_)).
@@ -1447,7 +1447,7 @@ Proof.
     .(_restrFrames).2 0 leR_O θ d).
   set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))).
   set (deps'' := mkDepsReflCohsInf deps.(1)).
-  simpl.
+  simpl ((mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow).2 r.+1 (⇑ Hr) _ _).
   rewrite <- (deps.(_cohReflBelowBelowPaintings).2 q r Hq Hr d0 (l θ)).
   rewrite rew_map with
     (P := fun b => deps'.(1).(_paintings).2 b)
@@ -1512,10 +1512,6 @@ Proof.
 
   set (d0 := (RestrOfReflCohs2 deps).(_restrFrames).2 0 leR_O θ d).
   set (c0 := (CohsOfReflCohs2 deps).(_restrPaintings).2 0 leR_O θ d (l; c)).
-  set (x0 := (
-    (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 r Hr d0;
-    (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 r Hr d0 c0)).
-
   eassert (coh_below_inf_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact ((ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf).2 r 0 Hr leR_O θ d).
@@ -1524,10 +1520,6 @@ Proof.
     (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x.1 x.2)
     coh_below_inf_pair_eq tt).
 
-  rewrite (proj2 (@rew_swap _ _ _ _ (deps.(_cohReflAboveBelowFrames).2 q r Hq Hr d0 c0)
-    ((mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x0.1 x0.2) _)
-    (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr d0 c0)).
-
   eassert (coh_above_sup_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 Hq leR_O θ d (l; c)).
@@ -1535,6 +1527,9 @@ Proof.
   rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
     (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr x.1 x.2)
     coh_above_sup_pair_eq tt).
+
+  simpl ((mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr _ _).
+  rewrite <- (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr d0 c0).
 
   rewrite rew_map with
     (P := fun b => mkPainting
@@ -1641,16 +1636,16 @@ Definition mkCohReflAboveAboveLayer {p k}
   rew [mkLayer _] prevCohReflAboveAboveFrames.2 q r Hq Hr d (l; c) in
   mkReflLayerAbove (mkDepsReflCohsInf deps)
     (mkDepsReflCohsSup deps).(_reflPaintingsAbove) _
-    (mkDepsReflCohsSup deps).(_cohReflRestrFramesAboveSup) q (Hq ↕ ↑ Hr)
-    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) (d; l) c).1
-    (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) (d; l) c).2;
-     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) (d; l) c) =
-  mkReflLayerAbove (mkDepsReflCohsInf deps)
-    (mkDepsReflCohsSup deps).(_reflPaintingsAbove) _
     (mkDepsReflCohsSup deps).(_cohReflRestrFramesAboveSup) r.+1 (⇑ Hr)
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ (Hq ↕ Hr)) (d; l) c).1
     (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ (Hq ↕ Hr)) (d; l) c).2;
-     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q.+1 (⇑ (Hq ↕ Hr)) (d; l) c).
+     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q.+1 (⇑ (Hq ↕ Hr)) (d; l) c) =
+  mkReflLayerAbove (mkDepsReflCohsInf deps)
+    (mkDepsReflCohsSup deps).(_reflPaintingsAbove) _
+    (mkDepsReflCohsSup deps).(_cohReflRestrFramesAboveSup) q (Hq ↕ ↑ Hr)
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) (d; l) c).1
+    (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) (d; l) c).2;
+     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) (d; l) c).
 Proof.
   apply functional_extensionality_dep.
   intro θ.
@@ -1676,9 +1671,8 @@ Proof.
     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) x.1 x.2)
     coh_above_sup_q_pair_eq tt).
 
-  rewrite (proj2 (@rew_swap _ _ _ _ (deps.(_cohReflAboveAboveFrames).2 q r Hq Hr d0 c0)
-    ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q (Hq ↕ ↑ Hr) _ _) _)
-    (deps.(_cohReflAboveAbovePaintings).2 q r Hq Hr d0 c0)).
+  simpl ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q (Hq ↕ ↑ Hr) _ _).
+  rewrite <- (deps.(_cohReflAboveAbovePaintings).2 q r Hq Hr d0 c0).
 
   set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps))).
   set (deps'' := RestrExtOfReflCohsInf (mkDepsReflCohsInf deps)).
@@ -1701,18 +1695,18 @@ Definition mkCohReflAboveAboveLayer0 {p k}
   (deps: DepsReflCohs2 p k) r (Hr: r <= p)
   (d: FramePrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)))
   (c: PaintingPrev (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) d):
-  rew <- [mkLayer _] ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c) in
-  mkReflLayerAbove0
-    (mkDepsReflCohsInf deps)
-    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r Hr d c)
-    ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r Hr d c) =
+  rew [mkLayer _] ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c) in
   mkReflLayerAbove
     (mkDepsReflCohsSup deps).(_depsReflCohsInf)
     (mkDepsReflCohsSup deps).(_reflPaintingsAbove) _
     (mkDepsReflCohsSup deps).(_cohReflRestrFramesAboveSup) r Hr
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).1
     (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).2;
-     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 0 leR_O d c).
+     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 0 leR_O d c) =
+  mkReflLayerAbove0
+    (mkDepsReflCohsInf deps)
+    ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r Hr d c)
+    ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r Hr d c).
 Proof.
   set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps))).
   apply functional_extensionality_dep; intro θ.
@@ -1746,8 +1740,7 @@ Proof.
   intros q r Hq Hr d c.
   destruct q.
   - unshelve eapply eq_existT_curried.
-    + symmetry.
-      now exact ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c).
+    + now exact ((mkCohReflAboveBelowFrames deps).2 r 0 Hr leR_O d c).
     + now exact (mkCohReflAboveAboveLayer0 deps r Hr d c).
   - destruct r; [now contradiction |].
     destruct p; [now contradiction |].
@@ -1979,8 +1972,7 @@ Fixpoint mkCohReflAboveBelowPainting {p k} (deps: DepsReflCohs2 p k)
 Proof.
   intros q r Hq Hr d c.
   destruct r.
-  - apply rew_swap with (P := mkPainting _), eq_sym.
-    unshelve eapply (eq_existT_curried_dep (Q := mkPainting
+  - unshelve eapply (eq_existT_curried_dep (Q := mkPainting
       (mkExtraDeps (CohsExtOfReflCohsSup (mkDepsReflCohsSup deps))))).
     + now exact (mkCohReflAboveAboveLayer0 deps q Hq d c).
     + now exact (mkCohReflAboveAbovePainting deps extraDeps 0 q leR_O Hq d c).

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1116,7 +1116,7 @@ Proof.
   intros θ.
   unfold mkRestrLayer, mkReflLayerBelow.
   rewrite <- map_subst_app, <- !map_subst.
-  simpl ((mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2 r (Hr ↕ ↑ Hq) ε _ _).
+  simpl.
   rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε _ (l θ)).
   rewrite rew_map with
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
@@ -1290,7 +1290,7 @@ Proof.
   set (c0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
     0 leR_O θ d (l; c)).
 
-  simpl ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2 r Hr ε _ _).
+  simpl.
   rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r Hq Hr ε d0 c0).
 
   eassert (coh_pair_eq: (_;_) = (_;_)).
@@ -1447,7 +1447,7 @@ Proof.
     .(_restrFrames).2 0 leR_O θ d).
   set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))).
   set (deps'' := mkDepsReflCohsInf deps.(1)).
-  simpl ((mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow).2 r.+1 (⇑ Hr) _ _).
+  simpl.
   rewrite <- (deps.(_cohReflBelowBelowPaintings).2 q r Hq Hr d0 (l θ)).
   rewrite rew_map with
     (P := fun b => deps'.(1).(_paintings).2 b)
@@ -1528,7 +1528,8 @@ Proof.
     (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr x.1 x.2)
     coh_above_sup_pair_eq tt).
 
-  simpl ((mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr _ _).
+  change_no_check ((mkDepsReflCohsInf deps).(_reflPaintingsBelow).2)
+    with (mkReflPaintingBelow deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
   rewrite <- (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr d0 c0).
 
   rewrite rew_map with
@@ -1671,7 +1672,8 @@ Proof.
     (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) x.1 x.2)
     coh_above_sup_q_pair_eq tt).
 
-  simpl ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q (Hq ↕ ↑ Hr) _ _).
+  change_no_check ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2)
+    with (mkReflPaintingAbove deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
   rewrite <- (deps.(_cohReflAboveAbovePaintings).2 q r Hq Hr d0 c0).
 
   set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps))).


### PR DESCRIPTION
### Overview

This change makes all coherences to have a consistent orientation - now they are all oriented in expanding direction. To achieve this I flipped the direction of `restr-refl-id` and `refl-above-above` coherences.

This cleans up proofs a little bit, i.e. allows us to get rid of `eq_sym`, `rew_swap` and `eq_trans_sym_inv_l` here and there.

### Performance

Proof terms are slightly smaller after the cleanup and it appears they typecheck slightly faster now: 24.4s vs 27.9s on my laptop.