### PR TITLE
Chain: a device for making monoidal path laws definitional

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -3,6 +3,7 @@ theories/νSet/SigT.v
 theories/νSet/Notation.v
 theories/νSet/LeSProp.v
 theories/νSet/HSet.v
+theories/νSet/Chain.v
 theories/νSet/RewLemmas.v
 theories/νSet/Layer.v
 theories/νSet/νSet.v

--- a/theories/νSet/Chain.v
+++ b/theories/νSet/Chain.v
@@ -1,0 +1,60 @@
+(** Chains: Moore-style composites of equalities
+
+    A [Chain] is a list of composable equality steps — the discrete analogue of
+    a Moore path. Concatenation [capp] recurses on its first argument, so
+    [capp cnil C] is [C] *definitionally* for every [C], and on canonical
+    cons-spines associativity and the right unit law hold definitionally too.
+    For [•] all three laws are propositional only: [•] reduces on its second
+    argument, so [p • eq_refl] is [p] while [eq_refl • q] is stuck, and neither
+    bracketing of [p • q • e] reduces.
+
+    [interp], written [⟦C⟧], collapses a chain to the single equality it
+    denotes; [interp_capp] and [interp_cmap] are the bridge back to eq-land,
+    where the chain structure is forgotten. *)
+
+Set Warnings "-notation-overridden".
+From Bonak Require Import Notation.
+
+Inductive Chain {X: Type}: X -> X -> Type :=
+| cnil {a}: Chain a a
+| ccons {a b c}: a = b -> Chain b c -> Chain a c.
+
+Notation "[: x ; .. ; y :]" := (ccons x .. (ccons y cnil) ..)
+  (at level 0).
+
+Fixpoint capp {X: Type} {a b c: X} (C: Chain a b): Chain b c -> Chain a c :=
+  match C with
+  | cnil => fun D => D
+  | ccons e C => fun D => ccons e (capp C D)
+  end.
+
+Fixpoint cmap {X Y: Type} (f: X -> Y) {a b: X} (C: Chain a b):
+  Chain (f a) (f b) :=
+  match C with
+  | cnil => cnil
+  | ccons e C => ccons (f_equal f e) (cmap f C)
+  end.
+
+Fixpoint interp {X: Type} {a b: X} (C: Chain a b): a = b :=
+  match C with
+  | cnil => eq_refl
+  | ccons e C => e • interp C
+  end.
+
+Notation "⟦ C ⟧" := (interp C) (at level 0, format "⟦ C ⟧").
+
+Lemma interp_capp {X: Type} {a b c: X} (C: Chain a b) (D: Chain b c):
+  ⟦capp C D⟧ = ⟦C⟧ • ⟦D⟧.
+Proof.
+  induction C as [|? ? ? e C IH]; cbn.
+  - now destruct (interp D).
+  - rewrite IH. now apply eq_trans_assoc.
+Defined.
+
+Lemma interp_cmap {X Y: Type} (f: X -> Y) {a b: X} (C: Chain a b):
+  ⟦cmap f C⟧ = f_equal f ⟦C⟧.
+Proof.
+  induction C as [|? ? ? e C IH]; cbn.
+  - reflexivity.
+  - rewrite IH. now destruct (interp C).
+Defined.

--- a/theories/νSet/RewLemmas.v
+++ b/theories/νSet/RewLemmas.v
@@ -3,7 +3,7 @@
 Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
