### PR TITLE
ci: two ci jobs - for released Rocq and for patched Rocq

### DIFF
--- a/.github/rocq-9.2-blacklist.txt
+++ b/.github/rocq-9.2-blacklist.txt
@@ -1,0 +1,8 @@
+# Files that are not built by the "Rocq 9.2" CI job, one path per line,
+# relative to the repository root.  Blank lines and #-comments are ignored,
+# and a listed file that does not exist is an error.
+#
+# This is meant for files that only the patched Rocq can compile in reasonable
+# time; they are still built in full by the "Rocq master+bonak-patches" job.
+# The list has to be closed under dependency: no file left in the build may
+# Require a blacklisted one.

--- a/.github/rocq-9.2-blacklist.txt
+++ b/.github/rocq-9.2-blacklist.txt
@@ -1,8 +1,0 @@
-# Files that are not built by the "Rocq 9.2" CI job, one path per line,
-# relative to the repository root.  Blank lines and #-comments are ignored,
-# and a listed file that does not exist is an error.
-#
-# This is meant for files that only the patched Rocq can compile in reasonable
-# time; they are still built in full by the "Rocq master+bonak-patches" job.
-# The list has to be closed under dependency: no file left in the build may
-# Require a blacklisted one.

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -29,28 +29,7 @@ jobs:
         with:
           submodules: "true"
       - name: "Apply the blacklist"
