### PR TITLE
Unify the fused layer coherence lemmas (`rew_cohLayer*`)

### DIFF
--- a/theories/νSet/RewLemmas.v
+++ b/theories/νSet/RewLemmas.v
@@ -1,5 +1,7 @@
 (** A few rewriting lemmas not in the standard library *)
 
+From Stdlib Require Import Logic.FunctionalExtensionality.
+
 Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
@@ -16,195 +18,134 @@ Lemma rew_swap: forall A (P: A -> Type) a b (H: a = b) (x: P a) (y: P b),
   x = rew <- H in y <-> rew H in x = y.
 Proof.
   now destruct H.
-Qed.
+Defined.
 
-Lemma rew_app_rl A (P: A -> Type) (x y: A) (H H': x = y) (a: P x) :
+Lemma rew_app_rl A (P: A -> Type) (x y: A) (H H': x = y) (a: P x):
   H = H' -> rew <- [P] H in rew [P] H' in a = a.
 Proof.
   intros * ->. now destruct H'.
-Qed.
+Defined.
 
 Lemma map_subst_app {A B} {x y} {𝛉: A} (H: x = y :> B) (P: A -> B -> Type)
   (f: forall 𝛉, P 𝛉 x):
   rew [P 𝛉] H in f 𝛉 = (rew [fun x => forall 𝛉, P 𝛉 x] H in f) 𝛉.
 Proof.
   now destruct H.
-Qed.
+Defined.
 
-(** Fused transport-chain lemmas.
+(** The pointwise-to-layer bridge: a layer is a dependent function over the
+    arity, so transporting a layer along a path in the frame is determined
+    pointwise ([functional_extensionality_dep] followed by
+    [map_subst_app]). *)
 
-    Each lemma equates, in one step, two forward chains of transports of the
-    same element — the goal shape of the layer coherence proofs after
-    [map_subst]. The digits name the number of transports on each side of
-    the equation. The premises are an equation between the transported
-    elements ([reflexivity] at the use sites) and an equation between the two
-    composite paths: the higher coherence, which every caller exhibits
-    explicitly — [UIP] in an HSet development. *)
-
-Lemma rew_chain13 {X B1 B2: Type} (P: X -> Type)
-  (f: B1 -> X) (g: B2 -> X)
-  {u1 v1: B1} {u3 v3: B2}
-  (E1: u1 = v1)
-  (F1: g v3 = f v1) (F2: u3 = v3) (F3: f u1 = g u3)
-  (aL aR: P (f u1)):
-  aL = aR ->
-  f_equal f E1 = F3 • (f_equal g F2 • F1) ->
-  rew [fun x => P (f x)] E1 in aL
-  = rew [P] F1 in rew [fun x => P (g x)] F2 in rew [P] F3 in aR.
+Lemma layer_rew_eq {A T X: Type} {P: X -> Type} {rf0: A -> T -> X}
+  {d1 d2: T} {E1: d1 = d2}
+  {l: forall ω, P (rf0 ω d1)} {l': forall ω, P (rf0 ω d2)}:
+  (forall ω, rew [fun d => P (rf0 ω d)] E1 in l ω = l' ω) ->
+  rew [fun d => forall ω, P (rf0 ω d)] E1 in l = l'.
 Proof.
-  intros base coh2. destruct base, E1, F2. cbn in coh2 |- *.
-  rewrite rew_compose.
-  rewrite eq_trans_refl_l in coh2.
-  now rewrite <- coh2.
-Qed.
+  intro H. apply functional_extensionality_dep; intro ω.
+  rewrite <- (map_subst_app E1 (fun ω d => P (rf0 ω d)) l).
+  now exact (H ω).
+Defined.
 
-Lemma rew_chain31 {X B1 B2: Type} (P: X -> Type)
-  (f1: B1 -> X) (f2: B2 -> X)
-  {u1 v1: B1} {u2 v2: B2}
-  (E1: u1 = v1) (E2: f2 v2 = f1 u1) (E3: u2 = v2)
-  (F1: f2 u2 = f1 v1)
-  (aL aR: P (f2 u2)):
-  aL = aR ->
-  f_equal f2 E3 • (E2 • f_equal f1 E1) = F1 ->
-  rew [fun x => P (f1 x)] E1 in rew [P] E2 in rew [fun x => P (f2 x)] E3 in aL
-  = rew [P] F1 in aR.
-Proof.
-  intros base coh2. destruct base, E1, E3. cbn in coh2 |- *.
-  rewrite eq_trans_refl_l in coh2.
-  now rewrite coh2.
-Qed.
+(** Fused transport-chain lemmas for layer coherence proofs
 
-Lemma rew_chain22 {X B1 B2: Type} (P: X -> Type)
-  (f: B1 -> X) (g: B2 -> X)
-  {u v: B1} {w w': B2}
-  (E1: u = v) (E0: g w = f u)
-  (F1: g w' = f v) (F2: w = w')
-  (aL aR: P (g w)):
-  aL = aR ->
-  E0 • f_equal f E1 = f_equal g F2 • F1 ->
-  rew [fun x => P (f x)] E1 in rew [P] E0 in aL
-  = rew [P] F1 in rew [fun x => P (g x)] F2 in aR.
-Proof.
-  intros base coh2. destruct base, E1, F2. cbn in coh2 |- *.
-  rewrite eq_trans_refl_l in coh2.
-  now rewrite coh2.
-Qed.
+    [rew_cohLayer<NM>] closes a layer coherence goal in one step, once
+    [layer_rew_eq] has taken the pointwise step: it equates two chains of
+    transports, N on the left-hand side and M on the right, whose starting
+    elements are identified by the painting coherence. A call site supplies
+    only the two premises: the painting coherence and the 2-dimensional frame
+    coherence ([UIP] in HSet development). *)
 
-Lemma rew_chain33 {X B1 B2 B3: Type} (P: X -> Type)
-  (f1: B1 -> X) (f2: B2 -> X) (g: B3 -> X)
-  {u1 v1: B1} {u2 v2: B2} {u3 v3: B3}
-  (E1: u1 = v1) (E2: f2 v2 = f1 u1) (E3: u2 = v2)
-  (F1: g v3 = f1 v1) (F2: u3 = v3) (F3: f2 u2 = g u3)
-  (aL aR: P (f2 u2)):
-  aL = aR ->
-  f_equal f2 E3 • (E2 • f_equal f1 E1) = F3 • (f_equal g F2 • F1) ->
-  rew [fun x => P (f1 x)] E1 in rew [P] E2 in rew [fun x => P (f2 x)] E3 in aL
-  = rew [P] F1 in rew [fun x => P (g x)] F2 in rew [P] F3 in aR.
-Proof.
-  intros base coh2. destruct base, E1, E3, F2. cbn in coh2 |- *.
-  rewrite rew_compose.
-  rewrite !eq_trans_refl_l in coh2.
-  now rewrite coh2.
-Qed.
-
-(** Fused layer-chain lemmas.
-
-    On top of [rew_chain*] lemmas above, they additionally absorb the head of the layer
-    coherence proofs — the commutation of the pointwise ([map_subst_app]) and
-    fiberwise ([map_subst]) transports — so that a layer coherence proof
-    reduces to [functional_extensionality_dep] followed by a single
-    application. *)
-
-Lemma rew_layer13 {A T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
-  {rf0: A -> T1 -> X} {rfG: T3 -> X}
-  {G: forall n, S3 n -> P (rfG n)}
-  {𝛉: A}
-  {d1 d2: T1} {E1: d1 = d2}
-  {n1 n2: T3} {D2: n1 = n2}
-  {D1: rfG n2 = rf0 𝛉 d2}
-  {K: rf0 𝛉 d1 = rfG n1}
-  {aL: P (rf0 𝛉 d1)} {aR: S3 n1}
-  {L: forall a, P (rf0 a d1)}:
-  L 𝛉 = aL ->
-  rew [P] K in aL = G n1 aR ->
-  f_equal (rf0 𝛉) E1 = K • (f_equal rfG D2 • D1) ->
-  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
-  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
-Proof.
-  intros HL HC Hpath.
-  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
-    <- (map_subst G D2 aR), <- HC.
-  exact (rew_chain13 P (rf0 𝛉) rfG E1 D1 D2 K aL aL eq_refl Hpath).
-Qed.
-
-Lemma rew_layer22 {A T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
-  {rf0: A -> T1 -> X} {rfG: T3 -> X}
-  {G: forall n, S3 n -> P (rfG n)}
-  {𝛉: A}
-  {d1 d2: T1} {E1: d1 = d2}
-  {n1 n2: T3} {D2: n1 = n2}
-  {E0: rfG n1 = rf0 𝛉 d1}
-  {D1: rfG n2 = rf0 𝛉 d2}
-  {aL: P (rfG n1)} {aR: S3 n1}
-  {L: forall a, P (rf0 a d1)}:
-  L 𝛉 = rew [P] E0 in aL ->
-  aL = G n1 aR ->
-  E0 • f_equal (rf0 𝛉) E1 = f_equal rfG D2 • D1 ->
-  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
-  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
-Proof.
-  intros HL HC Hpath.
-  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
-    <- (map_subst G D2 aR), <- HC.
-  exact (rew_chain22 P (rf0 𝛉) rfG E1 E0 D1 D2 aL aL eq_refl Hpath).
-Qed.
-
-Lemma rew_layer31 {A T1 T2 X: Type} {P: X -> Type} {S2: T2 -> Type}
-  {rf0: A -> T1 -> X} {rfF: T2 -> X}
+Lemma rew_cohLayer33 {T1 T2 T3 X: Type} {P: X -> Type}
+  {S2: T2 -> Type} {S3: T3 -> Type}
+  {rf0: T1 -> X} {rfF: T2 -> X} {rfG: T3 -> X}
   {F: forall m, S2 m -> P (rfF m)}
-  {𝛉: A}
+  {G: forall n, S3 n -> P (rfG n)}
   {d1 d2: T1} {E1: d1 = d2}
   {m1 m2: T2} {C2: m1 = m2}
-  {C1: rfF m2 = rf0 𝛉 d1}
-  {D1: rfF m1 = rf0 𝛉 d2}
-  {aL: S2 m1} {aR: P (rfF m1)}
-  {L: forall a, P (rf0 a d1)}:
-  L 𝛉 = rew [P] C1 in F m2 (rew [S2] C2 in aL) ->
+  {n1 n2: T3} {D2: n1 = n2}
+  {C1: rfF m2 = rf0 d1}
+  {D1: rfG n2 = rf0 d2}
+  {K: rfF m1 = rfG n1}
+  {aL: S2 m1} {aR: S3 n1}:
+  rew [P] K in F m1 aL = G n1 aR -> (* painting coherence *)
+  f_equal rfF C2 • (C1 • f_equal rf0 E1) = K • (f_equal rfG D2 • D1) ->
+  (* 2-dimensional frame coherence, UIP for HSets *)
+  rew [fun d => P (rf0 d)] E1 in rew [P] C1 in F m2 (rew [S2] C2 in aL)
+  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
+Proof.
+  intros HC Hpath.
+  rewrite <- (map_subst F C2 aL), <- (map_subst G D2 aR), <- HC.
+  destruct E1, C2, D2. cbn in Hpath |- *.
+  rewrite rew_compose.
+  rewrite 2 eq_trans_refl_l in Hpath.
+  now rewrite Hpath.
+Defined.
+
+(** The [rew_cohLayer*] lemmas for square-shaped coherences can be considered an
+    instance of the hexagon-shaped one, with 2 arrows trivial. *)
+
+Lemma rew_cohLayer13 {T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
+  {rf0: T1 -> X} {rfG: T3 -> X}
+  {G: forall n, S3 n -> P (rfG n)}
+  {d1 d2: T1} {E1: d1 = d2}
+  {n1 n2: T3} {D2: n1 = n2}
+  {D1: rfG n2 = rf0 d2}
+  {K: rf0 d1 = rfG n1}
+  {aL: P (rf0 d1)} {aR: S3 n1}:
+  rew [P] K in aL = G n1 aR ->
+  f_equal rf0 E1 = K • (f_equal rfG D2 • D1) ->
+  rew [fun d => P (rf0 d)] E1 in aL
+  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
+Proof.
+  intros HC Hpath.
+  eapply (rew_cohLayer33 (P := P) (S2 := P) (rf0 := rf0)
+    (rfF := fun x => x) (F := fun _ a => a)
+    (C2 := eq_refl) (C1 := eq_refl) (K := K) (aL := aL)).
+  now exact HC.
+  now rewrite 2 eq_trans_refl_l.
+Defined.
+
+Lemma rew_cohLayer22 {T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
+  {rf0: T1 -> X} {rfG: T3 -> X}
+  {G: forall n, S3 n -> P (rfG n)}
+  {d1 d2: T1} {E1: d1 = d2}
+  {n1 n2: T3} {D2: n1 = n2}
+  {E0: rfG n1 = rf0 d1}
+  {D1: rfG n2 = rf0 d2}
+  {aL: P (rfG n1)} {aR: S3 n1}:
+  aL = G n1 aR ->
+  E0 • f_equal rf0 E1 = f_equal rfG D2 • D1 ->
+  rew [fun d => P (rf0 d)] E1 in rew [P] E0 in aL
+  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
+Proof.
+  intros HC Hpath.
+  eapply (rew_cohLayer33 (P := P) (S2 := P) (rf0 := rf0)
+    (rfF := fun x => x) (F := fun _ a => a)
+    (C2 := eq_refl) (C1 := E0) (K := eq_refl) (aL := aL)).
+  now exact HC.
+  now rewrite 2 eq_trans_refl_l.
+Defined.
+
+Lemma rew_cohLayer31 {T1 T2 X: Type} {P: X -> Type} {S2: T2 -> Type}
+  {rf0: T1 -> X} {rfF: T2 -> X}
+  {F: forall m, S2 m -> P (rfF m)}
+  {d1 d2: T1} {E1: d1 = d2}
+  {m1 m2: T2} {C2: m1 = m2}
+  {C1: rfF m2 = rf0 d1}
+  {D1: rfF m1 = rf0 d2}
+  {aL: S2 m1} {aR: P (rfF m1)}:
   F m1 aL = aR ->
-  f_equal rfF C2 • (C1 • f_equal (rf0 𝛉) E1) = D1 ->
-  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
+  f_equal rfF C2 • (C1 • f_equal rf0 E1) = D1 ->
+  rew [fun d => P (rf0 d)] E1 in rew [P] C1 in F m2 (rew [S2] C2 in aL)
   = rew [P] D1 in aR.
 Proof.
-  intros HL HC Hpath.
-  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
-    <- (map_subst F C2 aL).
-  exact (rew_chain31 P (rf0 𝛉) rfF E1 C1 C2 D1 (F m1 aL) aR HC Hpath).
-Qed.
-
-Lemma rew_layer33 {A T1 T2 T3 X: Type} {P: X -> Type}
-  {S2: T2 -> Type} {S3: T3 -> Type}
-  {rf0: A -> T1 -> X} {rfF: T2 -> X} {rfG: T3 -> X}
-  {F: forall m, S2 m -> P (rfF m)}
-  {G: forall n, S3 n -> P (rfG n)}
-  {𝛉: A}
-  {d1 d2: T1} {E1: d1 = d2}
-  {m1 m2: T2} {C2: m1 = m2}
-  {n1 n2: T3} {D2: n1 = n2}
-  {C1: rfF m2 = rf0 𝛉 d1}
-  {D1: rfG n2 = rf0 𝛉 d2}
-  {K: rfF m1 = rfG n1}
-  {aL: S2 m1} {aR: S3 n1}
-  {L: forall a, P (rf0 a d1)}:
-  L 𝛉 = rew [P] C1 in F m2 (rew [S2] C2 in aL) -> (* reflexivity *)
-  rew [P] K in F m1 aL = G n1 aR -> (* painting coherence *)
-  f_equal rfF C2 • (C1 • f_equal (rf0 𝛉) E1) = K • (f_equal rfG D2 • D1) ->
-  (* 2-dimensional frame coherence, UIP for HSets *)
-  (rew [fun d => forall a, P (rf0 a d)] E1 in L) 𝛉
-  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
-Proof.
-  intros HL HC Hpath.
-  rewrite <- (map_subst_app E1 (fun a d => P (rf0 a d)) L), HL,
-    <- (map_subst F C2 aL), <- (map_subst G D2 aR), <- HC.
-  exact (rew_chain33 P (rf0 𝛉) rfF rfG E1 C1 C2 D1 D2 K (F m1 aL) (F m1 aL)
-    eq_refl Hpath).
-Qed.
+  intros HC Hpath.
+  eapply (rew_cohLayer33 (P := P) (S3 := P) (rf0 := rf0)
+    (rfF := rfF) (rfG := fun x => x) (G := fun _ a => a)
+    (m1 := m1) (D2 := eq_refl) (D1 := D1) (K := eq_refl) (aR := aR)).
+  now exact HC.
+  now rewrite 2 eq_trans_refl_l.
+Defined.

--- a/theories/νSet/SSGpd.v
+++ b/theories/νSet/SSGpd.v
@@ -1,5 +1,5 @@
 Set Warnings "-notation-overridden".
-From Bonak Require Import SigT HSet HGpd Notation LeSProp SSGpdLemmas.
+From Bonak Require Import SigT HSet HGpd Notation LeSProp RewLemmas SSGpdLemmas.
 
 Set Primitive Projections.
 Set Printing Projections.
@@ -469,11 +469,11 @@ Definition mkCohLayer `{extraDepsCohs: DepsCohsExtension p.+1 k depsCohs}
   mkCohLayerType q Hq r Hr d l.
 Proof.
   unfold mkCohLayerType, mkRestrLayer, mkLayer.
-  eapply rew_cohLayer with
+  eapply (rew_cohLayer33
     (P := fun x => depsCohs.(_deps).(_paintings).2 x)
     (rf0 := fun x => depsCohs.(_deps).(_restrFrames).2 0 leR_O x)
     (F := depsCohs.(_restrPaintings).2 q Hq)
-    (G := depsCohs.(_restrPaintings).2 r (Hr ↕ Hq)).
+    (G := depsCohs.(_restrPaintings).2 r (Hr ↕ Hq))).
   - now exact (cohPainting q Hq r Hr
       (((mkCohFrameTypesAndRestrFrames (mkRestrPaintings extraDepsCohs).1.1)
         .(RestrFramesDef) prevCohFrames.1).2 0 leR_O d) l).

--- a/theories/νSet/SSGpdLemmas.v
+++ b/theories/νSet/SSGpdLemmas.v
@@ -1,7 +1,10 @@
 Set Warnings "-notation-overridden".
-From Bonak Require Import SigT Notation.
+From Bonak Require Import SigT Notation RewLemmas.
 
 Set Keyed Unification.
+
+Local Arguments rew_cohLayer33 {T1 T2 T3 X} P {S2 S3} rf0 {rfF rfG} F G
+  {d1 d2} E1 {m1 m2} C2 {n1 n2} D2 C1 D1 K aL aR _ _.
 
 Lemma eq_existT_curried_hex {A1 A2 A3 B: Type}
   {P1: A1 -> Type} {P2: A2 -> Type} {P3: A3 -> Type} {Q: B -> Type}
@@ -138,31 +141,6 @@ Proof.
   intros HHv'; now exact HHv'.
 Defined.
 
-Lemma rew_cohLayer {T1 T2 T3 X: Type} (P: X -> Type)
-  {S2: T2 -> Type} {S3: T3 -> Type}
-  (rf0: T1 -> X) {rfF: T2 -> X} {rfG: T3 -> X}
-  (F: forall m, S2 m -> P (rfF m))
-  (G: forall n, S3 n -> P (rfG n))
-  {d1 d2: T1} (E1: d1 = d2)
-  {m1 m2: T2} (C2: m1 = m2)
-  {n1 n2: T3} (D2: n1 = n2)
-  (C1: rfF m2 = rf0 d1) (D1: rfG n2 = rf0 d2)
-  (K: rfF m1 = rfG n1)
-  (aL: S2 m1) (aR: S3 n1):
-  rew [P] K in F m1 aL = G n1 aR ->
-  f_equal rfF C2 • (C1 • f_equal rf0 E1) =
-  K • (f_equal rfG D2 • D1) ->
-  rew [fun d => P (rf0 d)] E1 in rew [P] C1 in F m2 (rew [S2] C2 in aL)
-  = rew [P] D1 in G n2 (rew [S3] D2 in aR).
-Proof.
-  intros HC Hpath.
-  rewrite <- (map_subst F C2 aL), <- (map_subst G D2 aR).
-  rewrite <- HC.
-  rewrite (rew_map P rf0 E1), (rew_map P rfF C2), (rew_map P rfG D2).
-  rewrite 4 rew_compose.
-  now exact (f_equal (fun h => rew [P] h in F m1 aL) Hpath).
-Defined.
-
 Lemma rew_coh2Painting_restr0 {Tp Td: Type} {S: Tp -> Type} (P: Td -> Type)
   (rf0: Tp -> Td) {rfF rfG: Tp -> Td}
   (F: forall m, S m -> P (rfF m))
@@ -179,7 +157,7 @@ Lemma rew_coh2Painting_restr0 {Tp Td: Type} {S: Tp -> Type} (P: Td -> Type)
   (R0: {a: Tp &T P (rf0 a)} -> Type)
   {v0: R0 (d1; rew [P] C1 in F m2 (rew [S] C2 in aL))}
   {v1: R0 (d2; rew [P] D1 in G n2 (rew [S] D2 in aR))}
-  (Hv: rew [R0] (= E1; rew_cohLayer P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH)
+  (Hv: rew [R0] (= E1; rew_cohLayer33 P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH)
     in v0 = v1):
   rew [fun π: rfF m1 = rf0 d2 =>
       rew [P] π in F m1 aL = rew [P] D1 in G n2 (rew [S] D2 in aR)] HH in
@@ -189,12 +167,12 @@ Lemma rew_coh2Painting_restr0 {Tp Td: Type} {S: Tp -> Type} (P: Td -> Type)
       ⊙ sigT_map_eq (P := fun a => {u: P (rf0 a) &T R0 (a; u)}) (Q := P)
           (f := rf0) (fun a uv => uv.1)
           (eq_existT_curried_dep (Q := R0) (H := E1)
-            (Hu := rew_cohLayer P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH)
+            (Hu := rew_cohLayer33 P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH)
             (Hv := Hv)))) =
   HK ⊙ (sigT_map_eq (Q := P) G (eq_refl (x := rew [S] D2 in aR)) ⊙ eq_refl).
 Proof.
   rewrite (sigT_map_eq_existT_curried_dep_fst rf0 (fun a u => u) E1
-    (rew_cohLayer P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH) Hv).
+    (rew_cohLayer33 P rf0 F G E1 C2 D2 C1 D1 K aL aR HK HH) Hv).
   cbn [projT1].
   clear Hv v0 v1 R0.
   destruct E1, C2, D2.
@@ -372,19 +350,19 @@ Lemma rew_coh2Layer
         Fs (g0 dd23) (rew [S0] D13 in Rr1 m3 (rew [S1] b3 in a3))]
     HHs in
   (sigT_map_eq (fun x v => rew [PA] gq x in Fq (g0 x) v)
-     (rew_cohLayer S0 g0 Rr Rs E11 b1 b2 C11 D11 KB1 a1 a2 HKB1 HHB1)
-   ⊙ (rew_cohLayer PA f0 Fq Fs E12 D11 C13 (gq dd21) (gs dd13) (KA2 m2)
+     (rew_cohLayer33 S0 g0 Rr Rs E11 b1 b2 C11 D11 KB1 a1 a2 HKB1 HHB1)
+   ⊙ (rew_cohLayer33 PA f0 Fq Fs E12 D11 C13 (gq dd21) (gs dd13) (KA2 m2)
         (Rs m2 (rew [S1] b2 in a2)) (Rq1 m2 (rew [S1] b2 in a2))
         (HKA2 m2 (rew [S1] b2 in a2)) HH2
       ⊙ sigT_map_eq (fun x v => rew [PA] gs x in Fs (g0 x) v)
-          (rew_cohLayer S0 g0 Rq1 Rr1 E13 b2 b3 C13 D13 KB3 a2 a3
+          (rew_cohLayer33 S0 g0 Rq1 Rr1 E13 b2 b3 C13 D13 KB3 a2 a3
              HKB3 HHB3))) =
-  rew_cohLayer PA f0 Fq Fr E14 C11 C15 (gq dd11) (gr dd15) (KA4 m1)
+  rew_cohLayer33 PA f0 Fq Fr E14 C11 C15 (gq dd11) (gr dd15) (KA4 m1)
     (Rr m1 (rew [S1] b1 in a1)) (Rq1 m1 (rew [S1] b1 in a1))
     (HKA4 m1 (rew [S1] b1 in a1)) HH4
   ⊙ (sigT_map_eq (fun x v => rew [PA] gr x in Fr (g0 x) v)
-       (rew_cohLayer S0 g0 Rq1 Rs E15 b1 b3 C15 D15 KB5 a1 a3 HKB5 HHB5)
-     ⊙ rew_cohLayer PA f0 Fr Fs E16 D15 D13 (gr dd25) (gs dd23) (KA6 m3)
+       (rew_cohLayer33 S0 g0 Rq1 Rs E15 b1 b3 C15 D15 KB5 a1 a3 HKB5 HHB5)
+     ⊙ rew_cohLayer33 PA f0 Fr Fs E16 D15 D13 (gr dd25) (gs dd23) (KA6 m3)
          (Rs m3 (rew [S1] b3 in a3)) (Rr1 m3 (rew [S1] b3 in a3))
          (HKA6 m3 (rew [S1] b3 in a3)) HH6).
 Proof.

--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -1,4 +1,3 @@
-From Stdlib Require Import Logic.FunctionalExtensionality.
 Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
@@ -310,15 +309,17 @@ Definition mkIdRestrReflLayerBelow {p k}
         ((ReflBelowOfReflCohsInf deps).(_reflFramesBelow)) deps.(_reflPaintingsBelow) _
           deps.(_cohReflRestrFramesBelowInf) i Hi d l).
 Proof.
-  apply functional_extensionality_dep.
-  intros θ.
-  eapply (rew_layer13
+  apply (layer_rew_eq
     (P := fun x => deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x)
     (rf0 := fun a x =>
-      deps.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).2 0 leR_O a x)
+      deps.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).2 0 leR_O a x));
+    intros θ.
+  eapply (rew_cohLayer13
+    (P := fun x => deps.(_depsCohs2).(_depsCohs).(_deps).(_paintings).2 x)
+    (rf0 := fun x =>
+      deps.(_depsCohs2).(_depsCohs).(_deps).(_restrFrames).2 0 leR_O θ x)
     (G := fun m c =>
       deps.(_depsCohs2).(_depsCohs).(_restrPaintings).2 i Hi ε m c)).
-  now trivial.
   now exact (deps.(_idRestrReflPaintingsBelow).2 i Hi ε _ (l θ)).
   now apply (deps.(_depsCohs2).(_depsCohs).(_deps).(_frames).2.(UIP)).
 Defined.
@@ -1108,18 +1109,20 @@ Definition mkCohReflRestrLayerBelowInf {p k}
       prevCohReflRestrFrames
       q.+1 (⇑ Hq) d l).
 Proof.
-  apply functional_extensionality_dep.
-  intros θ.
-  eapply (rew_layer33
+  apply (layer_rew_eq
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
     (rf0 := fun a x =>
-      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O a x)
+      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O a x));
+    intros θ.
+  eapply (rew_cohLayer33
+    (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
+    (rf0 := fun x =>
+      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ x)
     (F := fun m c =>
       (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 q Hq m c)
     (G := fun m c =>
       (mkDepsCohs (Cohs2OfReflCohs2 deps)).(1).(_restrPaintings).2
         r (Hr ↕ ↑ Hq) ε m c)).
-  now trivial.
   now exact (deps.(_cohReflRestrPaintingsBelowInf).2 q r Hq Hr ε _ (l θ)).
   now apply ((mkFrame (RestrOfReflCohs2 deps).(1)).(UIP)).
 Defined.
@@ -1188,18 +1191,20 @@ Definition mkCohReflRestrLayerBelowSup {p k}
       (mkDepsReflCohsInf deps).(1).(_cohReflRestrFramesBelowInf)
       q (Hq ↕ ↑ Hr) d l).
 Proof.
-  apply functional_extensionality_dep.
-  intros θ.
-  eapply (rew_layer33
+  apply (layer_rew_eq
     (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
     (rf0 := fun a x =>
-      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O a x)
+      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O a x));
+    intros θ.
+  eapply (rew_cohLayer33
+    (P := fun b => (mkDepsRestr (CohsOfReflCohs2 deps).(1)).(_paintings).2 b)
+    (rf0 := fun x =>
+      mkRestrFrame (depsCohs := (CohsOfReflCohs2 deps).(1)) 0 leR_O θ x)
     (F := fun m c =>
       (ReflCohsInfOfReflCohs2 deps).(_reflPaintingsBelow).2 q (Hq ↕ Hr) m c)
     (G := fun m c =>
       (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)).(_restrPaintings).2
         r.+1 (⇑ Hr) ε m c)).
-  now trivial.
   now exact (deps.(_cohReflRestrPaintingsBelowSup).2 q r Hq Hr ε _ (l θ)).
   now apply ((mkFrame (RestrOfReflCohs2 deps).(1)).(UIP)).
 Defined.
@@ -1249,16 +1254,19 @@ Definition mkCohReflRestrLayerAboveSup {p k}
       (mkReflPaintingsAbove deps.(1).(_depsReflCohsSup) deps.(1).(_extraDepsReflCohsSup)) _
       prevCohReflRestrFrames q Hq d (l; c)).
 Proof.
-  apply functional_extensionality_dep.
-  intros θ.
+  apply (layer_rew_eq
+    (P := fun x => mkPainting (RestrExtOfReflCohs2 deps) x)
+    (rf0 := fun a x =>
+      mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) 0 leR_O a x));
+    intros θ.
   eassert (coh_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     now exact ((CohsOfReflCohs2 deps).(_cohs).2 r Hr 0 leR_O ε θ d).
     now exact ((Cohs2OfReflCohs2 deps).(_cohPaintings).2 r Hr 0 leR_O ε θ d (l; c)). }
-  eapply (rew_layer33
+  eapply (rew_cohLayer33
     (P := fun x => mkPainting (RestrExtOfReflCohs2 deps) x)
-    (rf0 := fun a x =>
-      mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) 0 leR_O a x)
+    (rf0 := fun x =>
+      mkRestrFrame (depsCohs := CohsOfReflCohs2 deps) 0 leR_O θ x)
     (S2 := fun _ => unit)
     (rfF := fun x =>
       (ReflCohsInfOfReflCohs2 deps).(_reflFramesAbove).2 q Hq x.1 x.2)
@@ -1269,7 +1277,6 @@ Proof.
         r Hr ε m c')
     (C2 := coh_pair_eq)
     (aL := tt)).
-  now trivial.
   now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q r Hq Hr ε _ _).
   now apply ((mkFrame (RestrOfReflCohsSup deps.(_depsReflCohsSup))).(UIP)).
 Defined.
@@ -1289,17 +1296,22 @@ Definition mkCohReflRestrLayerAboveSup0 {p k}
     (mkReflFrameAbove0 (mkDepsReflCohsInf deps).(1) d c).1
     (mkReflFrameAbove0 (mkDepsReflCohsInf deps).(1) d c).2.
 Proof.
-  apply functional_extensionality_dep; intro θ.
-  eapply (rew_layer22
+  apply (layer_rew_eq
     (P := fun b =>
       (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_paintings).2 b)
     (rf0 := fun a x =>
       (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
-        0 leR_O a x)
+        0 leR_O a x));
+    intro θ.
+  eapply (rew_cohLayer22
+    (P := fun b =>
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_paintings).2 b)
+    (rf0 := fun x =>
+      (CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_restrFrames).2
+        0 leR_O θ x)
     (G := fun m c =>
       (mkDepsReflCohsInf deps).(_depsCohs2).(_depsCohs).(_restrPaintings).2
         r Hr ε m c)).
-  now trivial.
   now trivial.
   now apply
     ((CohsOfReflCohsInf (mkDepsReflCohsInf deps)).(_deps).(_frames).2.(UIP)).
@@ -1389,20 +1401,25 @@ Definition mkCohReflBelowBelowLayer {p k}
       (ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf)
       q (Hq ↕ Hr) d l).
 Proof.
-  apply functional_extensionality_dep.
-  intro θ.
-  eapply (rew_layer33
+  apply (layer_rew_eq
     (P := fun b =>
       (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
         .(1).(_paintings).2 b)
     (rf0 := fun a x =>
       (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
-        .(1).(_restrFrames).2 0 leR_O a x)
+        .(1).(_restrFrames).2 0 leR_O a x));
+    intro θ.
+  eapply (rew_cohLayer33
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
+        .(1).(_paintings).2 b)
+    (rf0 := fun x =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
+        .(1).(_restrFrames).2 0 leR_O θ x)
     (F := fun m c =>
       (mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow).2 q (Hq ↕ ↑ Hr) m c)
     (G := fun m c =>
       (mkDepsReflCohsInf deps).(1).(_reflPaintingsBelow).2 r.+1 (⇑ Hr) m c)).
-  now trivial.
   now exact (deps.(_cohReflBelowBelowPaintings).2 q r Hq Hr _ (l θ)).
   now apply
     ((mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps).(1)))
@@ -1450,8 +1467,15 @@ Definition mkCohReflAboveBelowLayer {p k}
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ Hq) (d; l) c).1
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 q.+1 (⇑ Hq) (d; l) c).2.
 Proof.
-  apply functional_extensionality_dep.
-  intro θ.
+  apply (layer_rew_eq
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsInf
+        (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_paintings).2 b)
+    (rf0 := fun a x =>
+      (mkDepsRestr (CohsOfReflCohsInf
+        (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_restrFrames).2
+        0 leR_O a x));
+    intro θ.
   eassert (coh_below_inf_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact ((ReflCohsInfOfReflCohs2 deps).(_cohReflRestrFramesBelowInf).2 r 0 Hr leR_O θ d).
@@ -1460,14 +1484,14 @@ Proof.
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 Hq leR_O θ d (l; c)).
     - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q 0 Hq leR_O θ d (l; c)). }
-  eapply (rew_layer33
+  eapply (rew_cohLayer33
     (P := fun b =>
       (mkDepsRestr (CohsOfReflCohsInf
         (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_paintings).2 b)
-    (rf0 := fun a x =>
+    (rf0 := fun x =>
       (mkDepsRestr (CohsOfReflCohsInf
         (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf))).(_restrFrames).2
-        0 leR_O a x)
+        0 leR_O θ x)
     (S2 := fun _ => unit)
     (rfF := fun x =>
       (mkDepsReflCohsSup deps).(1).(_depsReflCohsInf).(_reflFramesAbove).2
@@ -1485,7 +1509,6 @@ Proof.
     (D2 := coh_above_sup_pair_eq)
     (aL := tt)
     (aR := tt)).
-  now trivial.
   now exact (deps.(_cohReflAboveBelowPaintings).2 q r Hq Hr _ _).
   now apply
     ((mkDepsRestr (CohsOfReflCohsInf
@@ -1509,17 +1532,23 @@ Definition mkCohReflAboveBelowLayer0 {p k}
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).1
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 0 leR_O d c).2.
 Proof.
-  apply functional_extensionality_dep; intro θ.
-  eapply (rew_layer22
+  apply (layer_rew_eq
     (P := fun b =>
       (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
         .(_paintings).2 b)
     (rf0 := fun a x =>
       (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
-        .(_restrFrames).2 0 leR_O a x)
+        .(_restrFrames).2 0 leR_O a x));
+    intro θ.
+  eapply (rew_cohLayer22
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
+        .(_paintings).2 b)
+    (rf0 := fun x =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
+        .(_restrFrames).2 0 leR_O θ x)
     (G := fun m c =>
       (mkDepsReflCohsInf deps).(_reflPaintingsBelow).2 r Hr m c)).
-  now trivial.
   now trivial.
   now apply
     ((mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps).(1)))
@@ -1586,8 +1615,14 @@ Definition mkCohReflAboveAboveLayer {p k}
     (((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r.+1 (⇑ Hr) (d; l) c).2;
      (mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r.+1 (⇑ Hr) (d; l) c).
 Proof.
-  apply functional_extensionality_dep.
-  intro θ.
+  apply (layer_rew_eq
+    (P := fun x =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
+        .(_paintings).2 x)
+    (rf0 := fun a x =>
+      (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
+        .(_restrFrames).2 0 leR_O a x));
+    intro θ.
   eassert (coh_above_sup_r_pair_eq: (_;_) = (_;_)).
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 r 0 Hr leR_O θ d (l; c)).
@@ -1596,13 +1631,13 @@ Proof.
   { unshelve eapply eq_existT_curried.
     - now exact (deps.(_depsReflCohsSup).(_cohReflRestrFramesAboveSup).2 q 0 (Hq ↕ Hr) leR_O θ d (l; c)).
     - now exact (deps.(_cohReflRestrPaintingsAboveSup).2 q 0 (Hq ↕ Hr) leR_O θ d (l; c)). }
-  eapply (rew_layer33
+  eapply (rew_cohLayer33
     (P := fun x =>
       (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
         .(_paintings).2 x)
-    (rf0 := fun a x =>
+    (rf0 := fun x =>
       (mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
-        .(_restrFrames).2 0 leR_O a x)
+        .(_restrFrames).2 0 leR_O θ x)
     (S2 := fun _ => unit)
     (rfF := fun x =>
       (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r.+1 (⇑ Hr) x.1 x.2)
@@ -1617,7 +1652,6 @@ Proof.
     (D2 := coh_above_sup_r_pair_eq)
     (aL := tt)
     (aR := tt)).
-  now trivial.
   now exact (deps.(_cohReflAboveAbovePaintings).2 q r Hq Hr _ _).
   now apply
     ((mkDepsRestr (CohsOfReflCohsInf (mkDepsReflCohsInf deps)))
@@ -1641,19 +1675,26 @@ Definition mkCohReflAboveAboveLayer0 {p k}
     ((mkDepsReflCohsInf deps).(_reflFramesAbove).2 r Hr d c)
     ((mkDepsReflCohsSup deps).(_reflPaintingsAbove).2 r Hr d c).
 Proof.
-  apply functional_extensionality_dep; intro θ.
-  eassert (coh_id_pair_eq: (_;_) = (_;_)).
-  { unshelve eapply eq_existT_curried.
-    - now exact (mkIdRestrReflFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
-    - now exact (mkIdRestrReflPaintingBelow deps.(_depsReflCohsSup)
-        deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
-  eapply (rew_layer31
+  apply (layer_rew_eq
     (P := fun b =>
       (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))
         .(_paintings).2 b)
     (rf0 := fun a x =>
       (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))
-        .(_restrFrames).2 0 leR_O a x)
+        .(_restrFrames).2 0 leR_O a x));
+    intro θ.
+  eassert (coh_id_pair_eq: (_;_) = (_;_)).
+  { unshelve eapply eq_existT_curried.
+    - now exact (mkIdRestrReflFrameBelow (ReflCohsInfOfReflCohs2 deps) 0 leR_O θ d).
+    - now exact (mkIdRestrReflPaintingBelow deps.(_depsReflCohsSup)
+        deps.(_extraDepsReflCohsSup) 0 leR_O θ d c). }
+  eapply (rew_cohLayer31
+    (P := fun b =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))
+        .(_paintings).2 b)
+    (rf0 := fun x =>
+      (mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))
+        .(_restrFrames).2 0 leR_O θ x)
     (S2 := fun _ => unit)
     (rfF := fun x =>
       (mkReflFramesAbove deps.(_depsReflCohsSup)).2 r Hr x.1 x.2)
@@ -1661,7 +1702,6 @@ Proof.
       deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) r Hr x.1 x.2)
     (C2 := coh_id_pair_eq)
     (aL := tt)).
-  now trivial.
   now trivial.
   now apply
     ((mkDepsRestr (CohsOfReflCohsSup (mkDepsReflCohsSup deps)))

--- a/theories/νSet/νSet.v
+++ b/theories/νSet/νSet.v
@@ -1,5 +1,3 @@
-From Stdlib Require Import Logic.FunctionalExtensionality.
-
 Set Warnings "-notation-overridden".
 From Bonak Require Import SigT RewLemmas HSet Notation LeSProp.
 
@@ -457,13 +455,15 @@ Definition mkCohLayer `{extraDepsCohs: DepsCohsExtension p.+1 k depsCohs}
     mkRestrLayer depsCohs.(_restrPaintings) depsCohs.(_cohs) r (Hr ↕ Hq) ω _
       (mkRestrLayer (mkRestrPaintings extraDepsCohs).1 _ q.+1 (⇑ Hq) ε d l).
 Proof.
-  apply functional_extensionality_dep; intros 𝛉.
-  eapply (rew_layer33
+  apply (layer_rew_eq
     (P := fun x => depsCohs.(_deps).(_paintings).2 x)
-    (rf0 := fun a x => depsCohs.(_deps).(_restrFrames).2 0 leR_O a x)
+    (rf0 := fun a x => depsCohs.(_deps).(_restrFrames).2 0 leR_O a x));
+    intros 𝛉.
+  eapply (rew_cohLayer33
+    (P := fun x => depsCohs.(_deps).(_paintings).2 x)
+    (rf0 := fun x => depsCohs.(_deps).(_restrFrames).2 0 leR_O 𝛉 x)
     (F := fun m c => depsCohs.(_restrPaintings).2 q Hq ε m c)
     (G := fun m c => depsCohs.(_restrPaintings).2 r (Hr ↕ Hq) ω m c)).
-  now trivial.
   now exact (cohPaintings.2 q Hq r Hr ε ω _ (l 𝛉)).
   now exact (mkCoh2Frame extraDepsCohs prevCohFrames q Hq r Hr ε ω d 𝛉).
 Defined.


### PR DESCRIPTION
# Unify the fused layer coherence lemmas (`rew_cohLayer*`)

### About

After #22 and #23 we had two independent formulations of the same fused layer-coherence lemma: `rew_layer33` in `RewLemmas` (used by `νSet` and `νDgnSet`, stated for arity-indexed layers) and `rew_cohLayer` in `SSGpdLemmas` (used by `SSGpd`, stated on a single component). This PR reconciles them into one family `rew_cohLayer*` in `RewLemmas`, shared by all three files.

### The pointwise step is factored out

The old `rew_layer*` shape intrinsically assumed that layers are functions from the arity: the lemmas took the whole layer `L: forall a, P (rf0 a d1)` together with a designated component `𝛉`, plus a first premise (`L 𝛉 = ...`) discharged by `now trivial` at every call site, and absorbed the funext head of the proof.

The new `rew_cohLayer*` lemmas are stated on a single painting and know nothing about the layer former — this is exactly the statement `SSGpdLemmas` already had. They apply regardless of how layers are represented:

- layers as functions from the arity, as in `νSet` and `νDgnSet` here: the pointwise step is a separate bridge lemma `layer_rew_eq` — and every layer coherence proof closes in exactly two steps: an application of `layer_rew_eq`, then one of `rew_cohLayer*`;
- a layer as a single painting, as in `SSGpd` here: the proof is a single `rew_cohLayer33` application, with no funext involved;
- layers as vectors, as in `νSet` and `νDgnSet` on the `no-funext` branch, with a vector counterpart of the pointwise bridge.

In every case `rew_cohLayer*` takes the same two premises: the painting coherence and the 2-dimensional frame coherence (`UIP` for h-sets).

### Square-shaped lemmas as instances of the hexagon

`rew_cohLayer33`, the hexagon-shaped coherence (3 arrows against 3), is now proved first, and the square-shaped `rew_cohLayer13`, `rew_cohLayer22`, `rew_cohLayer31` are re-derived from it, by setting 2 of the 6 arrows trivial.
