### PR TITLE
SSGpd: experiment - unblacklist from Rocq 9.2

### DIFF
--- a/.github/rocq-9.2-blacklist.txt
+++ b/.github/rocq-9.2-blacklist.txt
@@ -1,1 +1,0 @@
-theories/νSet/SSGpd.v


### PR DESCRIPTION
In principle it should compile. Before it was failing on the `set` call in `mkCoh2Painting`, which is removed in #25. I expect around 8 hours, though..