-From Bonak Require Import HSet Notation.
+From Bonak Require Import HSet Notation Chain.
 
 Lemma rew_permute_ll_hset: forall (A: Type) (P Q: A -> HSet) (x y: A)
   (H: forall z: A, P z = Q z) (H': x = y) (a: P x),
@@ -44,12 +44,49 @@ Defined.
 
 (** Fused transport-chain lemmas for layer coherence proofs
 
-    [rew_cohLayer<NM>] closes a layer coherence goal in one step, once a bridge
-    (Layer.v) has taken the pointwise step: it equates two chains of transports,
-    N on the left-hand side and M on the right, whose starting elements are
-    identified by the painting coherence. A call site supplies only the two
-    premises: the painting coherence and the 2-dimensional frame coherence
-    ([UIP] in HSet development). *)
+    The [rew_cohLayer] lemma closes a layer coherence goal in one step, once a
+    bridge (Layer.v) has taken the pointwise step: it equates two chains of
+    transports, whose starting elements are identified by the painting
+    coherence. A call site supplies only the two premises: the painting
+    coherence and the 2-dimensional frame coherence ([UIP] in HSet development).
+
+    The [rew_cohLayer<NM>] lemmas are a family of specialized versions for
+    different coherence shapes, in which every side is a single arrow or
+    trivial. N and M count the arrows on each side of the frame coherence. *)
+
+Lemma rew_cohLayer {T1 T2 T3 X: Type} {P: X -> Type}
+  {S2: T2 -> Type} {S3: T3 -> Type}
+  {rf0: T1 -> X} {rfF: T2 -> X} {rfG: T3 -> X}
+  {F: forall m, S2 m -> P (rfF m)}
+  {G: forall n, S3 n -> P (rfG n)}
+  {d1 d2: T1} {E1: d1 = d2}
+  {m1 m2: T2} {C2C: Chain m1 m2}
+  {n1 n2: T3} {D2C: Chain n1 n2}
+  {C1C: Chain (rfF m2) (rf0 d1)}
+  {D1: rfG n2 = rf0 d2}
+  {KC: Chain (rfF m1) (rfG n1)}
+  {aL: S2 m1} {aR: S3 n1}:
+  (* painting coherence: *)
+  rew [P] ⟦KC⟧ in F m1 aL = G n1 aR ->
+  (* 2-dimensional frame coherence, [UIP] for HSets: *)
+  ⟦capp (cmap rfF C2C) (capp C1C [: f_equal rf0 E1 :])⟧
+  = ⟦capp KC (capp (cmap rfG D2C) [: D1 :])⟧ ->
+  rew [fun d => P (rf0 d)] E1 in rew [P] ⟦C1C⟧ in F m2 (rew [S2] ⟦C2C⟧ in aL)
+  = rew [P] D1 in G n2 (rew [S3] ⟦D2C⟧ in aR).
+Proof.
+  intros HC Hpath.
+  rewrite 4 interp_capp, 2 interp_cmap in Hpath.
+  revert HC Hpath.
+  generalize ⟦KC⟧ as K; generalize ⟦C1C⟧ as C1.
+  generalize ⟦D2C⟧ as D2; generalize ⟦C2C⟧ as C2.
+  intros C2 D2 C1 K HC Hpath.
+  rewrite <- (map_subst F C2 aL), <- (map_subst G D2 aR), <- HC.
+  destruct E1, C2, D2.
+  cbn in Hpath |- *.
+  rewrite rew_compose.
+  rewrite 2 eq_trans_refl_l in Hpath.
+  now rewrite Hpath.
+Defined.
 
 Lemma rew_cohLayer33 {T1 T2 T3 X: Type} {P: X -> Type}
   {S2: T2 -> Type} {S3: T3 -> Type}
@@ -63,22 +100,17 @@ Lemma rew_cohLayer33 {T1 T2 T3 X: Type} {P: X -> Type}
   {D1: rfG n2 = rf0 d2}
   {K: rfF m1 = rfG n1}
   {aL: S2 m1} {aR: S3 n1}:
-  rew [P] K in F m1 aL = G n1 aR -> (* painting coherence *)
+  (* painting coherence: *)
+  rew [P] K in F m1 aL = G n1 aR ->
+  (* 2-dimensional frame coherence, [UIP] for HSets: *)
   f_equal rfF C2 • (C1 • f_equal rf0 E1) = K • (f_equal rfG D2 • D1) ->
-  (* 2-dimensional frame coherence, UIP for HSets *)
   rew [fun d => P (rf0 d)] E1 in rew [P] C1 in F m2 (rew [S2] C2 in aL)
   = rew [P] D1 in G n2 (rew [S3] D2 in aR).
 Proof.
-  intros HC Hpath.
-  rewrite <- (map_subst F C2 aL), <- (map_subst G D2 aR), <- HC.
-  destruct E1, C2, D2. cbn in Hpath |- *.
-  rewrite rew_compose.
-  rewrite 2 eq_trans_refl_l in Hpath.
-  now rewrite Hpath.
+  now exact (rew_cohLayer (P := P) (S2 := S2) (S3 := S3) (rf0 := rf0)
+    (rfF := rfF) (rfG := rfG) (F := F) (G := G)
+    (C2C := [: C2 :]) (D2C := [: D2 :]) (KC := [: K :]) (C1C := [: C1 :])).
 Defined.
