### PR TITLE
νSet, νDgnSet: fuse the rewrite chains in layer coherence proofs

### DIFF
--- a/theories/νSet/RewLemmas.v
+++ b/theories/νSet/RewLemmas.v
@@ -30,3 +30,79 @@ Lemma map_subst_app {A B} {x y} {𝛉: A} (H: x = y :> B) (P: A -> B -> Type)
 Proof.
   now destruct H.
 Qed.
+
+(** Fused transport-chain lemmas.
+
+    Each lemma equates, in one step, two forward chains of transports of the
+    same element — the goal shape of the layer coherence proofs after
+    [map_subst]. The digits name the number of transports on each side of
+    the equation. The premises are an equation between the transported
+    elements ([reflexivity] at the use sites) and an equation between the two
+    composite paths: the higher coherence, which every caller exhibits
+    explicitly — [UIP] in an HSet development. *)
+
+Lemma rew_chain13 {X B1 B2: Type} (P: X -> Type)
+  (f: B1 -> X) (g: B2 -> X)
+  {u1 v1: B1} {u3 v3: B2}
+  (E1: u1 = v1)
+  (F1: g v3 = f v1) (F2: u3 = v3) (F3: f u1 = g u3)
+  (aL aR: P (f u1)):
+  aL = aR ->
+  f_equal f E1 = F3 • (f_equal g F2 • F1) ->
+  rew [fun x => P (f x)] E1 in aL
+  = rew [P] F1 in rew [fun x => P (g x)] F2 in rew [P] F3 in aR.
+Proof.
+  intros base coh2. destruct base, E1, F2. cbn in coh2 |- *.
+  rewrite rew_compose.
+  rewrite eq_trans_refl_l in coh2.
+  now rewrite <- coh2.
+Qed.
+
+Lemma rew_chain31 {X B1 B2: Type} (P: X -> Type)
+  (f1: B1 -> X) (f2: B2 -> X)
+  {u1 v1: B1} {u2 v2: B2}
+  (E1: u1 = v1) (E2: f2 v2 = f1 u1) (E3: u2 = v2)
+  (F1: f2 u2 = f1 v1)
+  (aL aR: P (f2 u2)):
+  aL = aR ->
+  f_equal f2 E3 • (E2 • f_equal f1 E1) = F1 ->
+  rew [fun x => P (f1 x)] E1 in rew [P] E2 in rew [fun x => P (f2 x)] E3 in aL
+  = rew [P] F1 in aR.
+Proof.
+  intros base coh2. destruct base, E1, E3. cbn in coh2 |- *.
+  rewrite eq_trans_refl_l in coh2.
+  now rewrite coh2.
+Qed.
+
+Lemma rew_chain22 {X B1 B2: Type} (P: X -> Type)
+  (f: B1 -> X) (g: B2 -> X)
+  {u v: B1} {w w': B2}
+  (E1: u = v) (E0: g w = f u)
+  (F1: g w' = f v) (F2: w = w')
+  (aL aR: P (g w)):
+  aL = aR ->
+  E0 • f_equal f E1 = f_equal g F2 • F1 ->
+  rew [fun x => P (f x)] E1 in rew [P] E0 in aL
+  = rew [P] F1 in rew [fun x => P (g x)] F2 in aR.
+Proof.
+  intros base coh2. destruct base, E1, F2. cbn in coh2 |- *.
+  rewrite eq_trans_refl_l in coh2.
+  now rewrite coh2.
+Qed.
+
+Lemma rew_chain33 {X B1 B2 B3: Type} (P: X -> Type)
+  (f1: B1 -> X) (f2: B2 -> X) (g: B3 -> X)
+  {u1 v1: B1} {u2 v2: B2} {u3 v3: B3}
+  (E1: u1 = v1) (E2: f2 v2 = f1 u1) (E3: u2 = v2)
+  (F1: g v3 = f1 v1) (F2: u3 = v3) (F3: f2 u2 = g u3)
+  (aL aR: P (f2 u2)):
+  aL = aR ->
+  f_equal f2 E3 • (E2 • f_equal f1 E1) = F3 • (f_equal g F2 • F1) ->
+  rew [fun x => P (f1 x)] E1 in rew [P] E2 in rew [fun x => P (f2 x)] E3 in aL
+  = rew [P] F1 in rew [fun x => P (g x)] F2 in rew [P] F3 in aR.
+Proof.
+  intros base coh2. destruct base, E1, E3, F2. cbn in coh2 |- *.
+  rewrite rew_compose.
+  rewrite !eq_trans_refl_l in coh2.
+  now rewrite coh2.
+Qed.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -318,18 +318,12 @@ Proof.
   rewrite <- map_subst.
   rewrite <- (deps.(_idRestrReflPaintingsBelow).2 i Hi ε _ (HSetVec.vec_nth l θ)).
   set (deps' := deps.(_depsCohs2).(_depsCohs).(_deps)).
-  rewrite rew_map with
+  apply rew_chain13 with
     (P := fun x => deps'.(_paintings).2 x)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-  rewrite rew_map with
-    (P := fun x => deps'.(_paintings).2 x)
-    (f := fun x => deps'.(_restrFrames).2 i Hi ε x).
-  rewrite 2 rew_compose.
-  match goal with
-  | |- rew [?P] ?H in _ = rew [?Q] ?H' in _ =>
-      replace H with H' by now apply deps'.(_frames).2.(UIP)
-  end.
-  reflexivity.
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
+    (g := fun d0 => deps'.(_restrFrames).2 i Hi ε d0).
+  now trivial.
+  now apply (deps'.(_frames).2.(UIP)).
 Defined.
 
 Fixpoint mkIdRestrReflFramesBelow {p k} (deps: DepsReflCohsInf p k):
@@ -1125,23 +1119,13 @@ Proof.
   rewrite <- !map_subst.
   simpl.
   rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε _ (HSetVec.vec_nth l θ)).
-  rewrite rew_map with
+  apply rew_chain33 with
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
-    (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
-      0 leR_O θ x).
-  rewrite rew_map with
-    (f := fun d1 => (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q Hq d1).
-  rewrite rew_map with
-    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
-        _deps).(_paintings).2 b)
-    (f := fun d0 => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
-      _deps).(_restrFrames).2 r (Hr ↕ ↑ Hq) ε d0).
-  rewrite 4 rew_compose.
-  apply rew_swap with
-    (P := fun b => (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(
-      _deps).(_paintings).2 b).
-  rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohs2 deps).(1)).(UIP).
+    (f1 := fun x => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ x)
+    (f2 := fun d1 => (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q Hq d1)
+    (g := fun d0 => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) r (Hr ↕ ↑ Hq) ε d0).
+  now trivial.
+  now apply ((mkFrame (RestrOfReflCohs2 deps).(1)).(UIP)).
 Defined.
 
 Fixpoint mkCohReflRestrFramesBelowInf {p k} (deps: DepsReflCohs2 p k):
@@ -1219,28 +1203,13 @@ Proof.
   set (h := deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε d0 (HSetVec.vec_nth l θ)).
   simpl in h |- *; rewrite <- h; clear h.
 
-  rewrite rew_map with
+  apply rew_chain33 with
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
-    (f := fun x => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_restrFrames).2
-      0 leR_O θ x).
-  rewrite rew_map with
-    (f := fun d1 =>
-      (toDepsReflBelow
-        (ReflCohsInfOfReflCohs2 deps).(_depsCohs2).(_depsCohs)
-        (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow')).(_reflFramesBelow).2
-        q (Hq ↕ Hr) d1).
-  rewrite rew_map with
-    (P := fun b =>
-      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_paintings).2 b)
-    (f := fun d1 =>
-      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_restrFrames).2
-        r.+1 (⇑ Hr) ε d1).
-  rewrite 4 rew_compose.
-  apply rew_swap with
-    (P := fun b =>
-      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_paintings).2 b).
-  rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohs2 deps).(1)).(UIP).
+    (f1 := fun x => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ x)
+    (f2 := fun d1 => (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q (Hq ↕ Hr) d1)
+    (g := fun d1 => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) r.+1 (⇑ Hr) ε d1).
+  now trivial.
+  now apply ((mkFrame (RestrOfReflCohs2 deps).(1)).(UIP)).
 Defined.
 
 Fixpoint mkCohReflRestrFramesBelowSup {p k} (deps: DepsReflCohs2 p k):
