### PR TITLE
SSGpd: the construction of semi-simplicial groupoids

### DIFF
--- a/.github/rocq-9.2-blacklist.txt
+++ b/.github/rocq-9.2-blacklist.txt
@@ -1,0 +1,1 @@
+theories/νSet/SSGpd.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,7 +1,11 @@
 -R _build/default/theories Bonak
-theories/νSet/HSet.v
-theories/νSet/Notation.v
-theories/νSet/RewLemmas.v
 theories/νSet/SigT.v
+theories/νSet/Notation.v
+theories/νSet/LeSProp.v
+theories/νSet/HSet.v
+theories/νSet/HGpd.v
+theories/νSet/RewLemmas.v
+theories/νSet/SSGpdLemmas.v
+theories/νSet/SSGpd.v
 theories/νSet/νSet.v
-theories/νSetDgn/νSetDgn.v
+theories/νSet/νDgnSet.v

--- a/theories/νSet/HGpd.v
+++ b/theories/νSet/HGpd.v
@@ -1,0 +1,148 @@
+(** This file defines HGpd and provides unit and sigT on HGpd. *)
+
+Import Logic.EqNotations.
+
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT HSet.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Universe Polymorphism.
+
+(** [HGpd] is the next truncation level: its identity types are [HSet]s. *)
+
+Record HGpd := {
+  GDom:> Type;
+  GUIP {x y: GDom} {h g: x = y} {p q: h = g}: p = q;
+}.
+
+Definition hpaths {A: HGpd} (x y: A): HSet := {|
+  Dom := x = y;
+  UIP := @GUIP A x y;
+|}.
+
+Lemma retract_eq {A B: Type} (f: A -> B) (g: B -> A)
+  (H: forall x, g (f x) = x) {x y: A} (p: x = y):
+  p = eq_trans (eq_sym (H x)) (eq_trans (f_equal g (f_equal f p)) (H y)).
+Proof.
+  destruct p; simpl. destruct (H x). reflexivity.
+Defined.
+
+Lemma retract_UIP {A: Type} {B: HSet} (f: A -> B) (g: B -> A)
+  (H: forall x, g (f x) = x) (x y: A) (p q: x = y): p = q.
+Proof.
+  rewrite (retract_eq f g H p).
+  rewrite (retract_eq f g H q).
+  now rewrite (@UIP B (f x) (f y) (f_equal f p) (f_equal f q)).
+Defined.
+
+(** A transparent copy of Stdlib's [Eqdep_dec.UIP_dec] (Hedberg's
+    theorem): the stdlib proof chain is [Qed]-opaque, which would leave
+    normal forms of groupoid-level coherences stuck on it. *)
+
+Section EqdepDec.
+
+Variable A: Type.
+
+Let comp {x y y': A} (eq1: x = y) (eq2: x = y'): y = y' :=
+  eq_ind _ (fun a => a = y') eq2 _ eq1.
+
+Remark trans_sym_eq {x y: A} (u: x = y): comp u u = eq_refl y.
+Proof.
+  case u; trivial.
+Defined.
+
+Variable x: A.
+Variable eq_dec: forall y: A, x = y \/ x <> y.
+
+Let nu {y: A} (u: x = y): x = y :=
+  match eq_dec y with
+  | or_introl eqxy => eqxy
+  | or_intror neqxy => False_ind _ (neqxy u)
+  end.
+
+#[local]
+Lemma nu_constant {y: A} (u v: x = y): nu u = nu v.
+Proof.
+  unfold nu.
+  destruct (eq_dec y) as [Heq|Hneq].
+  - reflexivity.
+  - case Hneq; trivial.
+Defined.
+
+Let nu_inv {y: A} (v: x = y): x = y := comp (nu (eq_refl x)) v.
+
+Remark nu_left_inv_on {y: A} (u: x = y): nu_inv (nu u) = u.
+Proof.
+  case u; unfold nu_inv.
+  apply trans_sym_eq.
+Defined.
+
+Theorem eq_proofs_unicity_on (y: A) (p1 p2: x = y): p1 = p2.
+Proof.
+  elim (nu_left_inv_on p1).
+  elim (nu_left_inv_on p2).
+  elim (nu_constant p1 p2).
+  reflexivity.
+Defined.
+
+End EqdepDec.
+
+Theorem UIP_dec (A: Type) (eq_dec: forall x y: A, {x = y} + {x <> y})
+  (x y: A) (p1 p2: x = y): p1 = p2.
+Proof.
+  apply eq_proofs_unicity_on.
+  intros y'; destruct (eq_dec x y'); [now left | now right].
+Defined.
+
+Lemma unit_GUIP (x y: unit) (h g: x = y) (p q: h = g): p = q.
+Proof.
+  apply UIP_dec. intros u v. left. now apply unit_UIP.
+Defined.
+
+
+Definition gunit@{m}: HGpd@{m} := {|
+  GDom := unit;
+  GUIP := unit_GUIP;
+|}.
+
+
+(** [sigT] seen as a type constructor on [HGpd] *)
+
+Definition sigT_path_code {A: HGpd} {B: A -> HGpd} (x y: {a: A &T B a}):
+  HSet :=
+  hsigT (A := hpaths x.1 y.1)
+    (fun p => hpaths (rew [B] p in x.2) y.2).
+
+Definition sigT_path_encode {A: HGpd} {B: A -> HGpd} {x y: {a: A &T B a}}
+  (p: x = y): sigT_path_code x y :=
+  (projT1_eq p; projT2_eq p).
+
+Definition sigT_path_decode {A: HGpd} {B: A -> HGpd} {x y: {a: A &T B a}}
+  (p: sigT_path_code x y): x = y :=
+  (= p.1; p.2).
+
+Lemma sigT_path_decode_encode {A: HGpd} {B: A -> HGpd} {x y: {a: A &T B a}}
+  (p: x = y): sigT_path_decode (sigT_path_encode p) = p.
+Proof.
+  symmetry. apply sigT_decompose_eq.
+Defined.
+
+Lemma sigT_GUIP {A: HGpd} {B: A -> HGpd} (x y: {a: A &T B a})
+  (h g: x = y) (p q: h = g): p = q.
+Proof.
+  eapply retract_UIP with
+    (f := @sigT_path_encode A B x y)
+    (g := @sigT_path_decode A B x y).
+  exact sigT_path_decode_encode.
+Defined.
+
+Definition gsigT {A: HGpd} (B: A -> HGpd): HGpd := {|
+  GDom := {a: A &T B a};
+  GUIP := sigT_GUIP;
+|}.
+
+Set Warnings "-notation-overridden".
+
+Notation "{ x & P }" := (gsigT (fun x => P%type)): type_scope.
+Notation "{ x : A & P }" := (gsigT (A := A) (fun x => P%type)): type_scope.