-
-(** The [rew_cohLayer*] lemmas for square-shaped coherences can be considered an
-    instance of the hexagon-shaped one, with 2 arrows trivial. *)
 
 Lemma rew_cohLayer13 {T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
   {rf0: T1 -> X} {rfG: T3 -> X}
@@ -93,12 +125,10 @@ Lemma rew_cohLayer13 {T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
   rew [fun d => P (rf0 d)] E1 in aL
   = rew [P] D1 in G n2 (rew [S3] D2 in aR).
 Proof.
-  intros HC Hpath.
-  eapply (rew_cohLayer33 (P := P) (S2 := P) (rf0 := rf0)
+  now exact (rew_cohLayer (P := P) (S2 := P) (rf0 := rf0)
     (rfF := fun x => x) (F := fun _ a => a)
-    (C2 := eq_refl) (C1 := eq_refl) (K := K) (aL := aL)).
-  now exact HC.
-  now rewrite 2 eq_trans_refl_l.
+    (C2C := cnil) (D2C := [: D2 :]) (KC := [: K :]) (C1C := cnil)
+    (aL := aL)).
 Defined.
 
 Lemma rew_cohLayer22 {T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
@@ -114,12 +144,10 @@ Lemma rew_cohLayer22 {T1 T3 X: Type} {P: X -> Type} {S3: T3 -> Type}
   rew [fun d => P (rf0 d)] E1 in rew [P] E0 in aL
   = rew [P] D1 in G n2 (rew [S3] D2 in aR).
 Proof.
-  intros HC Hpath.
-  eapply (rew_cohLayer33 (P := P) (S2 := P) (rf0 := rf0)
+  now exact (rew_cohLayer (P := P) (S2 := P) (rf0 := rf0)
     (rfF := fun x => x) (F := fun _ a => a)
-    (C2 := eq_refl) (C1 := E0) (K := eq_refl) (aL := aL)).
-  now exact HC.
-  now rewrite 2 eq_trans_refl_l.
+    (C2C := cnil) (D2C := [: D2 :]) (KC := cnil) (C1C := [: E0 :])
+    (aL := aL)).
 Defined.
 
 Lemma rew_cohLayer31 {T1 T2 X: Type} {P: X -> Type} {S2: T2 -> Type}
@@ -135,10 +163,8 @@ Lemma rew_cohLayer31 {T1 T2 X: Type} {P: X -> Type} {S2: T2 -> Type}
   rew [fun d => P (rf0 d)] E1 in rew [P] C1 in F m2 (rew [S2] C2 in aL)
   = rew [P] D1 in aR.
 Proof.
-  intros HC Hpath.
-  eapply (rew_cohLayer33 (P := P) (S3 := P) (rf0 := rf0)
+  now exact (rew_cohLayer (P := P) (S3 := P) (rf0 := rf0)
     (rfF := rfF) (rfG := fun x => x) (G := fun _ a => a)
-    (m1 := m1) (D2 := eq_refl) (D1 := D1) (K := eq_refl) (aR := aR)).
-  now exact HC.
-  now rewrite 2 eq_trans_refl_l.
+    (m1 := m1) (C2C := [: C2 :]) (D2C := cnil) (KC := cnil) (C1C := [: C1 :])
+    (D1 := D1) (aR := aR)).
 Defined.


### PR DESCRIPTION
## Chain: a device for making monoidal path laws definitional

### What it is about

A `Chain a b` is a list of composable equality steps. Because concatenation is list concatenation, the monoid laws — associativity and the units — hold definitionally on the concrete chains that appear in proofs, where for `•` associativity and the left unit are propositional and have to be proved and rewritten with. `theories/νSet/Chain.v` defines chains, their concatenation and functorial map, and the interpretation `⟦_⟧` that collapses a chain back into an ordinary equality.

### Where the idea comes from

The notion is that of Moore paths ([nLab](https://ncatlab.org/nlab/show/Moore+path+category)): paths carrying their own length, so that they compose into a strict category rather than one associative and unital only up to homotopy. `Chain.v` is their discrete version.

The inspiration to reach for it here came from Astra Kolomatskaia, *You Wouldn't Permutahedron* ([arXiv:2407.10891](https://arxiv.org/abs/2407.10891)). The paper is about permutahedral coherences of semi-simplicial types, it uses cubical Moore paths to keep the higher coherence formulas free of reassociation.

### What it buys

One `rew_cohLayer` lemma for all coherence shapes that appear in `νSet` and `νDgnSet` developments. Where we had four fused lemmas, one per shape, there is now a single lemma. The shape-specific lemmas remain as one-line `exact` instances.

### The general principle

The four `rew_cohLayer<NM>` lemmas have the same idea behind them: they are essentially one fact, obscured by the propositional algebra of `•`. Whenever a family of lemmas differs only by such algebra, a general approach to create a generic lemma is to define a grammar for the terms involved and give it an interpreter — the laws that were propositional in the target become definitional in the grammar, and the family of lemmas collapses to a single statement. Chains are that treatment for path composition, but the same move can be applied to other things, such as expressions built out of `LayerSig` operations (see PR #32).