@@ -1310,28 +1279,16 @@ Proof.
   rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
     deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q Hq x.1 x.2) coh_pair_eq tt).
 
-  rewrite rew_map with
-    (P := fun b =>
-      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_paintings).2 b)
-    (f := fun x => (mkDepsRestr
-      (CohsOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf))).(_restrFrames).2
-      0 leR_O θ x).
-  rewrite rew_map with
-    (P := fun b =>
-      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_paintings).2 b)
-    (f := fun d1 =>
-      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
-        r Hr ε d1).
-  rewrite rew_map with
-    (P := fun x => mkPainting (RestrExtOfReflCohsSup deps.(_depsReflCohsSup)) x)
-    (f := fun x =>
-      (AboveOfReflCohsInf deps.(_depsReflCohsSup).(_depsReflCohsInf)).(_reflFramesAbove').2
-        q Hq x.1 x.2).
-  rewrite 4 rew_compose.
-  apply rew_swap with
-    (P := fun x => mkPainting (RestrExtOfReflCohsSup deps.(_depsReflCohsSup)) x).
-  rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohsSup deps.(_depsReflCohsSup))).(UIP).
+  apply rew_chain33 with
+    (P := fun x => mkPainting (RestrExtOfReflCohs2 deps) x)
+    (f1 := fun x => mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) 0 leR_O θ x)
+    (f2 := fun x => (ReflCohsInfOfReflCohs2 deps).(_reflFramesAbove).2 q Hq x.1 x.2)
+    (g := fun d1 => mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) r Hr ε d1)
+    (E1 := prevCohReflRestrFrames.2 q r.+1 Hq (⇑ Hr) ε d (l; c))
+    (E3 := coh_pair_eq)
+    (F2 := prevCohReflRestrFrames.2 q 0 Hq leR_O θ d (l; c)).
+  now trivial.
+  now apply ((mkFrame (RestrOfReflCohsSup deps.(_depsReflCohsSup))).(UIP)).
 Defined.
 
 Definition mkCohReflRestrLayerAboveSup0 {p k}
