### PR TITLE
νSet, νDgnSet: fuse entire layer coherence proofs

### DIFF
--- a/theories/νSet/RewLemmas.v
+++ b/theories/νSet/RewLemmas.v
@@ -106,3 +106,105 @@ Proof.
   rewrite !eq_trans_refl_l in coh2.
   now rewrite coh2.
 Qed.
+
+(** Fused layer-chain lemmas.
+
+    On top of [rew_chain*] lemmas above, they additionally absorb the head of the layer
+    coherence proofs — the commutation of the pointwise ([map_subst_app]) and
+    fiberwise ([map_subst]) transports — so that a layer coherence proof
+    reduces to [functional_extensionality_dep] followed by a single
+    application. *)
+
+Lemma rew_layer13 {A T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
+  {rf0: A -> T1 -> X} {rfG: T3 -> X}
+  {G: forall n, S3 n -> P (rfG n)}
+  {𝛉: A}
+  {d1 d2: T1} {E1: d1 = d2}
+  {n1 n2: T3} {D2: n1 = n2}
+  {D1: rfG n2 = rf0 𝛉 d2}
+  {K: rf0 𝛉 d1 = rfG n1}
+  {aL: P (rf0 𝛉 d1)} {aR: S3 n1}
+  {L: forall a, P (rf0 a d1)}:
+  L 𝛉 = aL ->
+  rew [P] K in aL = G n1 aR ->
+  f_equal (rf0 𝛉) E1 = K • (f_equal rfG D2 • D1) ->
+  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
+  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
+Proof.
+  intros HL HC Hpath.
+  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
+    <- (map_subst G D2 aR), <- HC.
+  exact (rew_chain13 P (rf0 𝛉) rfG E1 D1 D2 K aL aL eq_refl Hpath).
+Qed.
+
+Lemma rew_layer22 {A T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
+  {rf0: A -> T1 -> X} {rfG: T3 -> X}
+  {G: forall n, S3 n -> P (rfG n)}
+  {𝛉: A}
+  {d1 d2: T1} {E1: d1 = d2}
+  {n1 n2: T3} {D2: n1 = n2}
+  {E0: rfG n1 = rf0 𝛉 d1}
+  {D1: rfG n2 = rf0 𝛉 d2}
+  {aL: P (rfG n1)} {aR: S3 n1}
+  {L: forall a, P (rf0 a d1)}:
+  L 𝛉 = rew [P] E0 in aL ->
+  aL = G n1 aR ->
+  E0 • f_equal (rf0 𝛉) E1 = f_equal rfG D2 • D1 ->
+  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
+  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
+Proof.
+  intros HL HC Hpath.
+  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
+    <- (map_subst G D2 aR), <- HC.
+  exact (rew_chain22 P (rf0 𝛉) rfG E1 E0 D1 D2 aL aL eq_refl Hpath).
+Qed.
+
+Lemma rew_layer31 {A T1 T2 X: Type} {P: X -> Type} {S2: T2 -> Type}
+  {rf0: A -> T1 -> X} {rfF: T2 -> X}
+  {F: forall m, S2 m -> P (rfF m)}
+  {𝛉: A}
+  {d1 d2: T1} {E1: d1 = d2}
+  {m1 m2: T2} {C2: m1 = m2}
+  {C1: rfF m2 = rf0 𝛉 d1}
+  {D1: rfF m1 = rf0 𝛉 d2}
+  {aL: S2 m1} {aR: P (rfF m1)}
+  {L: forall a, P (rf0 a d1)}:
+  L 𝛉 = rew [P] C1 in F m2 (rew [S2] C2 in aL) ->
+  F m1 aL = aR ->
+  f_equal rfF C2 • (C1 • f_equal (rf0 𝛉) E1) = D1 ->
+  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
+  = rew [P] D1 in aR.
+Proof.
+  intros HL HC Hpath.
+  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
+    <- (map_subst F C2 aL).
+  exact (rew_chain31 P (rf0 𝛉) rfF E1 C1 C2 D1 (F m1 aL) aR HC Hpath).
+Qed.
+
+Lemma rew_layer33 {A T1 T2 T3 X: Type} {P: X -> Type}
+  {S2: T2 -> Type} {S3: T3 -> Type}
+  {rf0: A -> T1 -> X} {rfF: T2 -> X} {rfG: T3 -> X}
+  {F: forall m, S2 m -> P (rfF m)}
+  {G: forall n, S3 n -> P (rfG n)}
+  {𝛉: A}
+  {d1 d2: T1} {E1: d1 = d2}
+  {m1 m2: T2} {C2: m1 = m2}
+  {n1 n2: T3} {D2: n1 = n2}
+  {C1: rfF m2 = rf0 𝛉 d1}
+  {D1: rfG n2 = rf0 𝛉 d2}
+  {K: rfF m1 = rfG n1}
+  {aL: S2 m1} {aR: S3 n1}
+  {L: forall a, P (rf0 a d1)}:
+  L 𝛉 = rew [P] C1 in F m2 (rew [S2] C2 in aL) -> (* reflexivity *)
+  rew [P] K in F m1 aL = G n1 aR -> (* painting coherence *)
+  f_equal rfF C2 • (C1 • f_equal (rf0 𝛉) E1) = K • (f_equal rfG D2 • D1) ->
+  (* 2-dimensional frame coherence, UIP for HSets *)
+  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
+  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
+Proof.
+  intros HL HC Hpath.
+  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
+    <- (map_subst F C2 aL), <- (map_subst G D2 aR), <- HC.
+  exact (rew_chain33 P (rf0 𝛉) rfF rfG E1 C1 C2 D1 D2 K (F m1 aL) (F m1 aL)
+    eq_refl Hpath).
+Qed.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -312,16 +312,15 @@ Definition mkIdRestrReflLayerBelow {p k}
 Proof.
   apply functional_extensionality_dep.
   intros θ.
-  unfold mkRestrLayer, mkReflLayerBelow.
-  rewrite <- map_subst_app, <- map_subst.
-  rewrite <- (deps.(_idRestrReflPaintingsBelow).2 i Hi ε _ (l θ)).
-  set (deps' := deps.(_depsCohs2).(_depsCohs).(_deps)).
-  apply rew_chain13 with
-    (P := fun x => deps'.(_paintings).2 x)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
-    (g := fun d0 => deps'.(_restrFrames).2 i Hi ε d0).
+  eapply (rew_layer13
+    (P := fun x => deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x)
+    (rf0 := fun a x =>
+      deps.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).2 0 leR_O a x)
+    (G := fun m c =>
+      deps.(_depsCohs2).(_depsCohs).(_restrPaintings).2 i Hi ε m c)).
   now trivial.
-  now apply (deps'.(_frames).2.(UIP)).
+  now exact (deps.(_idRestrReflPaintingsBelow).2 i Hi ε _ (l θ)).
+  now apply (deps.(_depsCohs2).(_depsCohs).(_deps).(_frames).2.(UIP)).
 Defined.
 
 Fixpoint mkIdRestrReflFramesBelow {p k} (deps: DepsReflCohsInf p k):
@@ -1110,16 +1109,17 @@ Definition mkCohReflRestrLayerBelowInf {p k}
 Proof.
   apply functional_extensionality_dep.
   intros θ.
-  unfold mkRestrLayer, mkReflLayerBelow.
-  rewrite <- map_subst_app, <- !map_subst.
-  simpl.
-  rewrite <- (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε _ (l θ)).
-  apply rew_chain33 with
+  eapply (rew_layer33
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
-    (f1 := fun x => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ x)
-    (f2 := fun d1 => (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q Hq d1)
-    (g := fun d0 => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) r (Hr ↕ ↑ Hq) ε d0).
+    (rf0 := fun a x =>
+      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O a x)
+    (F := fun m c =>
+      (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 q Hq m c)
+    (G := fun m c =>
+      (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2
+        r (Hr ↕ ↑ Hq) ε m c)).
   now trivial.
+  now exact (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε _ (l θ)).
   now apply ((mkFrame (RestrOfReflCohs2 deps).(1)).(UIP)).
 Defined.
 
@@ -1189,20 +1189,17 @@ Definition mkCohReflRestrLayerBelowSup {p k}
 Proof.
   apply functional_extensionality_dep.
   intros θ.
-  unfold mkRestrLayer, mkReflLayerBelow.
-  rewrite <- map_subst_app, <- !map_subst.
-
-  set (d0 := mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ d).
-
-  set (h := deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε d0 (l θ)).
-  simpl in h |- *; rewrite <- h; clear h.
-
-  apply rew_chain33 with
+  eapply (rew_layer33
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
-    (f1 := fun x => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ x)
-    (f2 := fun d1 => (ReflCohsInfOfReflCohs2 deps).(_reflFramesBelow').2 q (Hq ↕ Hr) d1)
-    (g := fun d1 => mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) r.+1 (⇑ Hr) ε d1).
+    (rf0 := fun a x =>
+      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O a x)
+    (F := fun m c =>
+      (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 q (Hq ↕ Hr) m c)
+    (G := fun m c =>
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
+        r.+1 (⇑ Hr) ε m c)).
   now trivial.
+  now exact (deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε _ (l θ)).
   now apply ((mkFrame (RestrOfReflCohs2 deps).(1)).(UIP)).
 Defined.
 
@@ -1253,34 +1250,26 @@ Definition mkCohReflRestrLayerAboveSup {p k}
 Proof.
   apply functional_extensionality_dep.
   intros θ.
-  unfold mkRestrLayer, mkReflLayerAbove.
-  rewrite <- map_subst_app, <- !map_subst.
-
-  set (d0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_deps).(_restrFrames).2
-    0 leR_O θ d).
-  set (c0 := (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
-    0 leR_O θ d (l; c)).
-
-  simpl.
-  rewrite <- (deps.(_cohReflRestrPaintingsAboveSup).2 q r Hq Hr ε d0 c0).
-
   eassert (coh_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     now exact ((CohsOfReflCohs2 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
     now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; c)). }
-  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
-    deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q Hq x.1 x.2) coh_pair_eq tt).
-
-  unfold CohsOfReflCohs2, CohsOfReflCohsSup.
-  apply rew_chain33 with
+  eapply (rew_layer33
     (P := fun x => mkPainting (RestrExtOfReflCohs2 deps) x)
-    (f1 := fun x => mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) 0 leR_O θ x)
-    (f2 := fun x => (ReflCohsInfOfReflCohs2 deps).(_reflFramesAbove).2 q Hq x.1 x.2)
-    (g := fun d1 => mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) r Hr ε d1)
-    (E1 := prevCohReflRestrFrames.2 q r.+1 Hq (⇑ Hr) ε d (l; c))
-    (E3 := coh_pair_eq)
-    (F2 := prevCohReflRestrFrames.2 q 0 Hq leR_O θ d (l; c)).
+    (rf0 := fun a x =>
+      mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) 0 leR_O a x)
+    (S2 := fun _ => unit)
+    (rfF := fun x =>
+      (ReflCohsInfOfReflCohs2 deps).(_reflFramesAbove).2 q Hq x.1 x.2)
+    (F := fun x _ =>
+      deps.(_depsReflCohsSup).(_reflPaintingsAbove).2 q Hq x.1 x.2)
+    (G := fun m c' =>
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_restrPaintings).2
+        r Hr ε m c')
+    (C2 := coh_pair_eq)
+    (aL := tt)).
   now trivial.
+  now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q r Hq Hr ε _ _).
   now apply ((mkFrame (RestrOfReflCohsSup deps.(_depsReflCohsSup))).(UIP)).
 Defined.
 
@@ -1300,16 +1289,19 @@ Definition mkCohReflRestrLayerAboveSup0 {p k}
     (mkReflFrameAbove0 (mkDepsReflCohsInf deps).(1) d c).2.
 Proof.
   apply functional_extensionality_dep; intro θ.
-  unfold mkRestrLayer.
-  rewrite <- map_subst_app, <- !map_subst.
-  set (deps' := (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps)).
-  unfold CohsOfReflCohsInf, CohsExtOfReflCohs2.
-  apply rew_chain22 with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
-    (g := fun d0 => deps'.(_restrFrames).2 r Hr ε d0).
+  eapply (rew_layer22
+    (P := fun b =>
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_paintings).2 b)
+    (rf0 := fun a x =>
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
+        0 leR_O a x)
+    (G := fun m c =>
+      (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs).(_restrPaintings).2
+        r Hr ε m c)).
   now trivial.
-  now apply (deps'.(_frames).2.(UIP)).
+  now trivial.
+  now apply
+    ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_frames).2.(UIP)).
 Defined.
 
 Definition mkCohReflRestrFrameAboveSup {p k} (deps: DepsReflCohs2 p k)
@@ -1398,21 +1390,22 @@ Definition mkCohReflBelowBelowLayer {p k}
 Proof.
   apply functional_extensionality_dep.
   intro θ.
-  unfold mkReflLayerBelow.
-  rewrite <- map_subst_app, <- !map_subst.
-  set (d0 := (CohsOfReflCohsInf (ReflCohsInfOfReflCohs2 deps)).(_deps)
-    .(_restrFrames).2 0 leR_O θ d).
-  set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1))).
-  set (deps'' := mkDepsReflCohsInf deps.(1)).
-  simpl.
-  rewrite <- (deps.(_cohReflBelowBelowPaintings).2 q r Hq Hr d0 (l θ)).
-  apply rew_chain33 with
-    (P := fun b => deps'.(1).(_paintings).2 b)
-    (f1 := fun x => deps'.(1).(_restrFrames).2 0 leR_O θ x)
-    (f2 := fun d0 => deps''.(_reflFramesBelow').2 q (Hq ↕ ↑ Hr) d0)
-    (g := fun d1 => deps''.(_reflFramesBelow').2 r.+1 (⇑ Hr) d1).
+  eapply (rew_layer33
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
+        .(1).(_paintings).2 b)
+    (rf0 := fun a x =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
+        .(1).(_restrFrames).2 0 leR_O a x)
+    (F := fun m c =>
+      (mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow).2 q (Hq ↕ ↑ Hr) m c)
+    (G := fun m c =>
+      (mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow).2 r.+1 (⇑ Hr) m c)).
   now trivial.
-  now apply (deps'.(1).(_frames).2.(UIP)).
+  now exact (deps.(_cohReflBelowBelowPaintings).2 q r Hq Hr _ (l θ)).
+  now apply
+    ((mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
+      .(1).(_frames).2.(UIP)).
 Defined.
 
 Fixpoint mkCohReflBelowBelowFrames {p k} (deps: DepsReflCohs2 p k):
@@ -1458,45 +1451,44 @@ Definition mkCohReflAboveBelowLayer {p k}
 Proof.
   apply functional_extensionality_dep.
   intro θ.
-  unfold mkReflLayerBelow, mkReflLayerAbove.
-  rewrite <- map_subst_app.
-
-  set (d0 := (RestrOfReflCohs2 deps).(_restrFrames).2 0 leR_O θ d).
-  set (c0 := (CohsOfReflCohs2 deps).(_restrPaintings).2 0 leR_O θ d (l; c)).
   eassert (coh_below_inf_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact ((ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf).2 r 0 Hr leR_O θ d).
     - now exact (deps.(_cohReflRestrPaintingsBelowInf).2 r 0 Hr leR_O θ d (l; c)). }
-  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
-    (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x.1 x.2)
-    coh_below_inf_pair_eq tt).
-
   eassert (coh_above_sup_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 Hq leR_O θ d (l; c)).
     - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q 0 Hq leR_O θ d (l; c)). }
-  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
-    (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr x.1 x.2)
-    coh_above_sup_pair_eq tt).
-
-  change_no_check ((mkDepsReflCohsInf deps).(_reflPaintingsBelow).2)
-    with (mkReflPaintingBelow deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
-  rewrite <- (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr d0 c0).
-
-  set (inf' := (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf)).
-  set (deps' := mkDepsRestr (CohsOfReflCohsInf inf')).
-  set (deps'' := mkDepsReflCohsInf deps).
-  apply rew_chain33 with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f1 := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
-    (f2 := fun x => inf'.(_reflFramesAbove).2 q Hq x.1 x.2)
-    (g := fun x => (toDepsReflBelow deps''.(_depsCohs2).(_depsCohs)
-      deps''.(_reflFramesBelow')).(_reflFramesBelow).2 r Hr x.1)
-    (E1 := prevCohReflAboveBelowFrames.2 q r.+1 Hq (⇑ Hr) d (l; c))
-    (E3 := coh_below_inf_pair_eq)
-    (F2 := coh_above_sup_pair_eq).
+  eapply (rew_layer33
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsInf
+        (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_paintings).2 b)
+    (rf0 := fun a x =>
+      (mkDepsRestr (CohsOfReflCohsInf
+        (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_restrFrames).2
+        0 leR_O a x)
+    (S2 := fun _ => unit)
+    (rfF := fun x =>
+      (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf).(_reflFramesAbove).2
+        q Hq x.1 x.2)
+    (F := fun x _ =>
+      (mkDepsReflCohsSup deps).(1).(_reflPaintingsAbove).2 q Hq x.1 x.2)
+    (S3 := fun _ => unit)
+    (rfG := fun x =>
+      (toDepsReflBelow (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs)
+        (mkDepsReflCohsInf deps).(_reflFramesBelow')).(_reflFramesBelow).2
+        r Hr x.1)
+    (G := fun x _ =>
+      (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr x.1 x.2)
+    (* (C2 := coh_below_inf_pair_eq) *)
+    (D2 := coh_above_sup_pair_eq)
+    (aL := tt)
+    (aR := tt)).
   now trivial.
-  now apply (deps'.(_frames).2.(UIP)).
+  now exact (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr _ _).
+  now apply
+    ((mkDepsRestr (CohsOfReflCohsInf
+      (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_frames).2.(UIP)).
 Defined.
 
 Definition mkCohReflAboveBelowLayer0 {p k}
@@ -1517,16 +1509,20 @@ Definition mkCohReflAboveBelowLayer0 {p k}
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).2.
 Proof.
   apply functional_extensionality_dep; intro θ.
-  unfold mkReflLayerBelow.
-  rewrite <- map_subst_app, <- !map_subst.
-  set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1))).
-  unfold CohsOfReflCohsInf, CohsExtOfReflCohs2.
-  apply rew_chain22 with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
-    (g := fun d0 => (mkDepsReflCohsInf deps).(_reflFramesBelow').2 r Hr d0).
+  eapply (rew_layer22
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
+        .(_paintings).2 b)
+    (rf0 := fun a x =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
+        .(_restrFrames).2 0 leR_O a x)
+    (G := fun m c =>
+      (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr m c)).
   now trivial.
-  now apply (deps'.(_frames).2.(UIP)).
+  now trivial.
+  now apply
+    ((mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
+      .(_frames).2.(UIP)).
 Defined.
 
 Definition mkCohReflAboveBelowFrame {p k} (deps: DepsReflCohs2 p k)
@@ -1591,44 +1587,40 @@ Definition mkCohReflAboveAboveLayer {p k}
 Proof.
   apply functional_extensionality_dep.
   intro θ.
-  unfold mkReflLayerAbove.
-  rewrite <- map_subst_app.
-
-  set (d0 := (RestrOfReflCohs2 deps).(_restrFrames).2 0 leR_O θ d).
-  set (c0 := (CohsOfReflCohs2 deps).(_restrPaintings).2 0 leR_O θ d (l; c)).
-
   eassert (coh_above_sup_r_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 r 0 Hr leR_O θ d (l; c)).
     - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 r 0 Hr leR_O θ d (l; c)). }
-  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
-    (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q (Hq ↕ ↑ Hr) x.1 x.2)
-    coh_above_sup_r_pair_eq tt).
-
   eassert (coh_above_sup_q_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 (Hq ↕ Hr) leR_O θ d (l; c)).
     - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q 0 (Hq ↕ Hr) leR_O θ d (l; c)). }
-  rewrite <- (map_subst (P := fun _ => unit) (fun x _ =>
-    (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) x.1 x.2)
-    coh_above_sup_q_pair_eq tt).
-
-  change_no_check ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2)
-    with (mkReflPaintingAbove deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)).
-  rewrite <- (deps.(_cohReflAboveAbovePaintings).2 q r Hq Hr d0 c0).
-
-  set (deps' := mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps))).
-  set (deps'' := RestrExtOfReflCohsInf (mkDepsReflCohsInf deps)).
-  apply rew_chain33 with
-    (P := fun x => deps'.(_paintings).2 x)
-    (f1 := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
-    (f2 := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r.+1 (⇑ Hr) x.1 x.2)
-    (g := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 q (Hq ↕ ↑ Hr) x.1 x.2)
-    (E1 := prevCohReflAboveAboveFrames.2 q r Hq Hr d (l; c))
-    (E3 := coh_above_sup_q_pair_eq)
-    (F2 := coh_above_sup_r_pair_eq).
+  eapply (rew_layer33
+    (P := fun x =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
+        .(_paintings).2 x)
+    (rf0 := fun a x =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
+        .(_restrFrames).2 0 leR_O a x)
+    (S2 := fun _ => unit)
+    (rfF := fun x =>
+      (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r.+1 (⇑ Hr) x.1 x.2)
+    (F := fun x _ =>
+      (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) x.1 x.2)
+    (S3 := fun _ => unit)
+    (rfG := fun x =>
+      (mkReflFramesAbove deps.(_depsReflCohsSup)).2 q (Hq ↕ ↑ Hr) x.1 x.2)
+    (G := fun x _ =>
+      (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 q (Hq ↕ ↑ Hr) x.1 x.2)
+    (C2 := coh_above_sup_q_pair_eq)
+    (D2 := coh_above_sup_r_pair_eq)
+    (aL := tt)
+    (aR := tt)).
   now trivial.
-  now apply (deps'.(_frames).2.(UIP)).
+  now exact (deps.(_cohReflAboveAbovePaintings).2 q r Hq Hr _ _).
+  now apply
+    ((mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
+      .(_frames).2.(UIP)).
 Defined.
 
 Definition mkCohReflAboveAboveLayer0 {p k}
@@ -1648,27 +1640,31 @@ Definition mkCohReflAboveAboveLayer0 {p k}
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r Hr d c)
     ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r Hr d c).
 Proof.
-  set (deps' := mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps))).
   apply functional_extensionality_dep; intro θ.
-  unfold mkReflLayerAbove, mkReflLayerAbove0.
-  unfold eq_rect_r; cbn.
-  rewrite <- map_subst_app.
   eassert (coh_id_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact (mkIdRestrReflFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
     - now exact (mkIdRestrReflPaintingBelow deps.(_depsReflCohsSup)
         deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
-  rewrite <- (map_subst (P := fun _ => unit) (fun x _ => mkReflPaintingAbove
-    deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
-    r Hr x.1 x.2) coh_id_pair_eq tt).
-  apply rew_chain31 with
-    (P := fun b => deps'.(_paintings).2 b)
-    (f1 := fun x => deps'.(_restrFrames).2 0 leR_O θ x)
-    (f2 := fun x => (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2)
-    (E1 := mkCohReflAboveBelowFrame deps (mkCohReflAboveBelowFramesPrefix deps) r 0 Hr leR_O d c)
-    (E3 := coh_id_pair_eq).
+  eapply (rew_layer31
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))
+        .(_paintings).2 b)
+    (rf0 := fun a x =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))
+        .(_restrFrames).2 0 leR_O a x)
+    (S2 := fun _ => unit)
+    (rfF := fun x =>
+      (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2)
+    (F := fun x _ => mkReflPaintingAbove
+      deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) r Hr x.1 x.2)
+    (C2 := coh_id_pair_eq)
+    (aL := tt)).
   now trivial.
-  now apply (deps'.(_frames).2.(UIP)).
+  now trivial.
+  now apply
+    ((mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))
+      .(_frames).2.(UIP)).
 Defined.
 
 Definition mkCohReflAboveAboveFrame {p k} (deps: DepsReflCohs2 p k)

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1480,7 +1480,7 @@ Proof.
         r Hr x.1)
     (G := fun x _ =>
       (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr x.1 x.2)
-    (* (C2 := coh_below_inf_pair_eq) *)
+    (C2 := coh_below_inf_pair_eq)
     (D2 := coh_above_sup_pair_eq)
     (aL := tt)
     (aR := tt)).

--- a/theories/νSet/νSet.v
+++ b/theories/νSet/νSet.v
@@ -458,18 +458,13 @@ Definition mkCohLayer `{extraDepsCohs: DepsCohsExtension p.+1 k depsCohs}
       (mkRestrLayer (mkRestrPaintings extraDepsCohs).1 _ q.+1 (⇑ Hq) ε d l).
 Proof.
   apply functional_extensionality_dep; intros 𝛉.
-  rewrite <- map_subst_app. unfold mkRestrLayer; simpl.
-  rewrite
-    <- map_subst with (f := fun x => depsCohs.(_restrPaintings).2 q Hq ε x),
-    <- map_subst with
-        (f := fun x => depsCohs.(_restrPaintings).2 r (Hr ↕ Hq) ω x),
-    <- cohPaintings.2.
-  apply rew_chain33 with
+  eapply (rew_layer33
     (P := fun x => depsCohs.(_deps).(_paintings).2 x)
-    (f1 := fun x => depsCohs.(_deps).(_restrFrames).2 0 leR_O 𝛉 x)
-    (f2 := fun x => depsCohs.(_deps).(_restrFrames).2 q Hq ε x)
-    (g := fun x => depsCohs.(_deps).(_restrFrames).2 r (Hr ↕ Hq) ω x).
+    (rf0 := fun a x => depsCohs.(_deps).(_restrFrames).2 0 leR_O a x)
+    (F := fun m c => depsCohs.(_restrPaintings).2 q Hq ε m c)
+    (G := fun m c => depsCohs.(_restrPaintings).2 r (Hr ↕ Hq) ω m c)).
   now trivial.
+  now exact (cohPaintings.2 q Hq r Hr ε ω _ (l 𝛉)).
   now exact (mkCoh2Frame extraDepsCohs prevCohFrames q Hq r Hr ε ω d 𝛉).
 Defined.
 


### PR DESCRIPTION
This is a follow-up to the previous `rew_chain*` refactoring. The new propsoed `rew_layer*` lemmas take the same idea further - they also absorb the initial part of layer coherence proofs (rewrites with `map_subst` and `map_subst_app`). This shows that all layer coherence proofs have entirely one and the same structure.