-        run: |
-          set -eu
-          blacklist=".github/rocq-9.2-blacklist.txt"
-          if [ ! -f "$blacklist" ]; then
-            echo "No $blacklist: building every file."
-            exit 0
-          fi
-          count=0
-          while IFS= read -r line || [ -n "$line" ]; do
-            file="${line%%#*}"
-            file="${file#"${file%%[![:space:]]*}"}"
-            file="${file%"${file##*[![:space:]]}"}"
-            [ -n "$file" ] || continue
-            if [ ! -f "$file" ]; then
-              echo "::error file=$blacklist::blacklisted file '$file' does not exist"
-              exit 1
-            fi
-            echo "Excluding $file"
-            rm -- "$file"
-            count=$((count + 1))
-          done < "$blacklist"
-          echo "$count file(s) excluded from the Rocq 9.2 build."
+        run: xargs -r rm -- < .github/rocq-9.2-blacklist.txt
       - name: "Docker Rocq action"
         uses: "coq-community/docker-coq-action@v1"
         with:
@@ -94,7 +73,6 @@ jobs:
       - name: "Resolve the patched Rocq revision"
         id: "rocq"
         run: |
-          set -eu
           sha=$(git ls-remote "$ROCQ_REPO" "refs/heads/$ROCQ_BRANCH" | cut -f1)
           test -n "$sha"
           echo "Building against $ROCQ_BRANCH at $sha"
@@ -115,7 +93,6 @@ jobs:
       - name: "Build the patched Rocq"
         if: steps.switch.outputs.cache-hit != 'true'
         run: |
-          set -eu
           opam pin add -y -n rocq-runtime "git+$ROCQ_REPO#$ROCQ_BRANCH"
           opam pin add -y -n rocq-core "git+$ROCQ_REPO#$ROCQ_BRANCH"
           opam pin add -y -n rocq-stdlib "git+$STDLIB_REPO#$STDLIB_REV"
@@ -124,6 +101,5 @@ jobs:
         run: opam install -y -j "$(nproc)" ./bonak.opam --deps-only
       - name: "Build"
         run: |
-          set -eu
           opam exec -- rocq --version
           opam exec -- dune build

--- a/.github/workflows/coq-action.yml
+++ b/.github/workflows/coq-action.yml
@@ -7,6 +7,7 @@ on:
       - "bonak.opam"
       - "dune-project"
       - "**/dune"
+      - ".github/rocq-9.2-blacklist.txt"
       - ".github/workflows/coq-action.yml"
   pull_request:
     types: [opened, reopened, synchronize]
@@ -15,14 +16,41 @@ on:
       - "bonak.opam"
       - "dune-project"
       - "**/dune"
+      - ".github/rocq-9.2-blacklist.txt"
       - ".github/workflows/coq-action.yml"
 jobs:
-  build:
+  # Builds the project with the latest Rocq release, minus the files listed in
+  # .github/rocq-9.2-blacklist.txt.
+  rocq-release:
+    name: "Rocq 9.2"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v4"
         with:
           submodules: "true"
+      - name: "Apply the blacklist"
+        run: |
+          set -eu
+          blacklist=".github/rocq-9.2-blacklist.txt"
+          if [ ! -f "$blacklist" ]; then
+            echo "No $blacklist: building every file."
+            exit 0
+          fi
+          count=0
+          while IFS= read -r line || [ -n "$line" ]; do
+            file="${line%%#*}"
+            file="${file#"${file%%[![:space:]]*}"}"
+            file="${file%"${file##*[![:space:]]}"}"
+            [ -n "$file" ] || continue
+            if [ ! -f "$file" ]; then
+              echo "::error file=$blacklist::blacklisted file '$file' does not exist"
+              exit 1
+            fi
+            echo "Excluding $file"
+            rm -- "$file"
+            count=$((count + 1))
+          done < "$blacklist"
+          echo "$count file(s) excluded from the Rocq 9.2 build."
       - name: "Docker Rocq action"
         uses: "coq-community/docker-coq-action@v1"
         with:
@@ -44,3 +72,58 @@ jobs:
               opam update -y default
               opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only
             endGroup
+
+  # Builds the whole project with our patched Rocq, which carries the fixpoint
+  # refolding and conversion-cache patches the heavier files rely on.
+  rocq-patched:
+    name: "Rocq master+bonak-patches"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 120
+    env:
+      ROCQ_REPO: "https://github.com/olympichek/rocq.git"
+      ROCQ_BRANCH: "master+bonak-patches"
+      # Rocq's stdlib lives in its own repository; this is the revision the
+      # patched branch is developed against.
+      STDLIB_REPO: "https://github.com/rocq-prover/stdlib.git"
+      STDLIB_REV: "b89635f66d5d5fe3c91a5755b389a30846411888"
+      OCAML_COMPILER: "5.3"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: "true"
+      - name: "Resolve the patched Rocq revision"
+        id: "rocq"
+        run: |
+          set -eu
+          sha=$(git ls-remote "$ROCQ_REPO" "refs/heads/$ROCQ_BRANCH" | cut -f1)
+          test -n "$sha"
+          echo "Building against $ROCQ_BRANCH at $sha"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      - uses: "ocaml/setup-ocaml@v3"
+        with:
+          ocaml-compiler: ${{ env.OCAML_COMPILER }}
+          opam-pin: false
+      # The opam switch holding the patched Rocq is cached: rebuilding it from
+      # source costs about five minutes.  The key pins the exact Rocq and
+      # stdlib revisions, so moving either one invalidates the cache.
+      - name: "Restore the opam switch"
+        id: "switch"
+        uses: "actions/cache@v4"
+        with:
+          path: "_opam"
+          key: "rocq-patched-${{ runner.os }}-ocaml-${{ env.OCAML_COMPILER }}-${{ steps.rocq.outputs.sha }}-${{ env.STDLIB_REV }}"
+      - name: "Build the patched Rocq"
+        if: steps.switch.outputs.cache-hit != 'true'
+        run: |
+          set -eu
+          opam pin add -y -n rocq-runtime "git+$ROCQ_REPO#$ROCQ_BRANCH"
+          opam pin add -y -n rocq-core "git+$ROCQ_REPO#$ROCQ_BRANCH"
+          opam pin add -y -n rocq-stdlib "git+$STDLIB_REPO#$STDLIB_REV"
+          opam install -y -j "$(nproc)" rocq-core rocq-stdlib
+      - name: "Install the remaining dependencies"
+        run: opam install -y -j "$(nproc)" ./bonak.opam --deps-only
+      - name: "Build"
+        run: |
+          set -eu
+          opam exec -- rocq --version
+          opam exec -- dune build


### PR DESCRIPTION
Enhance CI to contain two jobs:
- compile with Rocq 9.2 with support of adding files that are too slow to a blacklist
- compile the whole project with our custom [master+bonak-patches](https://github.com/olympichek/rocq/tree/master%2Bbonak-patches) branch