--- a/theories/νSet/HSet.v
+++ b/theories/νSet/HSet.v
@@ -22,12 +22,12 @@ Record HSet := {
 Lemma unit_UIP (x y: unit) (h g: x = y): h = g.
 Proof.
   destruct g, x; now apply UIP_refl_unit.
-Qed.
+Defined.
 
 Lemma bool_UIP (x y: bool) (h g: x = y): h = g.
 Proof.
   destruct g, x; now apply UIP_refl_bool.
-Qed.
+Defined.
 
 Definition hunit@{m}: HSet@{m} := {|
   Dom := unit;
@@ -45,13 +45,13 @@ Lemma sigT_eq {A: Type} {B} {x y: {a: A &T B a}}:
   (x.1; x.2) = (y.1; y.2) -> x = y.
 Proof.
   now easy.
-Qed.
+Defined.
 
 Lemma sigT_decompose_eq {A: Type} {B} {x y: {a: A &T B a}} {p: x = y}:
   p = (= projT1_eq p; projT2_eq p).
 Proof.
   now destruct p, x.
-Qed.
+Defined.
 
 Lemma sigT_decompose {A: Type} {B: A -> Type} {u v: {a: A &T B a}} {p q: u = v}
   {alpha: projT1_eq p = projT1_eq q}
@@ -60,13 +60,13 @@ Lemma sigT_decompose {A: Type} {B: A -> Type} {u v: {a: A &T B a}} {p q: u = v}
 Proof.
   rewrite (sigT_decompose_eq (p := q)), (sigT_decompose_eq (p := p)).
   destruct u, v; simpl. now destruct beta, alpha.
-Qed.
+Defined.
 
 Lemma sigT_UIP {A: HSet} {B: A -> HSet} (x y: {a: A &T B a}) (p q: x = y):
   p = q.
 Proof.
   unshelve eapply sigT_decompose. now apply A. now apply (B y.1).
-Qed.
+Defined.
 
 Definition hsigT {A: HSet} (B: A -> HSet): HSet := {|
   Dom := {a: A &T B a};

--- a/theories/νSet/SSGpd.v
+++ b/theories/νSet/SSGpd.v
@@ -1,0 +1,1143 @@
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT HSet HGpd Notation LeSProp SSGpdLemmas.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module SSGpd.
+
+(** The type of lists {frame(n,0);...;frame(n,p-1)} for arbitrary k := n-p
+    (the non-mandatory dependency in k is useful for type inference) *)
+
+Fixpoint mkFrameTypes p k: Type :=
+  match p with
+  | 0 => unit
+  | S p => { frames: mkFrameTypes p k.+1 &T HGpd }
+  end.
+
+(** The type of lists {painting(n,0);...;painting(n,p-1)} for n := k+p *)
+
+Fixpoint mkPaintingTypes p k: mkFrameTypes p k -> Type :=
+  match p with
+  | 0 => fun _ => unit
+  | S p => fun frames =>
+    { paintings: mkPaintingTypes p k.+1 frames.1 &T frames.2 -> HGpd }
+  end.
+
+(** A helper type so as to mutually build the types of restrFrames and
+    the body of frames using a single fixpoint *)
+
+Class RestrFrameTypeBlock p k := {
+  RestrFrameTypesDef: Type;
+  FrameDef: RestrFrameTypesDef -> mkFrameTypes p.+1 k;
+}.
+
+(**
+For n and p<=n be given, and assuming {frame(n,0);...;frame(n,p)} and
+{painting(n,0);...;painting(n,p)}, we build the list of pairs:
+- of the types RestrFrameTypes(n,p) of the list
+  {restrFrame(n,0);...;restrFrame(n,p-1)}
+  (represented as an inhabitant of a sigma-type
+   {R:RestrFrameTypes(n,0) & ... & RestrFrameTypes(n,p-1)})
+- and of the list {frame(n+1,0);...;frame(n+1,p)} in function of effective
+  restrFrames of type RestrFrameTypes(n,p)
+
+That is, we build:
+- p = 0 : { RestrFrameTypes(n,0..0-1) := unit ;
+                  (which denotes the empty list of restrFrameTypes)
+            Frames(n+1,0..0)(restrFrames^n_{0..0-1}) := {unit}
+                  (representing lists by Sigma-types) }
+- p = 1 : { RestrFrameTypes(n,0..0) = {_:unit & restrFrameType(n,0)} ;
+                  (thus denoting the singleton list {restrFrameType(n,0})
+            Frames(n+1,0..1)(restrFrames(n,0..0) :=
+                  {unit;{d:Frame(n,0)&Painting(n,0)(restrFrame(n,0)(d)}} }
+- ...
+- p     : { RestrFrameTypes(n,0..p-1) =
+              {RestrFrameType(n,0) & ... & RestrFrameType(n,p-1)} ;
+            Frames(n+1,0..p)(restrFrames(n,0..p-1)) :=
+              {frame(n+1,0);...;frame(n+1,p)} }
+
+  In practise, it is convenient to work with the difference k := n-p
+  rather than n itself. So, below, k is the difference.
+*)
+
+Generalizable Variables p k frames.
+
+Definition mkRestrFrameType
+  `(prevFrames: mkFrameTypes p.+1 k.+1)
+   (frames: mkFrameTypes p.+1 k) :=
+  forall q (Hq: q <= k), prevFrames.2 -> frames.2.
+
+Definition mkRestrFrameTypesStep `(frames: mkFrameTypes p.+1 k)
+  (prev: RestrFrameTypeBlock p k.+1) :=
+  { R: prev.(RestrFrameTypesDef) &T mkRestrFrameType (prev.(FrameDef) R) frames }.
+
+Definition mkLayer `{frames: mkFrameTypes p.+1 k}
+  {prevFrames: mkFrameTypes p.+1 k.+1}
+  (restrFrame: mkRestrFrameType prevFrames frames)
+  {painting: frames.2 -> HGpd}
+  (d: prevFrames.2) :=
+  painting (restrFrame 0 leR_O d).
+
+Fixpoint mkRestrFrameTypesAndFrames {p k}:
+  forall `(paintings: mkPaintingTypes p k frames), RestrFrameTypeBlock p k :=
+  match p with
+  | 0 => fun frames paintings =>
+    {|
+      RestrFrameTypesDef := unit;
+      FrameDef _ := (tt; gunit): mkFrameTypes 1 k
+    |}
+  | p.+1 => fun frames paintings =>
+    let prev :=
+      mkRestrFrameTypesAndFrames paintings.1 in
+    let frames' := prev.(FrameDef) in
+    {|
+      RestrFrameTypesDef := mkRestrFrameTypesStep frames prev;
+      FrameDef R :=
+        (frames' R.1; { d: (frames' R.1).2 &
+          mkLayer R.2 (painting := paintings.2) d }): mkFrameTypes p.+2 k
+    |}
+  end.
+
+Definition mkRestrFrameTypes `(paintings: mkPaintingTypes p k frames) :=
+  (mkRestrFrameTypesAndFrames paintings).(RestrFrameTypesDef).
+
+Class DepsRestr p k := {
+  _frames: mkFrameTypes p k;
+  _paintings: mkPaintingTypes p k _frames;
+  _restrFrames: mkRestrFrameTypes _paintings;
+}.
+
+Instance toDepsRestr `{paintings: mkPaintingTypes p k frames}
+  (restrFrames: mkRestrFrameTypes paintings) : DepsRestr p k :=
+  {| _restrFrames := restrFrames |}.
+
+#[local]
+Instance proj1DepsRestr `(deps: DepsRestr p.+1 k): DepsRestr p k.+1 :=
+{|
+  _frames := deps.(_frames).1;
+  _paintings := deps.(_paintings).1;
+  _restrFrames := deps.(_restrFrames).1;
+|}.
+
+Declare Scope depsrestr_scope.
+Delimit Scope depsrestr_scope with depsrestr.
+Bind Scope depsrestr_scope with DepsRestr.
+Notation "x .(1)" := (proj1DepsRestr x%_depsrestr)
+  (at level 1, left associativity, format "x .(1)"): depsrestr_scope.
+
+Definition mkFrames `(deps: DepsRestr p k): mkFrameTypes p.+1 k :=
+  (mkRestrFrameTypesAndFrames
+    deps.(_paintings)).(FrameDef) deps.(_restrFrames).
+
+Definition mkFrame `(deps: DepsRestr p k): HGpd := (mkFrames deps).2.
+
+Inductive DepsRestrExtension p: forall k, DepsRestr p k -> Type :=
+| TopRestrDep {deps} (E: mkFrame deps -> HGpd): DepsRestrExtension p 0 deps
+| AddRestrDep {k} deps:
+  DepsRestrExtension p.+1 k deps -> DepsRestrExtension p k.+1 deps.(1).
+
+Arguments TopRestrDep {p deps}.
+Arguments AddRestrDep {p k} deps.
+
+Declare Scope extra_depsrestr_scope.
+Delimit Scope extra_depsrestr_scope with extradepsrestr.
+Bind Scope extra_depsrestr_scope with DepsRestrExtension.
+Notation "( x ; y )" := (AddRestrDep x y)
+  (at level 0, format "( x ; y )"): extra_depsrestr_scope.
+
+(* Example: if p := 0, extraDeps := ({},E) mkPainting:= {E} *)
+
+Generalizable Variables deps.
+
+Fixpoint mkPainting `(extraDeps: DepsRestrExtension p k deps):
+  mkFrame deps -> HGpd :=
+  match extraDeps with
+  | TopRestrDep E => fun d => E d
+  | AddRestrDep deps extraDeps => fun (d: mkFrame deps.(1)) =>
+      {l: mkLayer deps.(_restrFrames).2 d & mkPainting extraDeps (d; l)}
+  end.
+
+Fixpoint mkPaintingsPrefix {p k}:
+  forall `(extraDeps: DepsRestrExtension p k deps),
+    mkPaintingTypes p k.+1 (mkFrames deps).1 :=
+  match p with
+  | 0 => fun _ _ => tt
+  | S p => fun deps extraDeps =>
+      (mkPaintingsPrefix (deps; extraDeps)%extradepsrestr;
+       mkPainting (deps; extraDeps)%extradepsrestr)
+  end.
+
+Definition mkPaintings {p k}: forall `(extraDeps: DepsRestrExtension p k deps),
+  mkPaintingTypes p.+1 k (mkFrames deps) :=
+  fun deps extraDeps => (mkPaintingsPrefix extraDeps; mkPainting extraDeps).
+
+Definition mkRestrPaintingType
+  `(extraDeps: DepsRestrExtension p.+1 k deps) :=
+  forall q (Hq: q <= k) (d: mkFrame deps.(1)),
+  (mkPaintings (deps; extraDeps)).2 d ->
+  deps.(_paintings).2 (deps.(_restrFrames).2 q Hq d).
+
+Fixpoint mkRestrPaintingTypes {p}:
+  forall `(extraDeps: DepsRestrExtension p k deps), Type :=
+  match p with
+  | 0 => fun _ _ _ => unit
+  | S p =>
+    fun k deps extraDeps =>
+    { _: mkRestrPaintingTypes (deps; extraDeps) &T
+      mkRestrPaintingType extraDeps }
+  end.
+
+(** A helper type so as to mutually build the types of cohFrames and
+    the body of restrFrames using a single fixpoint *)
+
+Class CohFrameTypeBlock `{extraDeps: DepsRestrExtension p k deps} := {
+  CohFrameTypesDef: Type;
+  RestrFramesDef: CohFrameTypesDef -> mkRestrFrameTypes (mkPaintings extraDeps)
+}.
+
+(** Auxiliary definitions to mutually build cohFrameTypes and restrFrames *)
+
+Definition mkCohFrameType `{extraDeps: DepsRestrExtension p.+1 k deps}
+  (prevRestrFrames: mkRestrFrameTypes (mkPaintings (deps; extraDeps))): Type :=
+  forall q (Hq: q <= k) r (Hr: r <= q)
+    (d: mkFrame (toDepsRestr prevRestrFrames).(1)),
+  deps.(_restrFrames).2 q Hq (prevRestrFrames.2 r (Hr ↕ (↑ Hq)) d) =
+  deps.(_restrFrames).2 r (Hr ↕ Hq) (prevRestrFrames.2 q.+1 (⇑ Hq) d).
+
+Definition mkCohFrameTypesStep `{extraDeps: DepsRestrExtension p.+1 k deps}
+  (prev: CohFrameTypeBlock (extraDeps := (deps; extraDeps))): Type :=
+  { Q: prev.(CohFrameTypesDef) &T mkCohFrameType (prev.(RestrFramesDef) Q) }.
+
+Definition mkRestrLayer `{extraDeps: DepsRestrExtension p.+1 k deps}
+  {prevRestrFrames: mkRestrFrameTypes (mkPaintings (deps;extraDeps))}
+  (restrPainting: mkRestrPaintingType extraDeps)
+  (cohFrame: mkCohFrameType prevRestrFrames)
+  q (Hq: q <= k)
+  (d: mkFrame (toDepsRestr prevRestrFrames).(1))
+  (l: mkLayer prevRestrFrames.2 d):
+  mkLayer deps.(_restrFrames).2 (prevRestrFrames.2 q.+1 (⇑ Hq) d) :=
+    rew [deps.(_paintings).2] cohFrame q Hq 0 leR_O d in
+    restrPainting q Hq _ l.
+
+(** Under previous assumptions, and, additionally:
+    - {restrPainting(n,0);...;restrPainting(n,p-1)}
+    we mutually build the pair of:
+    - the list of types for {cohFrame(n,0);...;cohFrame(n,p-1)}
+    - definitions of {restrFrame(n+1,0);...;restrFrame(n+1,p)} *)
+
+Fixpoint mkCohFrameTypesAndRestrFrames {p k}:
+  forall `{extraDeps: DepsRestrExtension p k deps}
+  (restrPaintings: mkRestrPaintingTypes extraDeps), CohFrameTypeBlock :=
+  match p with
+  | 0 =>
+    fun deps extraDeps restrPaintings =>
+    {|
+      CohFrameTypesDef := unit;
+      RestrFramesDef _ := (tt; fun _ _ _ => tt)
+    |}
+  | S p =>
+    fun deps extraDeps restrPaintings =>
+    let prev := mkCohFrameTypesAndRestrFrames restrPaintings.1 in
+    let restrFrames := prev.(RestrFramesDef) in
+    {|
+      CohFrameTypesDef := mkCohFrameTypesStep prev;
+      RestrFramesDef Q :=
+      let restrFrame q (Hq: q <= k)
+        (d: mkFrame (toDepsRestr (restrFrames Q.1))) :=
+          ((restrFrames Q.1).2 q.+1 (⇑ Hq) d.1;
+           mkRestrLayer restrPaintings.2 Q.2 q _ d.1 d.2)
+      in (restrFrames Q.1; restrFrame)
+    |}
+  end.
+
+(* Example: if p := 0, extraDeps := ({},E)
+   mkCohFrameTypes := {} *)
+
+Definition mkCohFrameTypes `{extraDeps: DepsRestrExtension p k deps}
+  (restrPaintings: mkRestrPaintingTypes extraDeps) :=
+  (mkCohFrameTypesAndRestrFrames restrPaintings).(CohFrameTypesDef).
+
+Class DepsCohs p k := {
+  _deps: DepsRestr p k;
+  _extraDeps: DepsRestrExtension p k _deps;
+  _restrPaintings: mkRestrPaintingTypes _extraDeps;
+  _cohs: mkCohFrameTypes _restrPaintings;
+}.
+
+#[local]
+Instance toDepsCohs `{extraDeps: DepsRestrExtension p k deps}
+  {restrPaintings: mkRestrPaintingTypes extraDeps}
+  (cohs: mkCohFrameTypes restrPaintings): DepsCohs p k :=
+  {| _cohs := cohs |}.
+
+#[local]
+Instance proj1DepsCohs `(depsCohs: DepsCohs p.+1 k): DepsCohs p k.+1 :=
+{|
+  _deps := depsCohs.(_deps).(1);
+  _extraDeps := (depsCohs.(_deps); depsCohs.(_extraDeps));
+  _restrPaintings := depsCohs.(_restrPaintings).1;
+  _cohs := depsCohs.(_cohs).1;
+|}.
+
+Declare Scope depscohs_scope.
+Delimit Scope depscohs_scope with depscohs.
+Bind Scope depscohs_scope with DepsCohs.
+Notation "x .(1)" := (proj1DepsCohs x%depscohs)
+  (at level 1, left associativity, format "x .(1)"): depscohs_scope.
+
+(** The restrFrame(n+1,0..p) component of the fixpoint *)
+
+Definition mkRestrFrames `{depsCohs: DepsCohs p k} :=
+  (mkCohFrameTypesAndRestrFrames depsCohs.(_restrPaintings)).(RestrFramesDef)
+    depsCohs.(_cohs).
+
+(** For n=p+k, we combine mkFrames (that is frames(n+1,p)),
+    mkPaintings (that is paintings(n+1,p)) and restrFrames
+    (that is restrFrames(n+1,p)) to build "dependencies" at the next
+    level, that is a deps(n+1,p).
+    That is, from:
+     - {frame(n,0);...;frame(n,p-1)}
+     - {painting(n,0);...;painting(n,p-1)}
+     - {restrFrame(n,0);...;restrFrame(n,p-1)} for p<=n+1
+     (forming a "deps"), and
+     - {frame(n,p);...;frame(n,n)}
+     - {painting(n,p);...;painting(n,n)}
+     - {restrFrame(n,p);...;restrFrame(n,n)}
+     - E:frame(n+1,n+1) -> HGpd
+     (forming an "extraDeps")
+     we form:
+     - {frame(n+1,0);...;frame(n+1,p)} (built by mkFrames)
+     - {painting(n+1,0);...;painting(p+n,p)} (built by mkPaintings)
+     - {restrFrame(n+1,0);...;restrFrame(n+1,p)} (built by mkRestrFrames)
+
+   Example: if p := 0, extraDeps := ({},E), restrPaintings := {}, cohs := {}
+   then mkDepsRestr := {frames'':={unit};
+                        paintings'':={E};
+                        restrFrames':={λq().()}}
+   (where restrFrames' is presented as a dependent pair, i.e. ((),λq().()) *)
+
+Definition mkDepsRestr `{depsCohs: DepsCohs p k} :=
+  toDepsRestr mkRestrFrames.
+
+(** Deducing restrFrame(n+1,p) *)
+
+(** Note that we use mkRestrFrames(n+1,p) both to build frame(n+2,p) and
+    restrFrame(n+1,p) : frame(n+2,p) -> frame(n+1,p), according to the
+    circularity between Frames and RestrFrameTypes.
+    But now, thanks to restrPaintings and cohFrames, we have an effective
+    definition of RestrFrame(n+1,p) and the circular dependency of
+    frame(n+2,p) with an inhabitant RestrFrame(n+1,p) of RestrFrameType(n+1,p)
+    is gone.
+ *)
+
+Definition mkRestrFrame `{depsCohs: DepsCohs p k}:
+  forall q (Hq: q <= k),
+  mkFrame mkDepsRestr.(1) -> mkFrame depsCohs.(_deps) :=
+  mkRestrFrames.2.
+
+Inductive DepsCohsExtension p: forall k (depsCohs: DepsCohs p k), Type :=
+| TopCohDep `{depsCohs: DepsCohs p 0}
+  (E: mkFrame mkDepsRestr -> HGpd):
+  DepsCohsExtension p 0 depsCohs
+| AddCohDep {k} (depsCohs: DepsCohs p.+1 k):
+  DepsCohsExtension p.+1 k depsCohs -> DepsCohsExtension p k.+1 depsCohs.(1).
+
+Arguments TopCohDep {p depsCohs}.
+Arguments AddCohDep {p k}.
+
+Declare Scope extra_depscohs_scope.
+Delimit Scope extra_depscohs_scope with extradepscohs.
+Bind Scope extra_depscohs_scope with DepsCohsExtension.
+Notation "( x ; y )" := (AddCohDep x y)
+  (at level 0, format "( x ; y )"): extra_depscohs_scope.
+
+Generalizable Variables depsCohs.
+
+Fixpoint mkExtraDeps `(extraDepsCohs: DepsCohsExtension p k depsCohs):
+  DepsRestrExtension p.+1 k mkDepsRestr.
+Proof.
+  destruct extraDepsCohs.
+  - now constructor.
+  - apply (AddRestrDep mkDepsRestr
+    (mkExtraDeps p.+1 k depsCohs extraDepsCohs)).
+Defined.
+
+Fixpoint mkRestrPainting `(extraDepsCohs: DepsCohsExtension p k depsCohs)
+  q {struct q}:
+  forall (Hq: q <= k) (d: mkFrame mkDepsRestr.(1)),
+    (mkPaintings (mkDepsRestr; mkExtraDeps extraDepsCohs)).2 d ->
+    mkDepsRestr.(_paintings).2 (mkDepsRestr.(_restrFrames).2 q Hq d).
+Proof.
+  destruct q as [|q]; intros Hq d [l c].
+  - exact l.
+  - destruct extraDepsCohs as [|k0 depsCohs0 extraDepsCohs0].
+    + now destruct (leR_O_contra Hq).
+    + unshelve eapply existT.
+      * exact (mkRestrLayer depsCohs0.(_restrPaintings).2 depsCohs0.(_cohs).2
+          q (⇓ Hq) d l).
+      * exact (mkRestrPainting _ _ _ extraDepsCohs0 q (⇓ Hq) (d; l) c).
+Defined.
+
+Fixpoint mkRestrPaintingsPrefix {p k}:
+  forall `(extraDepsCohs: DepsCohsExtension p k depsCohs),
+  mkRestrPaintingTypes
+    (mkDepsRestr; mkExtraDeps extraDepsCohs)%extradepsrestr :=
+  match p with
+  | 0 => fun _ _ => tt
+  | S p =>
+    fun depsCohs extraDepsCohs =>
+      (mkRestrPaintingsPrefix (depsCohs; extraDepsCohs)%extradepscohs;
+       mkRestrPainting (depsCohs; extraDepsCohs)%extradepscohs)
+  end.
+
+Definition mkRestrPaintings {p k}:
+  forall `(extraDepsCohs: DepsCohsExtension p k depsCohs),
+  mkRestrPaintingTypes (mkExtraDeps extraDepsCohs) :=
+  fun depsCohs extraDepsCohs => (mkRestrPaintingsPrefix extraDepsCohs; mkRestrPainting extraDepsCohs).
+
+(** The groupoid-level replacement for the old [mkCoh2Frame] UIP proof:
+    this is now explicit 2-dimensional frame coherence data. *)
+
+Definition mkCoh2FrameType
+  `(extraDepsCohs: DepsCohsExtension p.+1 k depsCohs)
+  (prevCohFrames: mkCohFrameTypes
+    (mkRestrPaintings (depsCohs; extraDepsCohs))): Type :=
+  forall q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+    (d: mkFrame (mkDepsRestr (depsCohs := toDepsCohs prevCohFrames.1)).(1)),
+  f_equal
+    (fun x => depsCohs.(_deps).(_restrFrames).2 q _ x)
+    (prevCohFrames.2 r (Hr ↕ ↑ Hq) s Hs d)
+  • (depsCohs.(_cohs).2 q Hq s (Hs ↕ Hr)
+      (mkRestrFrame r.+1 (⇑ (Hr ↕ ↑ Hq)) d)
+  • f_equal
+      (fun x => depsCohs.(_deps).(_restrFrames).2 s (Hs ↕ (Hr ↕ Hq)) x)
+      (prevCohFrames.2 q.+1 (⇑ Hq) r.+1 (⇑ Hr) d)) =
+  depsCohs.(_cohs).2 q Hq r Hr
+    (mkRestrFrame s (↑ (↑ (Hs ↕ (Hr ↕ Hq)))) d)
+  • (f_equal
+      (fun x => depsCohs.(_deps).(_restrFrames).2 r _ x)
+      (prevCohFrames.2 q.+1 (⇑ Hq) s (↑ (Hs ↕ Hr)) d)
+  • depsCohs.(_cohs).2 r (Hr ↕ Hq) s Hs
+      (mkRestrFrame q.+2 (⇑ (⇑ Hq)) d)).
+
+Definition mkCohPaintingType
+  `(extraDepsCohs: DepsCohsExtension p.+1 k depsCohs) :=
+  forall q (Hq: q <= k) r (Hr: r <= q)
+    (d: mkFrame mkDepsRestr.(1))
+    (c: (mkPaintings (mkDepsRestr;
+      mkExtraDeps (depsCohs; extraDepsCohs))).2 d),
+  rew [depsCohs.(_deps).(_paintings).2] depsCohs.(_cohs).2 q Hq r Hr d in
+  depsCohs.(_restrPaintings).2 q Hq _
+    ((mkRestrPaintings (depsCohs; extraDepsCohs)).2 r _ d c) =
+  depsCohs.(_restrPaintings).2 r (Hr ↕ Hq) _
+    ((mkRestrPaintings (depsCohs; extraDepsCohs)).2 q.+1 _ d c).
+
+Fixpoint mkCohPaintingTypes {p}:
+  forall `(extraDepsCohs: DepsCohsExtension p k depsCohs), Type :=
+  match p with
+  | 0 => fun _ _ _ => unit
+  | S p =>
+    fun k depsCohs extraDepsCohs =>
+    { R: mkCohPaintingTypes (depsCohs; extraDepsCohs) &T
+         mkCohPaintingType extraDepsCohs }
+  end.
+
+Definition mkCohLayerType `{extraDepsCohs: DepsCohsExtension p.+1 k depsCohs}
+  {prevCohFrames: mkCohFrameTypes
+    (extraDeps := (mkDepsRestr; mkExtraDeps extraDepsCohs))
+    (mkRestrPaintings extraDepsCohs).1}
+  q (Hq: q <= k) r (Hr: r <= q)
+  (d: mkFrame (mkDepsRestr (depsCohs := toDepsCohs prevCohFrames.1)).(1))
+  (l: mkLayer mkRestrFrame d): Type :=
+  rew [mkLayer _] prevCohFrames.2 q.+1 (⇑ Hq) r.+1 (⇑ Hr) d in
+  mkRestrLayer depsCohs.(_restrPaintings).2 depsCohs.(_cohs).2 q Hq _
+    (mkRestrLayer (mkRestrPaintings extraDepsCohs).1.2 prevCohFrames.2 r (Hr ↕ ↑ Hq) d l) =
+  mkRestrLayer depsCohs.(_restrPaintings).2 depsCohs.(_cohs).2 r (Hr ↕ Hq) _
+    (mkRestrLayer (mkRestrPaintings extraDepsCohs).1.2 prevCohFrames.2 q.+1 (⇑ Hq) d l).
+
+Definition mkCohLayer `{extraDepsCohs: DepsCohsExtension p.+1 k depsCohs}
+  {prevCohFrames: mkCohFrameTypes
+    (extraDeps := (mkDepsRestr; mkExtraDeps extraDepsCohs))
+    (mkRestrPaintings extraDepsCohs).1}
+  (cohPainting: mkCohPaintingType extraDepsCohs)
+  (coh2Frame: mkCoh2FrameType extraDepsCohs prevCohFrames)
+  q (Hq: q <= k) r (Hr: r <= q)
+  (d: mkFrame (mkDepsRestr (depsCohs := toDepsCohs prevCohFrames.1)).(1))
+  (l: mkLayer mkRestrFrame d):
+  mkCohLayerType q Hq r Hr d l.
+Proof.
+  unfold mkCohLayerType, mkRestrLayer, mkLayer.
+  eapply rew_cohLayer with
+    (P := fun x => depsCohs.(_deps).(_paintings).2 x)
+    (rf0 := fun x => depsCohs.(_deps).(_restrFrames).2 0 leR_O x)
+    (F := depsCohs.(_restrPaintings).2 q Hq)
+    (G := depsCohs.(_restrPaintings).2 r (Hr ↕ Hq)).
+  - now exact (cohPainting q Hq r Hr
+      (((mkCohFrameTypesAndRestrFrames (mkRestrPaintings extraDepsCohs).1.1)
+        .(RestrFramesDef) prevCohFrames.1).2 0 leR_O d) l).
+  - now apply (coh2Frame q Hq r Hr 0 leR_O d).
+Defined.
+
+Class Coh2FrameTypeBlock `{extraDepsCohs: DepsCohsExtension p k depsCohs} := {
+  Coh2FrameTypesDef: Type;
+  CohFramesDef: Coh2FrameTypesDef -> mkCohFrameTypes (mkRestrPaintings extraDepsCohs);
+}.
+
+Definition mkCoh2FrameTypesStep
+  `{extraDepsCohs: DepsCohsExtension p.+1 k depsCohs}
+  (cohPaintings: mkCohPaintingTypes extraDepsCohs)
+  (prev: Coh2FrameTypeBlock
+    (extraDepsCohs := (depsCohs; extraDepsCohs)%extradepscohs)): Type :=
+  { R: prev.(Coh2FrameTypesDef) &T
+    mkCoh2FrameType extraDepsCohs (prev.(CohFramesDef) R) }.
+
+Fixpoint mkCoh2FrameTypesAndCohFrames {p k}:
+  forall `{extraDepsCohs: DepsCohsExtension p k depsCohs}
+  (cohPaintings: mkCohPaintingTypes extraDepsCohs),
+  Coh2FrameTypeBlock (extraDepsCohs := extraDepsCohs).
+Proof.
+  destruct p.
+  - intros depsCohs extraDepsCohs cohPaintings.
+    unshelve econstructor.
+    + now exact unit.
+    + intros _. unshelve esplit. now exact tt. now intros.
+  - intros depsCohs extraDepsCohs cohPaintings.
+    set (prev := mkCoh2FrameTypesAndCohFrames p k.+1
+      depsCohs.(1)%depscohs
+      (depsCohs; extraDepsCohs)%extradepscohs cohPaintings.1).
+    unshelve econstructor.
+    + now exact (mkCoh2FrameTypesStep cohPaintings prev).
+    + intros Q.
+      set (h := prev.(CohFramesDef) Q.1).
+      unshelve esplit. now exact h.
+      intros q Hq r Hr d.
+      unshelve eapply eq_existT_curried.
+      * now exact (h.2 q.+1 (⇑ Hq) r.+1 (⇑ Hr) d.1).
+      * now exact (mkCohLayer cohPaintings.2 Q.2 q Hq r Hr d.1 d.2).
+Defined.
+
+Definition mkCoh2FrameTypes `{extraDepsCohs: DepsCohsExtension p k depsCohs}
+  (cohPaintings: mkCohPaintingTypes extraDepsCohs) :=
+  (mkCoh2FrameTypesAndCohFrames cohPaintings).(Coh2FrameTypesDef).
+
+Definition mkCohFrames `{extraDepsCohs: DepsCohsExtension p k depsCohs}
+  (cohPaintings: mkCohPaintingTypes extraDepsCohs)
+  (coh2Frames: mkCoh2FrameTypes cohPaintings):
+  mkCohFrameTypes (mkRestrPaintings extraDepsCohs) :=
+  (mkCoh2FrameTypesAndCohFrames cohPaintings).(CohFramesDef) coh2Frames.
+
+Definition mkCohFrame `{extraDepsCohs: DepsCohsExtension p k depsCohs}
+  (cohPaintings: mkCohPaintingTypes extraDepsCohs)
+  (coh2Frames: mkCoh2FrameTypes cohPaintings):
+  mkCohFrameType (mkRestrFrames (depsCohs :=
+    toDepsCohs (mkCohFrames cohPaintings coh2Frames).1)) :=
+  (mkCohFrames cohPaintings coh2Frames).2.
+
+Class DepsCohs2 p k := {
+  _depsCohs: DepsCohs p k;
+  _extraDepsCohs: DepsCohsExtension p k _depsCohs;
+  _cohPaintings: mkCohPaintingTypes _extraDepsCohs;
+  _coh2Frames: mkCoh2FrameTypes _cohPaintings;
+}.
+
+#[local]
+Instance toDepsCohs2 `{extraDepsCohs: DepsCohsExtension p k depsCohs}
+  {cohPaintings: mkCohPaintingTypes extraDepsCohs}
+  (coh2Frames: mkCoh2FrameTypes cohPaintings): DepsCohs2 p k :=
+  {| _coh2Frames := coh2Frames |}.
+
+#[local]
+Instance proj1DepsCohs2 `(depsCohs2: DepsCohs2 p.+1 k): DepsCohs2 p k.+1 :=
+{|
+  _depsCohs := depsCohs2.(_depsCohs).(1);
+  _extraDepsCohs := (depsCohs2.(_depsCohs); depsCohs2.(_extraDepsCohs));
+  _cohPaintings := depsCohs2.(_cohPaintings).1;
+  _coh2Frames := depsCohs2.(_coh2Frames).1;
+|}.
+
+Declare Scope depscohs2_scope.
+Delimit Scope depscohs2_scope with depscohs2.
+Bind Scope depscohs2_scope with DepsCohs2.
+Notation "x .(1)" := (proj1DepsCohs2 x%depscohs2)
+  (at level 1, left associativity, format "x .(1)"): depscohs2_scope.
+
+#[local]
+Instance mkDepsCohs `(depsCohs2: DepsCohs2 p k): DepsCohs p.+1 k :=
+{|
+  _deps := mkDepsRestr;
+  _extraDeps := mkExtraDeps depsCohs2.(_extraDepsCohs);
+  _restrPaintings := mkRestrPaintings depsCohs2.(_extraDepsCohs);
+  _cohs := mkCohFrames depsCohs2.(_cohPaintings) depsCohs2.(_coh2Frames);
+|}.
+
+Inductive DepsCohs2Extension p: forall k (depsCohs2: DepsCohs2 p k), Type :=
+| TopCoh2Dep `{depsCohs2: DepsCohs2 p 0}
+  (E: mkFrame (mkDepsRestr (depsCohs := mkDepsCohs depsCohs2)) -> HGpd):
+  DepsCohs2Extension p 0 depsCohs2
+| AddCoh2Dep {k} (depsCohs2: DepsCohs2 p.+1 k):
+  DepsCohs2Extension p.+1 k depsCohs2 ->
+  DepsCohs2Extension p k.+1 depsCohs2.(1).
+
+Arguments TopCoh2Dep {p depsCohs2}.
+Arguments AddCoh2Dep {p k}.
+
+Declare Scope extra_depscohs2_scope.
+Delimit Scope extra_depscohs2_scope with extradepscohs2.
+Bind Scope extra_depscohs2_scope with DepsCohs2Extension.
+Notation "( x ; y )" := (AddCoh2Dep x y)
+  (at level 0, format "( x ; y )"): extra_depscohs2_scope.
+
+Fixpoint mkExtraCohs `{depsCohs2: DepsCohs2 p k}
+  (extraDepsCohs2: DepsCohs2Extension p k depsCohs2):
+  DepsCohsExtension p.+1 k (mkDepsCohs depsCohs2).
+Proof.
+  destruct extraDepsCohs2.
+  - now constructor.
+  - apply (AddCohDep (mkDepsCohs depsCohs2)).
+    now exact (mkExtraCohs p.+1 k depsCohs2 extraDepsCohs2).
+Defined.
+
+Definition mkCohPainting `{depsCohs2: DepsCohs2 p k}
+  (extraDepsCohs2: DepsCohs2Extension p k depsCohs2):
+  mkCohPaintingType (mkExtraCohs extraDepsCohs2).
+Proof.
+  intros q Hq r.
+  generalize dependent q.
+  generalize dependent k.
+  generalize dependent p.
+  induction r as [|r mkCohPainting].
+  - now intros.
+  - intros p k depsCohs2 extraDepsCohs2 q Hq Hr d c.
+    destruct q; [now contradict Hq |].
+    destruct extraDepsCohs2; [now contradict Hq |].
+    destruct c as [l c].
+    unshelve eapply (eq_existT_curried_dep
+      (Q := mkPainting depsCohs2.(_depsCohs).(_extraDeps))).
+    + now exact (mkCohLayer depsCohs2.(_cohPaintings).2 depsCohs2.(_coh2Frames).2
+        q (⇓ Hq) r (⇓ Hr) d l).
+    + now exact (mkCohPainting p.+1 k depsCohs2 extraDepsCohs2
+        q (⇓ Hq) (⇓ Hr) (d; l) c).
+Defined.
+
+Fixpoint mkCohPaintingsPrefix `{depsCohs2: DepsCohs2 p k}
+  (extraDepsCohs2: DepsCohs2Extension p k depsCohs2) {struct p}:
+  @mkCohPaintingTypes p k.+1 (mkDepsCohs depsCohs2).(1)
+    (mkDepsCohs depsCohs2; mkExtraCohs extraDepsCohs2)%extradepscohs.
+Proof.
+  destruct p.
+  - now exact tt.
+  - unshelve esplit.
+    + now exact (mkCohPaintingsPrefix p k.+1 depsCohs2.(1)%depscohs2
+        (depsCohs2; extraDepsCohs2)%extradepscohs2).
+    + now exact (mkCohPainting (depsCohs2; extraDepsCohs2)%extradepscohs2).
+Defined.
+
+Definition mkCohPaintings `{depsCohs2: DepsCohs2 p k}
+  (extraDepsCohs2: DepsCohs2Extension p k depsCohs2):
+  mkCohPaintingTypes (mkExtraCohs extraDepsCohs2) :=
+  (mkCohPaintingsPrefix extraDepsCohs2; mkCohPainting extraDepsCohs2).
+
+Definition mkCoh2PaintingSourcePainting {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2)
+  (d: mkFrame ((mkDepsRestr (depsCohs := (mkDepsCohs depsCohs2).(1).(1)))).(1)): HGpd :=
+  (mkPaintings ((mkDepsRestr (depsCohs := mkDepsCohs depsCohs2)).(1).(1);
+    mkExtraDeps ((mkDepsCohs depsCohs2).(1); (mkDepsCohs depsCohs2;
+      mkExtraCohs extraDepsCohs2)))).2 d.
+
+Definition mkCoh2PaintingFrameEndpointType {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := (mkDepsCohs depsCohs2).(1).(1))).(1)): Type :=
+  depsCohs2.(_depsCohs).(_deps).(_restrFrames).2 q Hq
+    (mkRestrFrame (depsCohs := depsCohs2.(_depsCohs).(1)) r (Hr ↕ ↑ Hq)
+      (mkRestrFrame s (Hs ↕ ↑ (Hr ↕ ↑ Hq)) d)) =
+  depsCohs2.(_depsCohs).(_deps).(_restrFrames).2 s (Hs ↕ (Hr ↕ Hq))
+    (mkRestrFrame (depsCohs := depsCohs2.(_depsCohs).(1)) r.+1 (⇑ Hr ↕ ⇑ Hq)
+      (mkRestrFrame q.+2 (⇑ (⇑ Hq)) d)).
+
+Definition mkCoh2PaintingEndpointType {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2)
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := (mkDepsCohs depsCohs2).(1).(1))).(1))
+  (c: mkCoh2PaintingSourcePainting depsCohs2 extraDepsCohs2 d)
+  (coh2FrameEndpoint: mkCoh2PaintingFrameEndpointType
+    depsCohs2 q Hq r Hr s Hs d): Type :=
+  let restrPainting1 := mkRestrPainting
+    (depsCohs2.(_depsCohs); depsCohs2.(_extraDepsCohs)) in
+  let restrPainting2 := mkRestrPainting ((mkDepsCohs depsCohs2).(1);
+    (mkDepsCohs depsCohs2; mkExtraCohs extraDepsCohs2)) in
+  rew [depsCohs2.(_depsCohs).(_deps).(_paintings).2] coh2FrameEndpoint in
+  depsCohs2.(_depsCohs).(_restrPaintings).2 q Hq _
+    (restrPainting1 r (Hr ↕ ↑ Hq) _
+      (restrPainting2 s (Hs ↕ ↑ (Hr ↕ ↑ Hq)) d c)) =
+  depsCohs2.(_depsCohs).(_restrPaintings).2 s (Hs ↕ (Hr ↕ Hq)) _
+    (restrPainting1 r.+1 (⇑ Hr ↕ ⇑ Hq) _
+      (restrPainting2 q.+2 (⇑ (⇑ Hq)) d c)).
+
+(** The instance body is a named definition so that goals stay one line:
+    tactics like [destruct] re-typecheck their motive, which is
+    prohibitive over the unfolded body (observed: ~28s for
+    [destruct c] in [mkCoh2Painting] on the raw body, negligible once
+    folded). *)
+Definition mkCoh2PaintingInstanceType {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2)
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := (mkDepsCohs depsCohs2).(1).(1))).(1))
+  (c: mkCoh2PaintingSourcePainting depsCohs2 extraDepsCohs2 d): Type :=
+  let depsCohs := depsCohs2.(_depsCohs) in
+  let restrPainting2 := mkRestrPainting ((mkDepsCohs depsCohs2).(1);
+    (mkDepsCohs depsCohs2; mkExtraCohs extraDepsCohs2)) in
+  rew [mkCoh2PaintingEndpointType depsCohs2 extraDepsCohs2 q Hq r Hr s Hs d c]
+    depsCohs2.(_coh2Frames).2 q Hq r Hr s Hs d in
+  (sigT_map_eq (Q := fun x => GDom (depsCohs.(_deps).(_paintings).2 x))
+    (depsCohs.(_restrPaintings).2 q Hq)
+    (mkCohPainting (depsCohs2; extraDepsCohs2) r (Hr ↕ ↑ Hq) s Hs d c)
+  ⊙ (depsCohs2.(_cohPaintings).2 q Hq s (Hs ↕ Hr)
+      (mkRestrFrame r.+1 (⇑ (Hr ↕ ↑ Hq)) d)
+      (restrPainting2 r.+1 (⇑ (Hr ↕ ↑ Hq)) d c)
+  ⊙[fun x => GDom (depsCohs.(_deps).(_paintings).2 x)]
+    sigT_map_eq (Q := fun x => GDom (depsCohs.(_deps).(_paintings).2 x))
+      (depsCohs.(_restrPaintings).2 s (Hs ↕ (Hr ↕ Hq)))
+      (mkCohPainting (depsCohs2; extraDepsCohs2) q.+1 (⇑ Hq) r.+1 (⇑ Hr) d c))) =
+  depsCohs2.(_cohPaintings).2 q Hq r Hr
+    (mkRestrFrame s (↑ (↑ (Hs ↕ (Hr ↕ Hq)))) d)
+    (restrPainting2 s (↑ (↑ (Hs ↕ (Hr ↕ Hq)))) d c)
+  ⊙[fun x => GDom (depsCohs.(_deps).(_paintings).2 x)]
+    (sigT_map_eq (Q := fun x => GDom (depsCohs.(_deps).(_paintings).2 x))
+      (depsCohs.(_restrPaintings).2 r (Hr ↕ Hq))
+      (mkCohPainting (depsCohs2; extraDepsCohs2) q.+1 (⇑ Hq) s (↑ (Hs ↕ Hr)) d c)
+  ⊙ depsCohs2.(_cohPaintings).2 r (Hr ↕ Hq) s Hs
+      (mkRestrFrame q.+2 (⇑ (⇑ Hq)) d)
+      (restrPainting2 q.+2 (⇑ (⇑ Hq)) d c)).
+
+Definition mkCoh2PaintingType {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2): Type :=
+  forall
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := (mkDepsCohs depsCohs2).(1).(1))).(1))
+  (c: mkCoh2PaintingSourcePainting depsCohs2 extraDepsCohs2 d),
+  mkCoh2PaintingInstanceType depsCohs2 extraDepsCohs2 q Hq r Hr s Hs d c.
+
+Fixpoint mkCoh2PaintingTypes {p}:
+  forall `{extraDepsCohs2: DepsCohs2Extension p k depsCohs2}, Type :=
+  match p with
+  | 0 => fun _ _ _ => unit
+  | S p =>
+    fun k depsCohs2 extraDepsCohs2 =>
+    { R: @mkCoh2PaintingTypes p k.+1 depsCohs2.(1)%depscohs2
+        (depsCohs2; extraDepsCohs2)%extradepscohs2 &T
+         mkCoh2PaintingType depsCohs2 extraDepsCohs2 }
+  end.
+
+Arguments mkCoh2PaintingTypes {p k depsCohs2} extraDepsCohs2.
+
+Definition mkCoh2LayerFrameEndpointType {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2)
+  (coh2Frames: mkCoh2FrameTypes (mkCohPaintings (depsCohs2; extraDepsCohs2)))
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := toDepsCohs (mkCohFrames
+    (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 coh2Frames.1).1)).(1)): Type :=
+  mkRestrFrames.2 q.+1 (⇑ Hq)
+    (mkRestrFrames.2 r.+1 (⇑ (Hr ↕ ↑ Hq))
+      (mkRestrFrames.2 s.+1 (⇑ (Hs ↕ ↑ (Hr ↕ ↑ Hq))) d)) =
+  (mkRestrFrames.2 s.+1 (⇑ (Hs ↕ (Hr ↕ Hq)))
+    (mkRestrFrames.2 r.+2 (⇑ (⇑ Hr ↕ ⇑ Hq))
+      (mkRestrFrames.2 q.+3 (⇑ (⇑ (⇑ Hq))) d))).
+
+Definition mkCoh2LayerEndpointType {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2)
+  (prevCoh2Frames: mkCoh2FrameTypes (mkCohPaintings (depsCohs2; extraDepsCohs2)))
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := toDepsCohs (mkCohFrames
+    (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1).1)).(1))
+  (l: mkLayer (mkDepsRestr (depsCohs := toDepsCohs (mkCohFrames
+    (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1).1)).(_restrFrames).2 d)
+  (coh2FrameEndpoint: mkCoh2LayerFrameEndpointType depsCohs2
+    extraDepsCohs2 prevCoh2Frames q Hq r Hr s Hs d): Type :=
+  let depsCohs := depsCohs2.(_depsCohs) in
+  let cohFrame1 := mkCohFrame depsCohs2.(_cohPaintings).1 depsCohs2.(_coh2Frames).1 in
+  let restrPainting1 := mkRestrPainting (depsCohs; depsCohs2.(_extraDepsCohs)) in
+  let cohFrame2 := mkCohFrame (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1 in
+  let restrPainting2 := mkRestrPainting ((mkDepsCohs depsCohs2).(1);
+    (mkDepsCohs depsCohs2; mkExtraCohs extraDepsCohs2)) in
+  rew [mkLayer depsCohs.(_deps).(_restrFrames).2] coh2FrameEndpoint in
+  mkRestrLayer depsCohs.(_restrPaintings).2 depsCohs.(_cohs).2 q Hq
+    (mkRestrFrame r.+1 (⇑ (Hr ↕ ↑ Hq))
+      (mkRestrFrame s.+1 (⇑ (Hs ↕ ↑ (Hr ↕ ↑ Hq))) d))
+    (mkRestrLayer restrPainting1 cohFrame1 r (Hr ↕ ↑ Hq)
+      (mkRestrFrame s.+1 (⇑ (Hs ↕ ↑ (Hr ↕ ↑ Hq))) d)
+      (mkRestrLayer restrPainting2 cohFrame2 s (Hs ↕ ↑ (Hr ↕ ↑ Hq)) d l)) =
+  mkRestrLayer depsCohs.(_restrPaintings).2 depsCohs.(_cohs).2 s (Hs ↕ (Hr ↕ Hq))
+    (mkRestrFrame r.+2 (⇑ (⇑ Hr ↕ ⇑ Hq))
+      (mkRestrFrame q.+3 (⇑ (⇑ (⇑ Hq))) d))
+    (mkRestrLayer restrPainting1 cohFrame1 r.+1 (⇑ Hr ↕ ⇑ Hq)
+      (mkRestrFrame q.+3 (⇑ (⇑ (⇑ Hq))) d)
+      (mkRestrLayer restrPainting2 cohFrame2 q.+2 (⇑ (⇑ Hq)) d l)).
+
+Definition mkCoh2LayerType {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2)
+  (prevCoh2Frames: mkCoh2FrameTypes (mkCohPaintings (depsCohs2;extraDepsCohs2)))
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := toDepsCohs (mkCohFrames
+    (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1).1)).(1))
+  (l: mkLayer (mkDepsRestr (depsCohs := toDepsCohs (mkCohFrames (mkCohPaintings
+    (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1).1)).(_restrFrames).2 d): Type :=
+  let depsCohs := depsCohs2.(_depsCohs) in
+  let depsCohs' := toDepsCohs (mkCohFrames
+    (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1) in
+  rew [mkCoh2LayerEndpointType depsCohs2 extraDepsCohs2 prevCoh2Frames q Hq r Hr s Hs d l]
+    prevCoh2Frames.2 q.+1 (⇑ Hq) r.+1 (⇑ Hr) s.+1 (⇑ Hs) d in
+  (sigT_map_eq (Q := fun x => GDom (mkLayer depsCohs.(_deps).(_restrFrames).2 x))
+    (mkRestrLayer depsCohs2.(_depsCohs).(_restrPaintings).2
+      depsCohs2.(_depsCohs).(_cohs).2 q Hq)
+    (mkCohLayer (mkCohPaintings extraDepsCohs2).1.2
+      prevCoh2Frames.2 r (Hr ↕ ↑ Hq) s Hs d l)
+  ⊙ (mkCohLayer depsCohs2.(_cohPaintings).2
+    depsCohs2.(_coh2Frames).2 q Hq s (Hs ↕ Hr)
+      (mkRestrFrame (depsCohs := depsCohs') r.+1 (⇑ (Hr ↕ ↑ Hq)) (d; l)).1
+      (mkRestrFrame (depsCohs := depsCohs') r.+1 (⇑ (Hr ↕ ↑ Hq)) (d; l)).2
+  ⊙[fun x => GDom (mkLayer depsCohs.(_deps).(_restrFrames).2 x)]
+    sigT_map_eq (Q := fun x => GDom (mkLayer depsCohs.(_deps).(_restrFrames).2 x))
+      (mkRestrLayer depsCohs2.(_depsCohs).(_restrPaintings).2
+        depsCohs2.(_depsCohs).(_cohs).2 s (Hs ↕ (Hr ↕ Hq)))
+      (mkCohLayer (mkCohPaintings extraDepsCohs2).1.2 prevCoh2Frames.2
+        q.+1 (⇑ Hq) r.+1 (⇑ Hr) d l))) =
+  mkCohLayer depsCohs2.(_cohPaintings).2
+    depsCohs2.(_coh2Frames).2 q Hq r Hr
+    (mkRestrFrame (depsCohs := depsCohs') s (↑ (↑ (Hs ↕ (Hr ↕ Hq)))) (d; l)).1
+    (mkRestrFrame (depsCohs := depsCohs') s (↑ (↑ (Hs ↕ (Hr ↕ Hq)))) (d; l)).2
+  ⊙[fun x => GDom (mkLayer depsCohs.(_deps).(_restrFrames).2 x)]
+    (sigT_map_eq (Q := fun x => GDom (mkLayer depsCohs.(_deps).(_restrFrames).2 x))
+      (mkRestrLayer depsCohs2.(_depsCohs).(_restrPaintings).2
+        depsCohs2.(_depsCohs).(_cohs).2 r (Hr ↕ Hq))  
+      (mkCohLayer (mkCohPaintings extraDepsCohs2).1.2 
+        prevCoh2Frames.2 q.+1 (⇑ Hq) s (↑ (Hs ↕ Hr)) d l)
+  ⊙ mkCohLayer depsCohs2.(_cohPaintings).2
+      depsCohs2.(_coh2Frames).2 r (Hr ↕ Hq) s Hs
+      (mkRestrFrame (depsCohs := depsCohs') q.+2 (⇑ (⇑ Hq)) (d; l)).1
+      (mkRestrFrame (depsCohs := depsCohs') q.+2 (⇑ (⇑ Hq)) (d; l)).2).
+
+Definition mkCoh2Layer {p k}
+  (depsCohs2: DepsCohs2 p.+1 k)
+  (extraDepsCohs2: DepsCohs2Extension p.+1 k depsCohs2)
+  (prevCoh2Frames: mkCoh2FrameTypes (mkCohPaintings (depsCohs2;extraDepsCohs2)))
+  (coh2Painting: mkCoh2PaintingType depsCohs2 extraDepsCohs2)
+  (* coh3Frame: mkCoh3FrameType ... - not needed as for HGpd is given by GUIP *)
+  q (Hq: q <= k) r (Hr: r <= q) s (Hs: s <= r)
+  (d: mkFrame (mkDepsRestr (depsCohs := toDepsCohs (mkCohFrames
+    (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1).1)).(1))
+  (l: mkLayer (mkDepsRestr (depsCohs := toDepsCohs (mkCohFrames
+    (mkCohPaintings (depsCohs2; extraDepsCohs2)).1 prevCoh2Frames.1).1)).(_restrFrames).2 d):
+  mkCoh2LayerType depsCohs2 extraDepsCohs2 prevCoh2Frames q Hq r Hr s Hs d l.
+Proof.
+  unfold mkCoh2LayerType, mkCohLayer.
+  eapply rew_coh2Layer with
+    (S1 := fun x => (mkDepsRestr (depsCohs := (mkDepsCohs depsCohs2).(1).(1))).(_paintings).2 x)
+    (S0 := fun x => (mkDepsCohs depsCohs2).(1).(_deps).(_paintings).2 x)
+    (PA := fun x => depsCohs2.(_depsCohs).(_deps).(_paintings).2 x)
+    (g0 := fun x => (mkDepsCohs depsCohs2).(1).(_deps).(_restrFrames).2 0 leR_O x)
+    (f0 := fun x => depsCohs2.(_depsCohs).(_deps).(_restrFrames).2 0 leR_O x)
+    (Rr := (mkDepsCohs depsCohs2).(1).(_restrPaintings).2 r (Hr ↕ ↑ Hq))
+    (Rs := (mkDepsCohs depsCohs2).(1).(_restrPaintings).2 s (Hs ↕ (Hr ↕ ↑ Hq)))
+    (Rq1 := (mkDepsCohs depsCohs2).(1).(_restrPaintings).2 q.+1 (⇑ Hq))
+    (Rr1 := (mkDepsCohs depsCohs2).(1).(_restrPaintings).2 r.+1 (⇑ Hr ↕ ⇑ Hq))
+    (Fq := depsCohs2.(_depsCohs).(_restrPaintings).2 q Hq)
+    (Fr := depsCohs2.(_depsCohs).(_restrPaintings).2 r (Hr ↕ Hq))
+    (Fs := depsCohs2.(_depsCohs).(_restrPaintings).2 s ((Hs ↕ Hr) ↕ Hq))
+    (gq := fun x => depsCohs2.(_depsCohs).(_cohs).2 q Hq 0 leR_O x)
+    (gr := fun x => depsCohs2.(_depsCohs).(_cohs).2 r (Hr ↕ Hq) 0 leR_O x)
+    (gs := fun x => depsCohs2.(_depsCohs).(_cohs).2 s ((Hs ↕ Hr) ↕ Hq) 0 leR_O x)
+    (KA2 := fun x => depsCohs2.(_depsCohs).(_cohs).2 q Hq s (Hs ↕ Hr) x)
+    (KA4 := fun x => depsCohs2.(_depsCohs).(_cohs).2 q Hq r Hr x)
+    (KA6 := fun x => depsCohs2.(_depsCohs).(_cohs).2 r (Hr ↕ Hq) s Hs x)
+    (HKA2 := fun x c => depsCohs2.(_cohPaintings).2 q Hq s (Hs ↕ Hr) x c)
+    (HKA4 := fun x c => depsCohs2.(_cohPaintings).2 q Hq r Hr x c)
+    (HKA6 := fun x c => depsCohs2.(_cohPaintings).2 r (Hr ↕ Hq) s Hs x c).
+  - now exact (coh2Painting q Hq r Hr s Hs
+      (((mkCohFrameTypesAndRestrFrames
+          (mkRestrPaintings (mkDepsCohs depsCohs2; mkExtraCohs extraDepsCohs2)).1.1)
+        .(RestrFramesDef) ((mkCoh2FrameTypesAndCohFrames
+            (mkCohPaintings (depsCohs2; extraDepsCohs2)).1)
+          .(CohFramesDef) prevCoh2Frames.1).1).2 0 leR_O d) l).
+  - now apply depsCohs2.(_depsCohs).(_deps).(_frames).2.(GUIP).
+Defined.
+
+Fixpoint mkCoh2Frames `{depsCohs2: DepsCohs2 p k}
+  (extraDepsCohs2: DepsCohs2Extension p k depsCohs2)
+  (coh2Paintings: mkCoh2PaintingTypes extraDepsCohs2):
+  mkCoh2FrameTypes (mkCohPaintings extraDepsCohs2).
+Proof.
+  destruct p.
+  - unshelve esplit.
+    + now exact tt.
+    + intros q Hq r Hr s Hs d.
+      now trivial.
+  - set (h := mkCoh2Frames p k.+1 depsCohs2.(1)%depscohs2
+      (depsCohs2; extraDepsCohs2)%extradepscohs2 coh2Paintings.1).
+    unshelve esplit.
+    + now exact h.
+    + intros q Hq r Hr s Hs [d l].
+      unshelve eapply eq_existT_curried_hex.
+      * now exact (h.2 q.+1 (⇑ Hq) r.+1 (⇑ Hr) s.+1 (⇑ Hs) d).
+      * now exact_no_check (mkCoh2Layer depsCohs2 extraDepsCohs2 h
+          coh2Paintings.2 q Hq r Hr s Hs d l).
+Defined.
+
+Class DepsCohs3 p k := {
+  _depsCohs2: DepsCohs2 p k;
+  _extraDepsCohs2: DepsCohs2Extension p k _depsCohs2;
+  _coh2Paintings: mkCoh2PaintingTypes _extraDepsCohs2;
+}.
+
+#[local]
+Instance toDepsCohs3 `{extraDepsCohs2: DepsCohs2Extension p k depsCohs2}
+  (coh2Paintings: mkCoh2PaintingTypes extraDepsCohs2): DepsCohs3 p k :=
+  {| _coh2Paintings := coh2Paintings |}.
+
+#[local]
+Instance proj1DepsCohs3 `(depsCohs3: DepsCohs3 p.+1 k): DepsCohs3 p k.+1 :=
+{|
+  _depsCohs2 := depsCohs3.(_depsCohs2).(1);
+  _extraDepsCohs2 := (depsCohs3.(_depsCohs2); depsCohs3.(_extraDepsCohs2));
+  _coh2Paintings := depsCohs3.(_coh2Paintings).1;
+|}.
+
+Declare Scope depscohs3_scope.
+Delimit Scope depscohs3_scope with depscohs3.
+Bind Scope depscohs3_scope with DepsCohs3.
+Notation "x .(1)" := (proj1DepsCohs3 x%depscohs3)
+  (at level 1, left associativity, format "x .(1)"): depscohs3_scope.
+
+#[local]
+Instance mkDepsCohs2 `(depsCohs3: DepsCohs3 p k): DepsCohs2 p.+1 k :=
+{|
+  _depsCohs := mkDepsCohs depsCohs3.(_depsCohs2);
+  _extraDepsCohs := mkExtraCohs depsCohs3.(_extraDepsCohs2);
+  _cohPaintings := mkCohPaintings depsCohs3.(_extraDepsCohs2);
+  _coh2Frames := mkCoh2Frames depsCohs3.(_extraDepsCohs2) depsCohs3.(_coh2Paintings);
+|}.
+
+Inductive DepsCohs3Extension p: forall k (depsCohs3: DepsCohs3 p k), Type :=
+| TopCoh3Dep `{depsCohs3: DepsCohs3 p 0}
+  (E: mkFrame (mkDepsRestr (depsCohs := mkDepsCohs (mkDepsCohs2 depsCohs3))) -> HGpd)
+  : DepsCohs3Extension p 0 depsCohs3
+| AddCoh3Dep {k} (depsCohs3: DepsCohs3 p.+1 k):
+  DepsCohs3Extension p.+1 k depsCohs3 ->
+  DepsCohs3Extension p k.+1 depsCohs3.(1).
+
+Arguments TopCoh3Dep {p depsCohs3}.
+Arguments AddCoh3Dep {p k}.
+
+Declare Scope extra_depscohs3_scope.
+Delimit Scope extra_depscohs3_scope with extradepscohs3.
+Bind Scope extra_depscohs3_scope with DepsCohs3Extension.
+Notation "( x ; y )" := (AddCoh3Dep x y)
+  (at level 0, format "( x ; y )"): extra_depscohs3_scope.
+
+Fixpoint mkExtraCohs2 `{depsCohs3: DepsCohs3 p k}
+  (extraDepsCohs3: DepsCohs3Extension p k depsCohs3):
+  DepsCohs2Extension p.+1 k (mkDepsCohs2 depsCohs3).
+Proof.
+  destruct extraDepsCohs3.
+  - now constructor.
+  - apply (AddCoh2Dep (mkDepsCohs2 depsCohs3)).
+    now exact (mkExtraCohs2 p.+1 k depsCohs3 extraDepsCohs3).
+Defined.
+
+Definition mkCoh2Painting `{depsCohs3: DepsCohs3 p k}
+  (extraDepsCohs3: DepsCohs3Extension p k depsCohs3):
+  mkCoh2PaintingType (mkDepsCohs2 depsCohs3) (mkExtraCohs2 extraDepsCohs3).
+Proof.
+  intros q Hq r Hr s.
+  generalize dependent r.
+  generalize dependent q.
+  generalize dependent k.
+  generalize dependent p.
+  induction s as [|s mkCoh2Painting].
+  - intros p k depsCohs3 extraDepsCohs3 q Hq r Hr Hs d c.
+    unfold mkCoh2PaintingInstanceType; cbn.
+    unfold mkCohLayer.
+    now apply rew_coh2Painting_restr0 with
+      (P := fun x : (mkDepsCohs depsCohs3.(_depsCohs2)).(_deps).(_frames).2 =>
+        (mkDepsCohs depsCohs3.(_depsCohs2)).(_deps).(_paintings).2 x)
+      (rf0 := fun x =>
+        (mkDepsCohs depsCohs3.(_depsCohs2)).(_deps).(_restrFrames).2 0 leR_O x)
+      (F := (mkDepsCohs depsCohs3.(_depsCohs2)).(_restrPaintings).2 q Hq)
+      (G := (mkDepsCohs depsCohs3.(_depsCohs2)).(_restrPaintings).2 r (Hr ↕ Hq))
+      (R0 := fun z => mkPainting (mkExtraDeps depsCohs3.(_depsCohs2).(_extraDepsCohs)) z)
+      (HH := (mkCoh2Frames depsCohs3.(_extraDepsCohs2)
+        depsCohs3.(_coh2Paintings)).2 q Hq r Hr 0 leR_O d)
+      (HK := mkCohPainting depsCohs3.(_extraDepsCohs2) q Hq r Hr _ c.1).
+  - intros p k depsCohs3 extraDepsCohs3 q Hq r Hr Hs d c.
+    destruct r; [now contradiction |].
+    destruct q; [now contradiction |].
+    destruct extraDepsCohs3; [now contradiction |].
+    destruct c as [l c].
+    unfold mkCoh2PaintingInstanceType; cbv zeta.
+    set (Q := mkCoh2PaintingEndpointType _ _ q.+1 Hq r.+1 Hr s.+1 Hs d (l; c)).
+    set (H := (mkDepsCohs2 depsCohs3.(1)).(_coh2Frames).2 q.+1 Hq r.+1 Hr s.+1 Hs d).
+    cbn [mkDepsCohs2 _cohPaintings mkCohPaintings projT2].
+    unfold mkCohPainting; cbn [nat_ind].
+    change (depsCohs3.(1).(_extraDepsCohs2)) with
+      (AddCoh2Dep depsCohs3.(_depsCohs2) depsCohs3.(_extraDepsCohs2)).
+    lazy beta iota.
+    unshelve eapply (eq_existT_curried_dep_hex
+      (A0 := ((mkRestrFrameTypesAndFrames
+          (mkDepsCohs2 depsCohs3.(1)).(_depsCohs).(_deps).(_paintings).1)
+        .(FrameDef)
+          (mkDepsCohs2 depsCohs3.(1)).(_depsCohs).(_deps).(_restrFrames).1).2)
+      (B := ((mkRestrFrameTypesAndFrames
+          depsCohs3.(_depsCohs2).(_depsCohs).(_deps).(_paintings).1)
+        .(FrameDef)
+          depsCohs3.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).1).2)
+      (P0 := fun a => (mkLayer
+        (mkDepsCohs2 depsCohs3.(1)).(_depsCohs).(_deps).(_restrFrames).2
+        a).(GDom))
+      (R0 := fun a u => (mkPainting
+        (mkDepsCohs2 depsCohs3.(1)).(_depsCohs).(_extraDeps) (a; u)).(GDom))
+      (P' := fun b => (mkLayer
+        depsCohs3.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).2 b).(GDom))
+      (R' := fun b u => (mkPainting
+        depsCohs3.(_depsCohs2).(_depsCohs).(_extraDeps) (b; u)).(GDom))
+      ((mkDepsCohs2 depsCohs3.(1)).(_depsCohs).(_deps).(_restrFrames).2
+        q.+1 Hq)
+      (fun d0 l0 => mkRestrLayer
+        depsCohs3.(_depsCohs2).(_depsCohs).(_restrPaintings).2
+        depsCohs3.(_depsCohs2).(_depsCohs).(_cohs).2 q (⇓ Hq) d0 l0)
+      (fun d0 l0 c0 => mkRestrPainting
+        depsCohs3.(_depsCohs2).(_extraDepsCohs) q (⇓ Hq) (d0; l0) c0)
+      ((mkDepsCohs2 depsCohs3.(1)).(_depsCohs).(_deps).(_restrFrames).2
+        s.+1 (Hs ↕ (Hr ↕ Hq)))
+      (fun d0 l0 => mkRestrLayer
+        depsCohs3.(_depsCohs2).(_depsCohs).(_restrPaintings).2
+        depsCohs3.(_depsCohs2).(_depsCohs).(_cohs).2
+        s (⇓ (Hs ↕ (Hr ↕ Hq))) d0 l0)
+      (fun d0 l0 c0 => mkRestrPainting
+        depsCohs3.(_depsCohs2).(_extraDepsCohs)
+        s (⇓ (Hs ↕ (Hr ↕ Hq))) (d0; l0) c0)
+      ((mkDepsCohs2 depsCohs3.(1)).(_depsCohs).(_deps).(_restrFrames).2
+        r.+1 (Hr ↕ Hq))
+      (fun d0 l0 => mkRestrLayer
+        depsCohs3.(_depsCohs2).(_depsCohs).(_restrPaintings).2
+        depsCohs3.(_depsCohs2).(_depsCohs).(_cohs).2 r (⇓ (Hr ↕ Hq)) d0 l0)
+      (fun d0 l0 c0 => mkRestrPainting
+        depsCohs3.(_depsCohs2).(_extraDepsCohs) r (⇓ (Hr ↕ Hq)) (d0; l0) c0)).
+    + now exact (mkCoh2Layer depsCohs3.(_depsCohs2) depsCohs3.(_extraDepsCohs2)
+        (mkCoh2Frames (depsCohs3.(_depsCohs2); depsCohs3.(_extraDepsCohs2))
+          depsCohs3.(1).(_coh2Paintings))
+        depsCohs3.(_coh2Paintings).2 q (⇓ Hq) r (⇓ Hr) s (⇓ Hs) d l).
+    + now exact_no_check (mkCoh2Painting p.+1 k depsCohs3 extraDepsCohs3
+        q (⇓ Hq) r (⇓ Hr) (⇓ Hs) (d; l) c).
+Defined.
+
+Fixpoint mkCoh2Paintings `{depsCohs3: DepsCohs3 p k}
+  (extraDepsCohs3: DepsCohs3Extension p k depsCohs3) {struct p}:
+  mkCoh2PaintingTypes (mkExtraCohs2 extraDepsCohs3).
+Proof.
+  destruct p.
+  - unshelve esplit. now exact tt.
+    now exact (mkCoh2Painting extraDepsCohs3).
+  - unshelve esplit. now exact (mkCoh2Paintings p k.+1
+      depsCohs3.(1)%depscohs3 (depsCohs3; extraDepsCohs3)%extradepscohs3).
+    now exact (mkCoh2Painting extraDepsCohs3).
+Defined.
+
+(** The data of a semi-simplicial groupoid truncated in dimension p,
+    as in νSet, with the two additional levels of coherence data ([coh2Frames],
+    [coh2Paintings]) that UIP provided for free at the [HSet] level *)
+
+Class SSGpdData p := {
+  frames: mkFrameTypes p 0;
+  paintings: mkPaintingTypes p 0 frames;
+  restrFrames: mkRestrFrameTypes paintings;
+  restrPaintings E: mkRestrPaintingTypes (TopRestrDep E);
+  cohFrames E: mkCohFrameTypes (restrPaintings E);
+  cohPaintings E E': mkCohPaintingTypes
+    (depsCohs := toDepsCohs (deps := toDepsRestr restrFrames) (cohFrames E))
+    (TopCohDep E');
+  coh2Frames E E': mkCoh2FrameTypes (cohPaintings E E');
+  coh2Paintings E E' E'': mkCoh2PaintingTypes
+    (depsCohs2 := toDepsCohs2 (coh2Frames E E'))
+    (TopCoh2Dep E'');
+}.
+
+Section SSGpdData.
+Variable p: nat.
+Variable C: SSGpdData p.
+Variable E: mkFrame (toDepsRestr C.(restrFrames)) -> HGpd.
+
+#[local]
+Instance mkSSGpdData: SSGpdData p.+1 :=
+{|
+  frames := mkFrames _;
+  paintings := mkPaintings _;
+  restrFrames := mkRestrFrames;
+  restrPaintings E' := mkRestrPaintings (TopCohDep E');
+  cohFrames E' := mkCohFrames (C.(cohPaintings) E E') (C.(coh2Frames) E E');
+  cohPaintings E' E'' := mkCohPaintings
+    (TopCoh2Dep (depsCohs2 := toDepsCohs2 (C.(coh2Frames) E E')) E'');
+  coh2Frames E' E'' := mkCoh2Frames
+    (TopCoh2Dep (depsCohs2 := toDepsCohs2 (C.(coh2Frames) E E')) E'')
+    (C.(coh2Paintings) E E' E'');
+  coh2Paintings E' E'' E''' := mkCoh2Paintings
+    (TopCoh3Dep (depsCohs3 := toDepsCohs3 (C.(coh2Paintings) E E' E'')) E''');
+|}.
+End SSGpdData.
+
+Class SSGpd p := {
+  prefix: Type;
+  data: prefix -> SSGpdData p;
+}.
+
+(** ************************************************)
+(** The construction of [SSGpd n+1] from [SSGpd n] *)
+
+(** Extending the initial prefix *)
+Definition mkPrefix p {C: SSGpd p}: Type :=
+  { D: C.(prefix) &T mkFrame (toDepsRestr (C.(data) D).(restrFrames)) -> HGpd }.
+
+#[local]
+Instance mkSSGpd0: SSGpd 0.
+Proof.
+  unshelve esplit.
+  - now exact gunit.
+  - unshelve esplit; now trivial.
+Defined.
+
+#[local]
+Instance mkSSGpd {p} (C: SSGpd p): SSGpd p.+1 :=
+{|
+  prefix := mkPrefix p;
+  data := fun D: mkPrefix p => mkSSGpdData p (C.(data) D.1) D.2;
+|}.
+
+(** An [SSGpd] truncated up to dimension [n] *)
+Fixpoint SSGpdAt n: SSGpd n :=
+  match n with
+  | O => mkSSGpd0
+  | n.+1 => mkSSGpd (SSGpdAt n)
+  end.
+
+CoInductive SSGpdFrom n (X: (SSGpdAt n).(prefix)): Type := cons {
+  this: mkFrame (toDepsRestr ((SSGpdAt n).(data) X).(restrFrames)) -> HGpd;
+  next: SSGpdFrom n.+1 (X; this);
+}.
+
+(** The final construction *)
+Definition SSGpds := SSGpdFrom 0 tt.
+
+End SSGpd.
+
+(** Some example *)
+
+Example SemiSimplicial5 := Eval lazy in (SSGpd.SSGpdAt 5).(SSGpd.prefix _).
+Print SemiSimplicial5.

--- a/theories/νSet/SSGpdLemmas.v
+++ b/theories/νSet/SSGpdLemmas.v
@@ -1,0 +1,465 @@
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT Notation.
+
+Set Keyed Unification.
+
+Lemma eq_existT_curried_hex {A1 A2 A3 B: Type}
+  {P1: A1 -> Type} {P2: A2 -> Type} {P3: A3 -> Type} {Q: B -> Type}
+  (f1: A1 -> B) (g1: forall a, P1 a -> Q (f1 a))
+  (f2: A2 -> B) (g2: forall a, P2 a -> Q (f2 a))
+  (f3: A3 -> B) (g3: forall a, P3 a -> Q (f3 a))
+  {x1 y1: A1} {u1: P1 x1} {v1: P1 y1}
+  {x2 y2: A2} {u2: P2 x2} {v2: P2 y2}
+  {x3 y3: A3} {u3: P3 x3} {v3: P3 y3}
+  {K1: x1 = y1} {W1: rew [P1] K1 in u1 = v1}
+  {K2: x2 = y2} {W2: rew [P2] K2 in u2 = v2}
+  {K3: x3 = y3} {W3: rew [P3] K3 in u3 = v3}
+  {H2: f1 y1 = f3 x3} {U2: rew [Q] H2 in g1 y1 v1 = g3 x3 u3}
+  {H1': f1 x1 = f2 x2} {U1': rew [Q] H1' in g1 x1 u1 = g2 x2 u2}
+  {H3': f2 y2 = f3 y3} {U3': rew [Q] H3' in g2 y2 v2 = g3 y3 v3}
+  (HH: f_equal f1 K1 • (H2 • f_equal f3 K3) =
+    H1' • (f_equal f2 K2 • H3'))
+  (HHu: rew [fun h => rew [Q] h in g1 x1 u1 = g3 y3 v3] HH in
+    (sigT_map_eq g1 W1 ⊙ (U2 ⊙ sigT_map_eq g3 W3)) =
+    U1' ⊙ (sigT_map_eq g2 W2 ⊙ U3')):
+  f_equal (fun z: {a: A1 &T P1 a} => (f1 z.1; g1 z.1 z.2)) (= K1; W1)
+  • ((= H2; U2)
+     • f_equal (fun z: {a: A3 &T P3 a} => (f3 z.1; g3 z.1 z.2)) (= K3; W3)) =
+  (= H1'; U1')
+  • (f_equal (fun z: {a: A2 &T P2 a} => (f2 z.1; g2 z.1 z.2)) (= K2; W2)
+     • (= H3'; U3')).
+Proof.
+  rewrite 3 f_equal_eq_existT_curried.
+  rewrite 4 eq_trans_eq_existT_curried.
+  now exact (eq_existT_curried_eq HH HHu).
+Defined.
+
+Lemma eq_existT_curried_dep_hex
+  {A0 B: Type} {P0: A0 -> Type} {R0: forall a, P0 a -> Type}
+  {P': B -> Type} {R': forall b, P' b -> Type}
+  (f1: A0 -> B) (g1: forall a, P0 a -> P' (f1 a))
+  (h1: forall a u, R0 a u -> R' (f1 a) (g1 a u))
+  (f3: A0 -> B) (g3: forall a, P0 a -> P' (f3 a))
+  (h3: forall a u, R0 a u -> R' (f3 a) (g3 a u))
+  (f2: A0 -> B) (g2: forall a, P0 a -> P' (f2 a))
+  (h2: forall a u, R0 a u -> R' (f2 a) (g2 a u))
+  {x0 x1 x2 x3 x1' x2': A0}
+  {u0: P0 x0} {v0: R0 x0 u0} {u1: P0 x1} {v1: R0 x1 u1}
+  {u2: P0 x2} {v2: R0 x2 u2} {u3: P0 x3} {v3: R0 x3 u3}
+  {u1': P0 x1'} {v1': R0 x1' u1'} {u2': P0 x2'} {v2': R0 x2' u2'}
+  (H1: x0 = x1) (Hu1: rew [P0] H1 in u0 = u1)
+  (Hv1: rew [fun z => R0 z.1 z.2] (=H1; Hu1) in
+    (v0: (fun z => R0 z.1 z.2) (x0; u0)) = v1)
+  (H2: f1 x1 = f3 x2) (Hu2: rew [P'] H2 in g1 x1 u1 = g3 x2 u2)
+  (Hv2: rew [fun z => R' z.1 z.2] (=H2; Hu2) in
+    (h1 x1 u1 v1: (fun z => R' z.1 z.2) (f1 x1; g1 x1 u1)) = h3 x2 u2 v2)
+  (H3: x2 = x3) (Hu3: rew [P0] H3 in u2 = u3)
+  (Hv3: rew [fun z => R0 z.1 z.2] (=H3; Hu3) in
+    (v2: (fun z => R0 z.1 z.2) (x2; u2)) = v3)
+  (H1': f1 x0 = f2 x1') (Hu1': rew [P'] H1' in g1 x0 u0 = g2 x1' u1')
+  (Hv1': rew [fun z => R' z.1 z.2] (=H1'; Hu1') in
+    (h1 x0 u0 v0: (fun z => R' z.1 z.2) (f1 x0; g1 x0 u0)) = h2 x1' u1' v1')
+  (H2': x1' = x2') (Hu2': rew [P0] H2' in u1' = u2')
+  (Hv2': rew [fun z => R0 z.1 z.2] (=H2'; Hu2') in
+    (v1': (fun z => R0 z.1 z.2) (x1'; u1')) = v2')
+  (H3': f2 x2' = f3 x3) (Hu3': rew [P'] H3' in g2 x2' u2' = g3 x3 u3)
+  (Hv3': rew [fun z => R' z.1 z.2] (=H3'; Hu3') in
+    (h2 x2' u2' v2': (fun z => R' z.1 z.2) (f2 x2'; g2 x2' u2')) = h3 x3 u3 v3)
+  (HH: f_equal f1 H1 • (H2 • f_equal f3 H3) =
+    H1' • (f_equal f2 H2' • H3'))
+  (HHu: rew [fun h => rew [P'] h in g1 x0 u0 = g3 x3 u3] HH in
+    (sigT_map_eq g1 Hu1 ⊙ (Hu2 ⊙ sigT_map_eq g3 Hu3)) =
+    Hu1' ⊙ (sigT_map_eq g2 Hu2' ⊙ Hu3'))
+  (HHv:
+    rew [fun p: (f1 x0; g1 x0 u0) = (f3 x3; g3 x3 u3) =>
+        rew [fun z: {a: B &T P' a} => R' z.1 z.2] p in
+        (h1 x0 u0 v0:
+          (fun z: {a: B &T P' a} => R' z.1 z.2) (f1 x0; g1 x0 u0)) =
+        h3 x3 u3 v3]
+      eq_existT_curried_hex f1 g1 f2 g2 f3 g3 HH HHu in
+    (@sigT_map_eq _ _ (fun z: {x: A0 &T P0 x} => R0 z.1 z.2)
+       (fun z: {x: B &T P' x} => R' z.1 z.2)
+       (fun z => (f1 z.1; g1 z.1 z.2)) (fun z => h1 z.1 z.2)
+       (x0; u0) (x1; u1) v0 v1 (=H1; Hu1) Hv1
+     ⊙ (Hv2
+        ⊙ @sigT_map_eq _ _ (fun z: {x: A0 &T P0 x} => R0 z.1 z.2)
+            (fun z: {x: B &T P' x} => R' z.1 z.2)
+            (fun z => (f3 z.1; g3 z.1 z.2)) (fun z => h3 z.1 z.2)
+            (x2; u2) (x3; u3) v2 v3 (=H3; Hu3) Hv3)) =
+    Hv1'
+    ⊙ (@sigT_map_eq _ _ (fun z: {x: A0 &T P0 x} => R0 z.1 z.2)
+         (fun z: {x: B &T P' x} => R' z.1 z.2)
+         (fun z => (f2 z.1; g2 z.1 z.2)) (fun z => h2 z.1 z.2)
+         (x1'; u1') (x2'; u2') v1' v2' (=H2'; Hu2') Hv2' ⊙ Hv3')):
+  rew [fun h => rew [fun x => {a: P' x &T R' x a}] h in
+      (g1 x0 u0; h1 x0 u0 v0) = (g3 x3 u3; h3 x3 u3 v3)] HH in
+  (sigT_map_eq (fun a uv => (g1 a uv.1; h1 a uv.1 uv.2))
+     (eq_existT_curried_dep (Q := fun z => R0 z.1 z.2)
+        (H := H1) (Hu := Hu1) (Hv := Hv1))
+   ⊙ (eq_existT_curried_dep (Q := fun z => R' z.1 z.2)
+        (H := H2) (Hu := Hu2) (Hv := Hv2)
+      ⊙ sigT_map_eq (fun a uv => (g3 a uv.1; h3 a uv.1 uv.2))
+          (eq_existT_curried_dep (Q := fun z => R0 z.1 z.2)
+             (H := H3) (Hu := Hu3) (Hv := Hv3)))) =
+  eq_existT_curried_dep (Q := fun z => R' z.1 z.2)
+    (H := H1') (Hu := Hu1') (Hv := Hv1')
+  ⊙ (sigT_map_eq (fun a uv => (g2 a uv.1; h2 a uv.1 uv.2))
+       (eq_existT_curried_dep (Q := fun z => R0 z.1 z.2)
+          (H := H2') (Hu := Hu2') (Hv := Hv2'))
+     ⊙ eq_existT_curried_dep (Q := fun z => R' z.1 z.2)
+         (H := H3') (Hu := Hu3') (Hv := Hv3')).
+Proof.
+  rewrite 3 sigT_map_eq_existT_curried_dep_curried.
+  rewrite 4 (sigT_trans_eq_existT_curried_dep (Q := fun z => R' z.1 z.2)).
+  refine (eq_existT_curried_dep_eq (Q := fun z => R' z.1 z.2) HH HHu _).
+  unfold eq_existT_curried_hex in HHv.
+  cbn [projT1 projT2] in HHv |- *.
+  revert HHv.
+  generalize (eq_existT_curried_eq HH HHu).
+  do 4 lazymatch goal with
+  | |- context [ @eq_trans_eq_existT_curried ?A ?P ?x ?y ?z ?u ?v ?w
+        ?p ?q ?p' ?q' ] =>
+      generalize (@eq_trans_eq_existT_curried A P x y z u v w p q p' q')
+  end.
+  generalize (f_equal_eq_existT_curried f2 g2 H2' Hu2').
+  generalize (f_equal_eq_existT_curried f3 g3 H3 Hu3).
+  generalize (f_equal_eq_existT_curried f1 g1 H1 Hu1).
+  generalize (= f_equal f1 H1; sigT_map_eq g1 Hu1).
+  generalize (= f_equal f3 H3; sigT_map_eq g3 Hu3).
+  generalize (= f_equal f2 H2'; sigT_map_eq g2 Hu2').
+  generalize (= H2 • f_equal f3 H3; Hu2 ⊙ sigT_map_eq g3 Hu3).
+  generalize (= f_equal f2 H2' • H3'; sigT_map_eq g2 Hu2' ⊙ Hu3').
+  generalize (= f_equal f1 H1 • (H2 • f_equal f3 H3);
+    sigT_map_eq g1 Hu1 ⊙ (Hu2 ⊙ sigT_map_eq g3 Hu3)).
+  generalize (= H1' • (f_equal f2 H2' • H3');
+    Hu1' ⊙ (sigT_map_eq g2 Hu2' ⊙ Hu3')).
+  intros qR qL q23' q23 q2' q3 q1 e e0 e1 e2 e3 e4 e5 e6.
+  destruct e, e0, e1, e2, e3, e4, e5.
+  intros HHv'; now exact HHv'.
+Defined.
+
+Lemma rew_cohLayer {T1 T2 T3 X: Type} (P: X -> Type)
+  {S2: T2 -> Type} {S3: T3 -> Type}
+  (rf0: T1 -> X) {rfF: T2 -> X} {rfG: T3 -> X}
+  (F: forall m, S2 m -> P (rfF m))
+  (G: forall n, S3 n -> P (rfG n))
+  {d1 d2: T1} (E1: d1 = d2)
+  {m1 m2: T2} (C2: m1 = m2)
+  {n1 n2: T3} (D2: n1 = n2)
+  (C1: rfF m2 = rf0 d1) (D1: rfG n2 = rf0 d2)
+  (K: rfF m1 = rfG n1)
+  (aL: S2 m1) (aR: S3 n1):
+  rew [P] K in F m1 aL = G n1 aR ->
+  f_equal rfF C2 • (C1 • f_equal rf0 E1) =
+  K • (f_equal rfG D2 • D1) ->
+  rew [fun d => P (rf0 d)] E1 in rew [P] C1 in F m2 (rew [S2] C2 in aL)
+  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
+Proof.
+  intros HC Hpath.
+  rewrite <- (map_subst F C2 aL), <- (map_subst G D2 aR).
+  rewrite <- HC.
+  rewrite (rew_map P rf0 E1), (rew_map P rfF C2), (rew_map P rfG D2).
+  rewrite 4 rew_compose.
+  now exact (f_equal (fun h => rew [P] h in F m1 aL) Hpath).
+Defined.
+
+Lemma rew_coh2Painting_restr0 {Tp Td: Type} {S: Tp -> Type} (P: Td -> Type)
+  (rf0: Tp -> Td) {rfF rfG: Tp -> Td}
+  (F: forall m, S m -> P (rfF m))
+  (G: forall n, S n -> P (rfG n))
+  {d1 d2: Tp} (E1: d1 = d2)
+  {m1 m2: Tp} (C2: m1 = m2)
+  {n1 n2: Tp} (D2: n1 = n2)
+  (C1: rfF m2 = rf0 d1) (D1: rfG n2 = rf0 d2)
+  (K: rfF m1 = rfG n1)
+  (aL: S m1) (aR: S n1)
+  (HK: rew [P] K in F m1 aL = G n1 aR)
+  (HH: f_equal rfF C2 • (C1 • f_equal rf0 E1) =
+       K • (f_equal rfG D2 • D1))
+  (R0: {a: Tp &T P (rf0 a)} -> Type)
+  {v0: R0 (d1; rew [P] C1 in F m2 (rew [S] C2 in aL))}
+  {v1: R0 (d2; rew [P] D1 in G n2 (rew [S] D2 in aR))}
+  (Hv: rew [R0] (= E1; rew_cohLayer P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH)
+    in v0 = v1):
+  rew [fun π: rfF m1 = rf0 d2 =>
+      rew [P] π in F m1 aL = rew [P] D1 in G n2 (rew [S] D2 in aR)] HH in
+  (sigT_map_eq (Q := P) F (eq_refl (x := rew [S] C2 in aL))
+   ⊙ ((eq_refl : rew [P] C1 in F m2 (rew [S] C2 in aL)
+       = rew [P] C1 in F m2 (rew [S] C2 in aL))
+      ⊙ sigT_map_eq (P := fun a => {u: P (rf0 a) &T R0 (a; u)}) (Q := P)
+          (f := rf0) (fun a uv => uv.1)
+          (eq_existT_curried_dep (Q := R0) (H := E1)
+            (Hu := rew_cohLayer P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH)
+            (Hv := Hv)))) =
+  HK ⊙ (sigT_map_eq (Q := P) G (eq_refl (x := rew [S] D2 in aR)) ⊙ eq_refl).
+Proof.
+  rewrite (sigT_map_eq_existT_curried_dep_fst rf0 (fun a u => u) E1
+    (rew_cohLayer P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH) Hv).
+  cbn [projT1].
+  clear Hv v0 v1 R0.
+  destruct E1, C2, D2.
+  cbn in HH |- *.
+  revert HH. revert HK. revert C1. revert D1.
+  generalize (G n1 aR) as gb.
+  intros gb D1 C1 HK HH.
+  rewrite (sigT_map_eq_id_refl rf0).
+  revert HH. revert HK. revert C1. revert D1.
+  generalize (rf0 d1) as X.
+  intros X D1.
+  destruct D1.
+  intros C1 HK HH.
+  cbn in HH.
+  revert HK.
+  destruct HH.
+  intros HK.
+  cbn in HK |- *.
+  destruct HK.
+  revert C1.
+  generalize (rfG n1) as Y.
+  intros Y C1.
+  destruct C1.
+  now reflexivity.
+Defined.
+
+Section Coh2Layer.
+
+Variables (T1 T0 XA: Type).
+Variable S1: T1 -> Type.
+Variable S0: T0 -> Type.
+Variable PA: XA -> Type.
+
+Variables (g0 uq1 ur ur1 us hq hr hs: T1 -> T0).
+Variables (f0 fq fr fs: T0 -> XA).
+
+Variable Rr: forall x, S1 x -> S0 (ur x).
+Variable Rs: forall x, S1 x -> S0 (us x).
+Variable Rq1: forall x, S1 x -> S0 (uq1 x).
+Variable Rr1: forall x, S1 x -> S0 (ur1 x).
+Variable Fq: forall y, S0 y -> PA (fq y).
+Variable Fr: forall y, S0 y -> PA (fr y).
+Variable Fs: forall y, S0 y -> PA (fs y).
+
+Variable gq: forall x, fq (g0 x) = f0 (hq x).
+Variable gr: forall x, fr (g0 x) = f0 (hr x).
+Variable gs: forall x, fs (g0 x) = f0 (hs x).
+
+Variable KA2: forall x, fq (us x) = fs (uq1 x).
+Variable KA4: forall x, fq (ur x) = fr (uq1 x).
+Variable KA6: forall x, fr (us x) = fs (ur1 x).
+
+Variable HKA2: forall x (c: S1 x),
+  rew [PA] KA2 x in Fq (us x) (Rs x c) = Fs (uq1 x) (Rq1 x c).
+Variable HKA4: forall x (c: S1 x),
+  rew [PA] KA4 x in Fq (ur x) (Rr x c) = Fr (uq1 x) (Rq1 x c).
+Variable HKA6: forall x (c: S1 x),
+  rew [PA] KA6 x in Fr (us x) (Rs x c) = Fs (ur1 x) (Rr1 x c).
+
+(** The permutahedral coherence of frames: the hexagon proved as a
+    composition of the seven other hexagons of the permutahedron. The six
+    squares hold by naturality and don't appear here explicitly. *)
+Lemma permutahedral_coherence
+  (n1 n2 n3 m1 m2 m3 dd11 dd21 dd13 dd23 dd15 dd25: T1)
+  (b1: n1 = m1) (b2: n2 = m2) (b3: n3 = m3)
+  (KB1: ur n1 = us n2) (KB3: uq1 n2 = ur1 n3) (KB5: uq1 n1 = us n3)
+  (E11: dd11 = dd21) (E13: dd13 = dd23) (E15: dd15 = dd25)
+  (C11: ur m1 = g0 dd11) (D11: us m2 = g0 dd21)
+  (C13: uq1 m2 = g0 dd13) (D13: ur1 m3 = g0 dd23)
+  (C15: uq1 m1 = g0 dd15) (D15: us m3 = g0 dd25)
+  (E12: hq dd21 = hs dd13) (E14: hq dd11 = hr dd15)
+  (E16: hr dd25 = hs dd23)
+  (HHB1: f_equal ur b1 • (C11 • f_equal g0 E11) =
+         KB1 • (f_equal us b2 • D11))
+  (HHB3: f_equal uq1 b2 • (C13 • f_equal g0 E13) =
+         KB3 • (f_equal ur1 b3 • D13))
+  (HHB5: f_equal uq1 b1 • (C15 • f_equal g0 E15) =
+         KB5 • (f_equal us b3 • D15))
+  (HH2: f_equal fq D11 • (gq dd21 • f_equal f0 E12) =
+        KA2 m2 • (f_equal fs C13 • gs dd13))
+  (HH4: f_equal fq C11 • (gq dd11 • f_equal f0 E14) =
+        KA4 m1 • (f_equal fr C15 • gr dd15))
+  (HH6: f_equal fr D15 • (gr dd25 • f_equal f0 E16) =
+        KA6 m3 • (f_equal fs D13 • gs dd23))
+  (HHs: f_equal hq E11 • (E12 • f_equal hs E13) =
+        E14 • (f_equal hr E15 • E16)):
+  f_equal fq KB1 • (KA2 n2 • f_equal fs KB3) =
+  KA4 n1 • (f_equal fr KB5 • KA6 n3).
+Proof.
+  destruct b1, b2, b3, E11, E13, E15.
+  cbn in HHB1, HHB3, HHB5, HHs.
+  revert KB1 KB3 KB5 D11 D13 D15 C11 C13 C15 HHB1 HHB3 HHB5
+    E16 E12 E14 HHs HH2 HH4 HH6.
+  generalize (KA2 n2). generalize (KA4 n1). generalize (KA6 n3).
+  generalize (gq dd11). generalize (gs dd13). generalize (gr dd15).
+  generalize (hq dd11). generalize (hs dd13). generalize (hr dd15).
+  generalize (g0 dd11). generalize (g0 dd13). generalize (g0 dd15).
+  generalize (ur n1). generalize (us n2). generalize (uq1 n2).
+  generalize (ur1 n3). generalize (uq1 n1). generalize (us n3).
+  intros t t0 t1 t2 t3 t4 t5 t6 t7 t8 t9 t10 ge gs0 gq0 k6 k4 k2
+    KB1 KB3 KB5 D11 D13 D15 C11 C13 C15 HHB1 HHB3 HHB5
+    E16 E12 E14 HHs HH2 HH4 HH6.
+  revert ge gs0 gq0 C11 C13 C15 HHB1 HHB3 HHB5 E16 E12 E14 HHs HH2 HH4 HH6.
+  destruct D11, D13, D15.
+  intros ge gs0 gq0 C11 C13 C15 HHB1 HHB3 HHB5.
+  cbn in HHB1, HHB3, HHB5.
+  destruct HHB1, HHB3, HHB5.
+  revert ge gs0 gq0.
+  destruct C11, C13, C15.
+  intros ge gs0 gq0 E16 E12 E14 HHs.
+  revert E12 E14 HHs ge gs0 gq0.
+  destruct E16.
+  destruct E12.
+  intros E14 HHs. cbn in HHs. destruct HHs.
+  intros ge gs0 gq0.
+  revert k2 k4 k6.
+  revert gs0 ge gq0.
+  cbn.
+  generalize (fq t4). generalize (fs t2). generalize (fr t0).
+  generalize (f0 t10).
+  destruct gs0.
+  destruct ge.
+  destruct gq0.
+  intros k2 k4 k6 HH2 HH4 HH6.
+  cbn in HH2, HH4, HH6.
+  destruct HH2, HH4, HH6.
+  now reflexivity.
+Defined.
+
+Lemma rew_coh2Layer
+  (n1 n2 n3 m1 m2 m3 dd11 dd21 dd13 dd23 dd15 dd25: T1)
+  (a1: S1 n1) (a2: S1 n2) (a3: S1 n3)
+  (b1: n1 = m1) (b2: n2 = m2) (b3: n3 = m3)
+  (KB1: ur n1 = us n2) (KB3: uq1 n2 = ur1 n3) (KB5: uq1 n1 = us n3)
+  (E11: dd11 = dd21) (E13: dd13 = dd23) (E15: dd15 = dd25)
+  (C11: ur m1 = g0 dd11) (D11: us m2 = g0 dd21)
+  (C13: uq1 m2 = g0 dd13) (D13: ur1 m3 = g0 dd23)
+  (C15: uq1 m1 = g0 dd15) (D15: us m3 = g0 dd25)
+  (E12: hq dd21 = hs dd13) (E14: hq dd11 = hr dd15)
+  (E16: hr dd25 = hs dd23)
+  (HKB1: rew [S0] KB1 in Rr n1 a1 = Rs n2 a2)
+  (HKB3: rew [S0] KB3 in Rq1 n2 a2 = Rr1 n3 a3)
+  (HKB5: rew [S0] KB5 in Rq1 n1 a1 = Rs n3 a3)
+  (HHB1: f_equal ur b1 • (C11 • f_equal g0 E11) =
+         KB1 • (f_equal us b2 • D11))
+  (HHB3: f_equal uq1 b2 • (C13 • f_equal g0 E13) =
+         KB3 • (f_equal ur1 b3 • D13))
+  (HHB5: f_equal uq1 b1 • (C15 • f_equal g0 E15) =
+         KB5 • (f_equal us b3 • D15))
+  (HH2: f_equal fq D11 • (gq dd21 • f_equal f0 E12) =
+        KA2 m2 • (f_equal fs C13 • gs dd13))
+  (HH4: f_equal fq C11 • (gq dd11 • f_equal f0 E14) =
+        KA4 m1 • (f_equal fr C15 • gr dd15))
+  (HH6: f_equal fr D15 • (gr dd25 • f_equal f0 E16) =
+        KA6 m3 • (f_equal fs D13 • gs dd23))
+  (HHA: f_equal fq KB1 • (KA2 n2 • f_equal fs KB3) =
+        KA4 n1 • (f_equal fr KB5 • KA6 n3))
+  (HHs: f_equal hq E11 • (E12 • f_equal hs E13) =
+        E14 • (f_equal hr E15 • E16))
+  (Hcoh2Painting:
+    rew [fun pi: fq (ur n1) = fs (ur1 n3) =>
+        rew [PA] pi in Fq (ur n1) (Rr n1 a1) = Fs (ur1 n3) (Rr1 n3 a3)]
+      HHA in
+    (sigT_map_eq Fq HKB1 ⊙ (HKA2 n2 a2 ⊙ sigT_map_eq Fs HKB3)) =
+    HKA4 n1 a1 ⊙ (sigT_map_eq Fr HKB5 ⊙ HKA6 n3 a3))
+  (Hcoh3Frame: HHA =
+    permutahedral_coherence n1 n2 n3 m1 m2 m3 dd11 dd21 dd13 dd23 dd15 dd25
+      b1 b2 b3 KB1 KB3 KB5 E11 E13 E15 C11 D11 C13 D13 C15 D15 E12 E14 E16
+      HHB1 HHB3 HHB5 HH2 HH4 HH6 HHs):
+  rew [fun pi: hq dd11 = hs dd23 =>
+      rew [fun y => PA (f0 y)] pi in
+      rew [PA] gq dd11 in
+        Fq (g0 dd11) (rew [S0] C11 in Rr m1 (rew [S1] b1 in a1)) =
+      rew [PA] gs dd23 in
+        Fs (g0 dd23) (rew [S0] D13 in Rr1 m3 (rew [S1] b3 in a3))]
+    HHs in
+  (sigT_map_eq (fun x v => rew [PA] gq x in Fq (g0 x) v)
+     (rew_cohLayer S0 g0 Rr Rs E11 b1 b2 C11 D11 KB1 a1 a2 HKB1 HHB1)
+   ⊙ (rew_cohLayer PA f0 Fq Fs E12 D11 C13 (gq dd21) (gs dd13) (KA2 m2)
+        (Rs m2 (rew [S1] b2 in a2)) (Rq1 m2 (rew [S1] b2 in a2))
+        (HKA2 m2 (rew [S1] b2 in a2)) HH2
+      ⊙ sigT_map_eq (fun x v => rew [PA] gs x in Fs (g0 x) v)
+          (rew_cohLayer S0 g0 Rq1 Rr1 E13 b2 b3 C13 D13 KB3 a2 a3
+             HKB3 HHB3))) =
+  rew_cohLayer PA f0 Fq Fr E14 C11 C15 (gq dd11) (gr dd15) (KA4 m1)
+    (Rr m1 (rew [S1] b1 in a1)) (Rq1 m1 (rew [S1] b1 in a1))
+    (HKA4 m1 (rew [S1] b1 in a1)) HH4
+  ⊙ (sigT_map_eq (fun x v => rew [PA] gr x in Fr (g0 x) v)
+       (rew_cohLayer S0 g0 Rq1 Rs E15 b1 b3 C15 D15 KB5 a1 a3 HKB5 HHB5)
+     ⊙ rew_cohLayer PA f0 Fr Fs E16 D15 D13 (gr dd25) (gs dd23) (KA6 m3)
+         (Rs m3 (rew [S1] b3 in a3)) (Rr1 m3 (rew [S1] b3 in a3))
+         (HKA6 m3 (rew [S1] b3 in a3)) HH6).
+Proof.
+  unfold permutahedral_coherence in Hcoh3Frame.
+  destruct b1, b2, b3, E11, E13, E15.
+  lazy beta iota delta [f_equal].
+  change (rew [S1] eq_refl in a1) with a1.
+  change (rew [S1] eq_refl in a2) with a2.
+  change (rew [S1] eq_refl in a3) with a3.
+  cbn in HHB1, HHB3, HHB5, HHs.
+  revert KB1 KB3 KB5 C11 D11 C13 D13 C15 D15 E12 E14 E16 HKB1 HKB3 HKB5
+    HHB1 HHB3 HHB5 HH2 HH4 HH6 HHA HHs Hcoh3Frame Hcoh2Painting.
+  generalize (HKA2 n2 a2). generalize (HKA4 n1 a1). generalize (HKA6 n3 a3).
+  generalize (KA2 n2). generalize (KA4 n1). generalize (KA6 n3).
+  intros k6 k4 k2 hk6 hk4 hk2 KB1 KB3 KB5 C11 D11 C13 D13 C15 D15
+    E12 E14 E16 HKB1 HKB3 HKB5 HHB1 HHB3 HHB5 HH2 HH4 HH6 HHA HHs
+    Hcoh3Frame Hcoh2Painting.
+  rewrite 3 sigT_map_eq_refl.
+  cbv beta.
+  revert KB1 KB3 KB5 D11 D13 D15 C11 C13 C15 HHB1 HHB3 HHB5 HKB1 HKB3 HKB5
+    E16 E12 E14 HHs k2 k4 k6 hk2 hk4 hk6 HH2 HH4 HH6 HHA Hcoh3Frame Hcoh2Painting.
+  generalize (gq dd11). generalize (gs dd13). generalize (gr dd15).
+  cbn.
+  generalize (Rr n1 a1). generalize (Rs n2 a2). generalize (Rq1 n2 a2).
+  generalize (Rr1 n3 a3). generalize (Rq1 n1 a1). generalize (Rs n3 a3).
+  generalize (hq dd11). generalize (hs dd13). generalize (hr dd15).
+  generalize (g0 dd11). generalize (g0 dd13). generalize (g0 dd15).
+  generalize (ur n1). generalize (us n2). generalize (uq1 n2).
+  generalize (ur1 n3). generalize (uq1 n1). generalize (us n3).
+  intros t t0 t1 t2 t3 t4 t5 t6 t7 t8 t9 t10 s s0 s1 s2 s3 s4 ge gs0 gq0
+    KB1 KB3 KB5 D11 D13 D15 C11 C13 C15 HHB1 HHB3 HHB5 HKB1 HKB3 HKB5
+    E16 E12 E14 HHs k2 k4 k6 hk2 hk4 hk6 HH2 HH4 HH6 HHA Hcoh3Frame Hcoh2Painting.
+  revert ge gs0 gq0 C11 C13 C15 HHB1 HHB3 HHB5 HKB1 HKB3 HKB5 E16 E12 E14
+    HHs k2 k4 k6 hk2 hk4 hk6 HH2 HH4 HH6 HHA Hcoh3Frame Hcoh2Painting.
+  destruct D11, D13, D15.
+  intros ge gs0 gq0 C11 C13 C15 HHB1 HHB3 HHB5.
+  cbn in HHB1, HHB3, HHB5.
+  destruct HHB1, HHB3, HHB5.
+  intros HKB1 HKB3 HKB5.
+  destruct HKB1, HKB3, HKB5.
+  revert ge gs0 gq0.
+  destruct C11, C13, C15.
+  intros ge gs0 gq0 E16 E12 E14 HHs.
+  revert E12 E14 HHs ge gs0 gq0.
+  destruct E16.
+  destruct E12.
+  intros E14 HHs. cbn in HHs. destruct HHs.
+  intros ge gs0 gq0.
+  cbn.
+  generalize (Fq t4 s4). generalize (Fs t2 s2). generalize (Fr t0 s0).
+  revert gq0 gs0 ge.
+  generalize (fq t4). generalize (fs t2). generalize (fr t0).
+  intros x x0 x1 gq0 gs0 ge p0 p2 p4 k2 k4 k6 hk2 hk4 hk6
+    HH2 HH4 HH6 HHA Hcoh3Frame Hcoh2Painting.
+  rewrite 3 sigT_trans_eq_refl.
+  revert Hcoh2Painting. revert Hcoh3Frame. revert HH2 HH4 HH6. revert HHA.
+  revert hk2 hk4 hk6. revert k2 k4 k6. revert p0 p2 p4. revert gs0 ge gq0.
+  generalize (f0 t10).
+  destruct gs0.
+  destruct ge.
+  destruct gq0.
+  intros p0 p2 p4 k2 k4 k6 hk2 hk4 hk6 HHA HH2 HH4 HH6 Hcoh3Frame Hcoh2Painting.
+  cbn in HH2, HH4, HH6.
+  revert hk2 hk4 hk6 HHA Hcoh3Frame Hcoh2Painting.
+  destruct HH2, HH4, HH6.
+  intros hk2 hk4.
+  destruct hk2, hk4.
+  intros hk6 HHA Hcoh3Frame Hcoh2Painting.
+  cbn in hk6, HHA, Hcoh3Frame, Hcoh2Painting |- *.
+  rewrite Hcoh3Frame in Hcoh2Painting.
+  cbn in Hcoh2Painting.
+  rewrite 2 sigT_trans_eq_refl in Hcoh2Painting.
+  change (eq_ind p4 (fun p: PA x1 => p4 = p) eq_refl p4 hk6) with (eq_refl • hk6).
+  rewrite eq_trans_refl_l.
+  now exact Hcoh2Painting.
+Defined.
+
+End Coh2Layer.

--- a/theories/νSet/SigT.v
+++ b/theories/νSet/SigT.v
@@ -60,4 +60,170 @@ Lemma eq_existT_curried_dep {A x} {P: A -> Type} {Q: {a &T P a} -> Type}
    rew [fun x => {a: P x &T Q (x; a)}] H in (u; v) = (u'; v').
 Proof.
    now destruct Hu, Hv, H.
-Qed.
+Defined.
+
+Lemma eq_existT_curried_eq {A: Type} {P: A -> Type}
+  {x y: A} {u: P x} {v: P y}
+  {p p': x = y}
+  {q: rew [P] p in u = v} {q': rew [P] p' in u = v}
+  (Hp: p = p')
+  (Hq: rew [fun r => rew [P] r in u = v] Hp in q = q'):
+  (= p; q) = (= p'; q').
+Proof.
+  destruct Hp; simpl in Hq. now destruct Hq.
+Defined.
+
+Lemma eq_existT_curried_dep_eq {A x y} {P: A -> Type}
+  {Q: {a &T P a} -> Type}
+  {H H': x = y}
+  {u: P x} {v: Q (x; u)}
+  {u': P y} {v': Q (y; u')}
+  {Hu: rew [P] H in u = u'} {Hu': rew [P] H' in u = u'}
+  {Hv: rew [Q] (=H; Hu) in v = v'}
+  {Hv': rew [Q] (=H'; Hu') in v = v'}
+  (HH: H = H')
+  (HHu: rew [fun H => rew [P] H in u = u'] HH in Hu = Hu')
+  (HHv: rew [fun p => rew [Q] p in v = v']
+    eq_existT_curried_eq HH HHu in Hv = Hv'):
+  rew [fun H => rew [fun x => {a: P x &T Q (x; a)}] H in
+    (u; v) = (u'; v')] HH in
+  @eq_existT_curried_dep A x P Q y H u v u' v' Hu Hv =
+  @eq_existT_curried_dep A x P Q y H' u v u' v' Hu' Hv'.
+Proof.
+  destruct HH; cbn in HHu. destruct HHu; cbn in HHv.
+  now destruct HHv.
+Defined.
+
+Definition sigT_map_eq {A B: Type} {P: A -> Type} {Q: B -> Type}
+  {f: A -> B} (g: forall a, P a -> Q (f a))
+  {x y: A} {u: P x} {v: P y}
+  {p: x = y} (q: rew [P] p in u = v):
+  rew [Q] f_equal f p in g x u = g y v.
+Proof.
+  now destruct q, p.
+Defined.
+
+Lemma sigT_map_eq_id_refl {A B: Type} {Q: B -> Type} (f: A -> B)
+  {x: A} {u v: Q (f x)} (q: u = v):
+  @sigT_map_eq A B (fun a => Q (f a)) Q f (fun a u => u) x x u v eq_refl q = q.
+Proof.
+  now destruct q.
+Defined.
+
+Lemma sigT_map_eq_refl {A B: Type} {P: A -> Type} {Q: B -> Type}
+  {f: A -> B} (g: forall a, P a -> Q (f a))
+  {x: A} {u v: P x} (q: u = v):
+  sigT_map_eq g (p := eq_refl) q = f_equal (g x) q.
+Proof.
+  now destruct q.
+Defined.
+
+Lemma f_equal_eq_existT_curried {A B: Type} {P: A -> Type} {Q: B -> Type}
+  (f: A -> B) (g: forall a, P a -> Q (f a))
+  {x y: A} {u: P x} {v: P y}
+  (p: x = y) (q: rew [P] p in u = v):
+  f_equal (fun z: {a: A &T P a} => (f z.1; g z.1 z.2)) (= p; q) =
+  (= f_equal f p; sigT_map_eq g q).
+Proof.
+  now destruct q, p.
+Defined.
+
+Lemma sigT_map_eq_existT_curried_dep_fst {A B: Type} {P: A -> Type}
+  {P': B -> Type} {Q: {a: A &T P a} -> Type}
+  (f: A -> B) (g: forall a, P a -> P' (f a))
+  {x y: A} {u: P x} {v: Q (x; u)}
+  {u': P y} {v': Q (y; u')}
+  (H: x = y) (Hu: rew [P] H in u = u')
+  (Hv: rew [Q] (=H; Hu) in v = v'):
+  sigT_map_eq
+    (P := fun a => {u: P a &T Q (a; u)})
+    (Q := P')
+    (fun a uv => g a uv.1)
+    (eq_existT_curried_dep (H := H) (Hu := Hu) (Hv := Hv)) =
+  sigT_map_eq g Hu.
+Proof.
+  now destruct Hv, Hu, H.
+Defined.
+
+Lemma sigT_map_eq_existT_curried_dep_curried {A B: Type} {P: A -> Type}
+  {R: forall a, P a -> Type} {P': B -> Type}
+  {R': forall b, P' b -> Type}
+  (f: A -> B) (g: forall a, P a -> P' (f a))
+  (h: forall a u, R a u -> R' (f a) (g a u))
+  {x y: A} {u: P x} {v: R x u}
+  {u': P y} {v': R y u'}
+  (H: x = y) (Hu: rew [P] H in u = u')
+  (Hv: rew [fun z => R z.1 z.2] (=H; Hu) in
+    (v: (fun z => R z.1 z.2) (x; u)) = v'):
+  sigT_map_eq
+    (P := fun a => {u: P a &T R a u})
+    (Q := fun b => {u: P' b &T R' b u})
+    (fun a uv => (g a uv.1; h a uv.1 uv.2))
+    (eq_existT_curried_dep (Q := fun z => R z.1 z.2)
+      (H := H) (Hu := Hu) (Hv := Hv)) =
+  eq_existT_curried_dep
+    (Q := fun z => R' z.1 z.2)
+    (H := f_equal f H)
+    (Hu := sigT_map_eq g Hu)
+    (Hv := rew [fun p => rew [fun z => R' z.1 z.2] p in
+        (h x u v: (fun z => R' z.1 z.2) (f x; g x u)) =
+        (h y u' v': (fun z => R' z.1 z.2) (f y; g y u'))]
+      f_equal_eq_existT_curried f g H Hu in
+      @sigT_map_eq _ _ (fun z => R z.1 z.2) (fun z => R' z.1 z.2)
+        (fun z => (f z.1; g z.1 z.2))
+        (fun z => h z.1 z.2) (x; u) (y; u') v v' (=H; Hu) Hv).
+Proof.
+  now destruct Hv, Hu, H.
+Defined.
+
+Definition sigT_trans_eq {A: Type} {P: A -> Type}
+  {x y z: A} {u: P x} {v: P y} {w: P z}
+  {p: x = y} (q: rew [P] p in u = v)
+  {p': y = z} (q': rew [P] p' in v = w):
+  rew [P] eq_trans p p' in u = w.
+Proof.
+  now destruct q', p', q, p.
+Defined.
+
+Infix "⊙" := sigT_trans_eq (at level 65, left associativity).
+
+Notation "q ⊙[ P ] q'" := (@sigT_trans_eq _ P _ _ _ _ _ _ _ q _ q')
+  (at level 65, left associativity, only parsing).
+
+Lemma sigT_trans_eq_refl {A: Type} {P: A -> Type} {x: A} {u v w: P x}
+  (q: u = v) (q': v = w):
+  sigT_trans_eq (p := eq_refl) q (p' := eq_refl) q' = eq_trans q q'.
+Proof.
+  now destruct q', q.
+Defined.
+
+Lemma eq_trans_eq_existT_curried {A: Type} {P: A -> Type}
+  {x y z: A} {u: P x} {v: P y} {w: P z}
+  (p: x = y) (q: rew [P] p in u = v)
+  (p': y = z) (q': rew [P] p' in v = w):
+  eq_trans (= p; q) (= p'; q') =
+  (= eq_trans p p'; sigT_trans_eq q q').
+Proof.
+  now destruct q', p', q, p.
+Defined.
+
+Lemma sigT_trans_eq_existT_curried_dep {A: Type} {P: A -> Type}
+  {Q: {a: A &T P a} -> Type}
+  {x y z: A}
+  {u: P x} {v: Q (x; u)}
+  {u': P y} {v': Q (y; u')}
+  {u'': P z} {v'': Q (z; u'')}
+  (H: x = y) (Hu: rew [P] H in u = u')
+  (Hv: rew [Q] (=H; Hu) in v = v')
+  (H': y = z) (Hu': rew [P] H' in u' = u'')
+  (Hv': rew [Q] (=H'; Hu') in v' = v''):
+  eq_existT_curried_dep (H := H) (Hu := Hu) (Hv := Hv)
+    ⊙ eq_existT_curried_dep (H := H') (Hu := Hu') (Hv := Hv') =
+  eq_existT_curried_dep
+    (H := eq_trans H H')
+    (Hu := Hu ⊙ Hu')
+    (Hv := rew [fun p => rew [Q] p in v = v'']
+      eq_trans_eq_existT_curried H Hu H' Hu' in (Hv ⊙ Hv')).
+Proof.
+  now destruct Hv', Hu', H', Hv, Hu, H.
+Defined.


### PR DESCRIPTION
# `SSGpd`: the construction of semi-simplicial groupoids

### About the construction

- we replace h-sets with h-groupoids
- we fix the arity to `n = 1`, the simplicial case (for simplicity)
- we add a third mutual recursion block: the proof of `mkCohFrames` is done together with `mkCoh2FrameTypes`
- we prove 2-level coherences: `mkCoh2Frames`, `mkCoh2Layer`, `mkCoh2Paintings`
- 3-level frame coherence is closed by `GUIP`, groupoid's path `UIP` assumption

### What makes it all possible

The observation: the structure of coherence proofs is the same, not just across different coherences (`νDgnSet` coherences follow the same structure as `νSet` one), but also across different coherence levels.

- frame coherence induction: decomposition into a proof of frame coherence (recursively) and a proof of layer coherence
- level one is done by `eq_existT_curried`, level two is done by `eq_existT_curried_hex`
- layer coherence: decomposition into a proof of painting coherence, plus a proof of frame coherence *one level up*
- level one is done by `rew_cohLayer`, level two by `rew_coh2Layer`
- painting coherence induction: decomposition into a proof of layer coherence and a proof of painting coherence (recursively)
- level one is done by `eq_existT_curried_dep`, level two is done by `eq_existT_curried_dep_hex`

### Glue - the `SSGpdLemmas` file

These lemmas abstract away the frame/layer/painting structure of the construction, and encapsulate all of the path algebra we need for coherence proofs.

`eq_existT_curried_hex` - the 2-level analogue of `eq_existT_curried` used in `mkCoh2Frames`, fuses 3 things:
- `f_equal_eq_existT_curried` - `eq_existT_curried` commutes with `f_equal`
- `eq_trans_eq_existT_curried` - `eq_existT_curried` commutes with `eq_trans`
- `eq_existT_curried_eq` - assembles an equality of paths built with `eq_existT_curried`

`eq_existT_curried_dep_hex` - 2-level analogue of `eq_existT_curried_dep`, used in induction step case of `mkCoh2Painting`

`rew_cohLayer` - a single lemma that fuses the entire rewrite chain of the layer coherence proof:
- a couple of `map_subst` rewrites
- multiple `rew_map` rewrites
- multiple `rew_compose` rewrites
- a `rew_swap` application
- a rewrite with `rew_app_rl`

`rew_coh2Layer` - a 2-level analogue of `rew_cohLayer`, encapsulates all of the path algebra needed for `mkCoh2Layer` proof

`permutahedral_coherence` - a helper definition for `rew_coh2Layer`

`rew_coh2Painting_restr0` - a lemma for the base case of `mkCoh2Painting`. Unlike the 1-level case, it doesn't hold by `reflexivity`

### Outcome

The `SemiSimplicial5` example, as computed in `νSet` from the `no-funext` branch, gets stuck on h-set's `UIP`. In contrast, in `SSGpd`, `SemiSimplicial5` fully computes. `SemiSimplicial6` gets stuck on `GUIP`, groupoid's `UIP`.

### Compilation performance

There were a few issues to overcome. It is recommended to use [master+bonak-patches](https://github.com/olympichek/rocq/tree/master%2Bbonak-patches) branch to compile this project. With this branch the project compiles in 1m 20s on my laptop.

This branch contains:
- Pierre-Marie Pédrot's fixpoint refolding patches
- A patch to make `whd_all` and `whd_allnolet` go through `CClosure`, to benefit from fixpoint refolding
- A fast path in conversion's `compare_under` (now merged as [#22299](https://github.com/rocq-prover/rocq/pull/22299))
- An implementation of cache for Rocq's conversion

### Future work: going back to abstract arity

This is a follow-up step, still an open problem.

Both known approaches have issues:
- layers as functions from arity: layer coherence proofs don't compute, get stuck on fun-ext axiom
- layers as vectors: require more rewrites, complicate 2-level proofs, harder to abstract

### Future work: helper lemmas in a stronger type theory

Investigate whether at least some of the lemmas from `SSGpdLemmas` are true by definition in a type theory with more definitional rules, such as Cubical Type Theory or Higher Observational Type Theory. Definitional rule establishing that equality of pairs is a pair of equality proofs by definition seems to be particularly useful here.

### Future work: towards infinity

Now we just need to understand how to generalize the coherence proof pattern from sets and groupoids to n-groupoids and ∞-groupoids..