@@ -1357,15 +1314,11 @@ Proof.
   rewrite HSetVec.vec_nth_of_fun.
   rewrite <- !map_subst.
   set (deps' := (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps)).
-  rewrite rew_map with
+  apply rew_chain22 with
     (P := fun b => deps'.(_paintings).2 b)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-  rewrite rew_map with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
-  rewrite 2 rew_compose.
-  apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-  rewrite rew_app_rl. now trivial.
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
+    (g := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+  now trivial.
   now apply (deps'.(_frames).2.(UIP)).
 Defined.
 
@@ -1464,18 +1417,12 @@ Proof.
   set (deps'' := mkDepsReflCohsInf deps.(1)).
   simpl.
   rewrite <- (deps.(_cohReflBelowBelowPaintings).2 q r Hq Hr d0 (HSetVec.vec_nth l θ)).
-  rewrite rew_map with
+  apply rew_chain33 with
     (P := fun b => deps'.(1).(_paintings).2 b)
-    (f := fun x => deps'.(1).(_restrFrames).2 0 leR_O θ x).
-  rewrite rew_map with
-    (P := fun b => deps'.(1).(_paintings).2 b)
-    (f := fun d0 => deps''.(_reflFramesBelow').2 q (Hq ↕ ↑ Hr) d0).
-  rewrite rew_map with
-    (P := fun b => deps'.(1).(_paintings).2 b)
-    (f := fun d1 => deps''.(_reflFramesBelow').2 r.+1 (⇑ Hr) d1).
-  rewrite 4 rew_compose.
-  apply rew_swap with (P := fun b => deps'.(1).(_paintings).2 b).
-  rewrite rew_app_rl. now trivial.
+    (f1 := fun x => deps'.(1).(_restrFrames).2 0 leR_O θ x)
+    (f2 := fun d0 => deps''.(_reflFramesBelow').2 q (Hq ↕ ↑ Hr) d0)
+    (g := fun d1 => deps''.(_reflFramesBelow').2 r.+1 (⇑ Hr) d1).
+  now trivial.
   now apply (deps'.(1).(_frames).2.(UIP)).
 Defined.
 
@@ -1548,27 +1495,20 @@ Proof.
     with (mkReflPaintingBelow deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
   rewrite <- (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr d0 c0).
 
-  rewrite rew_map with
-    (P := fun b => mkPainting
-      (RestrExtOfReflCohsInf (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf)) b)
-    (f := fun x => (mkDepsRestr (CohsOfReflCohsInf
-      (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_restrFrames).2 0 leR_O θ x).
-  rewrite rew_map with
-    (P := fun x => mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps).(1)) x)
-    (f := fun x =>
-      (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf).(_reflFramesAbove).2 q Hq x.1 x.2).
-  rewrite rew_map with
-    (P := fun b => (mkDepsRestr
-      (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs).(1)).(_paintings).2 b)
-    (f := fun x => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr x.1).
-
-  rewrite 4 rew_compose.
-
-  apply rew_swap with (P := fun b => (mkDepsRestr (CohsOfReflCohsInf
-    (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_paintings).2 b).
-  rewrite rew_app_rl. now trivial.
-  now apply ((mkDepsRestr (CohsOfReflCohsInf
-    (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_frames).2.(UIP)).
+  set (inf' := (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf)).
+  set (deps' := mkDepsRestr (CohsOfReflCohsInf inf')).
+  set (deps'' := mkDepsReflCohsInf deps).
+  apply rew_chain33 with
+    (P := fun b => deps'.(_paintings).2 b)
+    (f1 := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
+    (f2 := fun x => inf'.(_reflFramesAbove).2 q Hq x.1 x.2)
+    (g := fun x => (toDepsReflBelow deps''.(_depsCohs2).(_depsCohs)
+      deps''.(_reflFramesBelow')).(_reflFramesBelow).2 r Hr x.1)
+    (E1 := prevCohReflAboveBelowFrames.2 q r.+1 Hq (⇑ Hr) d (l; c))
+    (E3 := coh_below_inf_pair_eq)
+    (F2 := coh_above_sup_pair_eq).
+  now trivial.
+  now apply (deps'.(_frames).2.(UIP)).
 Defined.
 
 Definition mkCohReflAboveBelowLayer0 {p k}
@@ -1596,16 +1536,12 @@ Proof.
   cbn.
   rewrite HSetVec.vec_nth_of_fun.
   set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1))).
-  rewrite rew_map with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
   rewrite <- !map_subst.
-  rewrite rew_map with
+  apply rew_chain22 with
     (P := fun b => deps'.(_paintings).2 b)
-    (f := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr d0).
-  rewrite 2 rew_compose.
-  apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-  rewrite rew_app_rl. now trivial.
+    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
+    (g := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr d0).
+  now trivial.
   now apply (deps'.(_frames).2.(UIP)).
 Defined.
 
@@ -1699,19 +1635,16 @@ Proof.
 
   set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps))).
   set (deps'' := RestrExtOfReflCohsInf (mkDepsReflCohsInf deps)).
-  rewrite rew_map with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-  rewrite rew_map with
-    (P := fun x => mkPainting deps'' x)
-    (f := fun x => (mkDepsReflCohsInf deps).(_reflFramesAbove).2 q (Hq ↕ ↑ Hr) x.1 x.2).
-  rewrite rew_map with
-    (P := fun x => mkPainting deps'' x)
-    (f := fun x => (mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) x.1 x.2).
-  rewrite 4 rew_compose.
-  apply rew_swap with (P := fun x => mkPainting deps'' x).
-  rewrite rew_app_rl. now trivial.
-  now apply (mkFrame (RestrOfReflCohsInf (mkDepsReflCohsInf deps))).(UIP).
+  apply rew_chain33 with
+    (P := fun x => deps'.(_paintings).2 x)
+    (f1 := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
+    (f2 := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r.+1 (⇑ Hr) x.1 x.2)
+    (g := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 q (Hq ↕ ↑ Hr) x.1 x.2)
+    (E1 := prevCohReflAboveAboveFrames.2 q r Hq Hr d (l; c))
+    (E3 := coh_above_sup_q_pair_eq)
+    (F2 := coh_above_sup_r_pair_eq).
+  now trivial.
+  now apply (deps'.(_frames).2.(UIP)).
 Defined.
 
 Definition mkCohReflAboveAboveLayer0 {p k}
@@ -1745,15 +1678,13 @@ Proof.
   rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
     deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
     r Hr x.1 x.2) coh_id_pair_eq tt).
-  rewrite rew_map with
+  apply rew_chain31 with
     (P := fun b => deps'.(_paintings).2 b)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x).
-  rewrite rew_map with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2).
-  rewrite 2 rew_compose.
-  apply rew_swap with (P := fun b => deps'.(_paintings).2 b).
-  rewrite rew_app_rl. now trivial.
+    (f1 := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
+    (f2 := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2)
+    (E1 := mkCohReflAboveBelowFrame deps (mkCohReflAboveBelowFramesPrefix deps) r 0 Hr leR_O d c)
+    (E3 := coh_id_pair_eq).
+  now trivial.
   now apply (deps'.(_frames).2.(UIP)).
 Defined.
 

--- a/theories/νSet/νSet.v
+++ b/theories/νSet/νSet.v
@@ -466,18 +466,14 @@ Proof.
     <- map_subst with (f := fun x => depsCohs.(_restrPaintings).2 q Hq ε x),
     <- map_subst with
         (f := fun x => depsCohs.(_restrPaintings).2 r (Hr ↕ Hq) ω x),
-    -> rew_map with (P := fun x => depsCohs.(_deps).(_paintings).2 x)
-        (f := fun x => depsCohs.(_deps).(_restrFrames).2 O leR_O θ x),
-    -> rew_map with (P := fun x => depsCohs.(_deps).(_paintings).2 x)
-        (f := fun x => depsCohs.(_deps).(_restrFrames).2 r
-          (Hr ↕ Hq) ω x),
-    -> rew_map with (P := fun x => depsCohs.(_deps).(_paintings).2 x)
-        (f := fun x => depsCohs.(_deps).(_restrFrames).2 q _ ε x),
     <- cohPaintings.2.
-  repeat rewrite rew_compose.
-  apply rew_swap with (P := fun x => depsCohs.(_deps).(_paintings).2 x).
-  rewrite rew_app_rl. now trivial.
-  now apply mkCoh2Frame.
+  apply rew_chain33 with
+    (P := fun x => depsCohs.(_deps).(_paintings).2 x)
+    (f1 := fun x => depsCohs.(_deps).(_restrFrames).2 0 leR_O θ x)
+    (f2 := fun x => depsCohs.(_deps).(_restrFrames).2 q Hq ε x)
+    (g := fun x => depsCohs.(_deps).(_restrFrames).2 r (Hr ↕ Hq) ω x).
+  now trivial.
+  now exact (mkCoh2Frame extraDepsCohs prevCohFrames q Hq r Hr ε ω θ d).
 Defined.
 
 Fixpoint mkCohFrames `{extraDepsCohs: DepsCohsExtension p k depsCohs}


### PR DESCRIPTION
### About

This PR is a mirror of PR #20 for `no-funext` branch.

### Overview

All proofs of coherences for layers follow the same pattern at the end of the proof:

1. Multiple `rew_map` rewrites
2. Multiple `rew_compose` rewrites
3. A `rew_swap` application
4. A rewrite with `rew_app_rl`

After the last step the remaining goals are equality of terms (closed by `reflexivity`) plus an equality of paths (closed by `UIP`).

This PR encapsulates the rewrite chain pattern used in layer coherence proofs into a single `rew_chain*` lemma. We add multiple versions of `rew_chain*` lemma to accommodate coherences of different shapes, e.g. `rew_chain33` is a lemma for the coherence establishing equality of 3 arrows to another 3 arrows, the hexagon-shaped coherences.

### Performance

This branch replaces a chain of rewrites with an application of a single lemma in 10 layer coherence proofs. This has positive impact on compilation performance: `νDgnSet.v` compiles in 23.91s with this change on top of `no-funext` branch vs 42.27s without this change.