### PR TITLE
Equiv: univalence-based approach to νSet equivalence relation

### DIFF
--- a/theories/νSet/Equiv/Correspondence.v
+++ b/theories/νSet/Equiv/Correspondence.v
@@ -6,12 +6,12 @@
 
     This file is a thin wrapper on top of the two round trips:
     - [gf: PresheafEquiv (g (f psh)) psh] from [PresheafRoundtrip.v]
-    - [fg: νSetFromEquiv trTower0 (f (g X)) X] from [νSetRoundtrip.v]
+    - [fg: νSetFromEquiv rel0 (f (g X)) X] from [νSetRoundtrip.v]
     It combines them into an actual [Equiv] between the type of presheaves and
     the type of νSets. The axioms enter where each side's notion of sameness is
     turned into an equality — [presheafEquivEq] from [PresheafEquiv.v] on the
     fibred side (a theorem, from univalence and funext), [νSetFromEquivEq] below
-    on the indexed side (an axiom, stream extensionality). *)
+    on the indexed side (an axiom, coinductive extensionality). *)
 
 Set Warnings "-notation-overridden".
 From Bonak Require Import HSet Notation νSet.Layer Univalence
@@ -30,10 +30,12 @@ Module Export PresheafRoundtrip := PresheafRoundtrip.PresheafRoundtrip A.
 
 (** Extensionality for the coinductive ν-set tower
 
-    [νSetFromEquiv trTower0 SA SB] relates [SA] and [SB] level by level. At
-    each level it contains equivalences between their filler fibres, proofs
-    that these equivalences commute with the stored restriction paintings,
-    and a corresponding relation between the tails.
+    [νSetFromEquiv rel0 SA SB] relates [SA] and [SB] level by level. At each
+    level it contains an equivalence between their filler fibres over the
+    equality of the prefixes reached so far, and a corresponding relation
+    between the tails over the extended prefix equality. All restriction and
+    coherence data at a level is computed from the prefix, so transport along
+    that equality supplies its compatibility.
 
     The round trip [fg X] constructs this relation between [f (g X)] and [X].
     The axiom below converts it into equality of the two coinductive towers.
@@ -47,7 +49,7 @@ Module Export PresheafRoundtrip := PresheafRoundtrip.PresheafRoundtrip A.
     axiom. *)
 
 Axiom νSetFromEquivEq: forall SA SB: νSets,
-  νSetFromEquiv trTower0 SA SB -> SA = SB.
+  νSetFromEquiv rel0 SA SB -> SA = SB.
 
 Definition presheafνSetsEquiv: Equiv Presheaf νSets :=
   qinvEquiv f g

--- a/theories/νSet/Equiv/νSetEquiv.v
+++ b/theories/νSet/Equiv/νSetEquiv.v
@@ -1,24 +1,27 @@
-(** The bisimulation theory of νSets: the staged translation data and the
-    coinductive levelwise equivalence [νSetFromEquiv].
+(** The bisimulation theory of νSets: prefix equalities and the coinductive
+    levelwise equivalence [νSetFromEquiv].
 
-    Two towers are bisimilar when their stored frames and paintings
-    correspond level by level. That correspondence is carried as data:
-    equivalences between the two towers' frames and paintings, from which a
-    third instantiation of the block pattern rebuilds the equivalence one
-    level up. The frame translations are equivalences *by construction* —
-    each stage is a [sigTEquiv]/[layerEquiv] composite of the stage below
-    and the stored painting equivalences. The inverse functions and their
-    homotopies are supplied by those equivalences.
+    Two towers are bisimilar when their finite prefixes correspond level by
+    level and their filler families correspond over that identification. The
+    levelwise correspondence is converted into an *equality* of prefixes as
+    soon as it is formed: univalence and functional extensionality turn the
+    filler equivalences into an equality of the sigma-type prefixes
+    ([prefixEq]). All restriction and coherence data of the construction is
+    computed from the prefix, so transport along that equality supplies its
+    compatibility.
 
-    Sides: [A] is the target of the translations, [B] the source; frame
-    translations go [B -> A] ([eqvFun] of the stored equivalences), and
-    so do the painting equivalences, fiberwise over them.
- *)
+    [prefixEqRewTotal] computes transport along a prefix equality on a
+    total-space element: the frame component transports along the lower
+    prefix equality, and the filler component maps through the inverse of
+    the stored equivalence. This is the one place where the computation
+    rules of [ua] enter. *)
 
 Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
-From Bonak Require Import SigT RewLemmas HSet LeSProp Notation νSet.Layer νSet.
+From Stdlib Require Import Logic.FunctionalExtensionality.
+From Bonak Require Import SigT RewLemmas HSet LeSProp Notation Univalence
+  νSet.Layer νSet.
 From Bonak.νSet.Lib Require Import Equiv.
 
 Set Primitive Projections.
@@ -30,628 +33,208 @@ Import A.
 
 Module Export νSet := νSet.νSet A.
 
-(** Lifting equivalences through the layer former
-
-    The layer counterpart of [sigTEquiv]: a layer is a weak product, so
-    pointwise equivalences of its components lift to an equivalence of
-    layers, with [ext] from the layer interface proving both inverse laws. *)
-
-Definition layerEquiv {B C: arity -> HSet}
-  (e: forall ε, Equiv (B ε) (C ε)): Equiv (Layer B) (Layer C).
-Proof.
-  unshelve refine (qinvEquiv (lmap (fun ε => (e ε).(eqvFun)))
-    (lmap (fun ε => invEq (e ε))) _ _).
-  - intro l. apply ext; intro ε. rewrite 2 nth_lmap. now apply retEq.
-  - intro l. apply ext; intro ε. rewrite 2 nth_lmap. now apply secEq.
-Defined.
-
-Lemma layerEquivNth {B C: arity -> HSet} (e: forall ε, Equiv (B ε) (C ε))
-  (l: Layer B) (ε: arity): nth (layerEquiv e l) ε = e ε (nth l ε).
-Proof.
-  now exact (nth_lmap (fun ε => (e ε).(eqvFun)) l ε).
-Defined.
-
-(** Equivalence lists over two towers of dependencies *)
-
-Fixpoint mkFrameEqvTypes {p k}:
-  mkFrameTypes p k -> mkFrameTypes p k -> Type :=
-  match p with
-  | 0 => fun _ _ => unit
-  | S p => fun framesA framesB =>
-      { _: mkFrameEqvTypes framesA.1 framesB.1 &T
-        Equiv framesB.2 framesA.2 }
-  end.
-
-Fixpoint mkPaintingEqvTypes {p k}:
-  forall {framesA framesB: mkFrameTypes p k},
-  mkFrameEqvTypes framesA framesB ->
-  mkPaintingTypes p k framesA -> mkPaintingTypes p k framesB -> Type :=
-  match p with
-  | 0 => fun _ _ _ _ _ => unit
-  | S p => fun framesA framesB eqvs paintingsA paintingsB =>
-      { _: mkPaintingEqvTypes eqvs.1 paintingsA.1 paintingsB.1 &T
-        forall d: framesB.2,
-          Equiv (paintingsB.2 d) (paintingsA.2 (eqvs.2 d)) }
-  end.
-
-(** The translation block
-
-    The types of the translation coherences at stages <= p (the frame
-    equivalences commute with the two towers' restrictions), together
-    with the next-level frame equivalences they determine. The two
-    definitions are mutually dependent, so [mkTrRestrTypesAndFrames]
-    constructs them together. *)
-
-Class TrRestrBlock {p k} {framesA framesB: mkFrameTypes p k}
-  (eqvs: mkFrameEqvTypes framesA framesB)
-  (blockA blockB: RestrFrameTypeBlock p k) := {
-  TrRestrTypesDef: blockA.(RestrFrameTypesDef) ->
-    blockB.(RestrFrameTypesDef) -> Type;
-  FrameEqvDef: forall {RA RB} (Q: TrRestrTypesDef RA RB),
-    mkFrameEqvTypes (blockA.(FrameDef) RA) (blockB.(FrameDef) RB);
-}.
-
-Definition mkTrRestrTypesStep {p k} {framesA framesB: mkFrameTypes p.+1 k}
-  (eqvs: mkFrameEqvTypes framesA framesB)
-  {prevA prevB: RestrFrameTypeBlock p k.+1}
-  (prevTr: TrRestrBlock eqvs.1 prevA prevB)
-  (RA: mkRestrFrameTypesStep framesA prevA)
-  (RB: mkRestrFrameTypesStep framesB prevB): Type :=
-  { Q: prevTr.(TrRestrTypesDef) RA.1 RB.1 &T
-    forall q (Hq: q <= k) (ε: arity) (d: (prevB.(FrameDef) RB.1).2),
-      eqvs.2 (RB.2 q Hq ε d) =
-      RA.2 q Hq ε ((prevTr.(FrameEqvDef) Q).2 d) }.
-
-(** The layer equivalence: componentwise, the stored painting equivalence
-    followed by transport along the diagonal translation coherence *)
-
-Definition mkTrLayerEquiv {p k} {framesA framesB: mkFrameTypes p.+1 k}
-  {eqvs: mkFrameEqvTypes framesA framesB}
-  {paintingsA: mkPaintingTypes p.+1 k framesA}
-  {paintingsB: mkPaintingTypes p.+1 k framesB}
-  (pEqvs: mkPaintingEqvTypes eqvs paintingsA paintingsB)
-  {prevA prevB: RestrFrameTypeBlock p k.+1}
-  {prevTr: TrRestrBlock eqvs.1 prevA prevB}
-  {RA: mkRestrFrameTypesStep framesA prevA}
-  {RB: mkRestrFrameTypesStep framesB prevB}
-  (Q: mkTrRestrTypesStep eqvs prevTr RA RB)
-  (d: (prevB.(FrameDef) RB.1).2):
-  Equiv (mkLayer (paintings := paintingsB) RB d)
-    (mkLayer (paintings := paintingsA) RA
-      ((prevTr.(FrameEqvDef) Q.1).2 d)) :=
-  layerEquiv (fun ε => compEquiv
-    (pEqvs.2 (RB.2 0 leR_O ε d))
-    (rewEquiv (fun x => paintingsA.2 x) (Q.2 0 leR_O ε d))).
-
-Fixpoint mkTrRestrTypesAndFrames {p k}:
-  forall {framesA framesB: mkFrameTypes p k}
-    (eqvs: mkFrameEqvTypes framesA framesB)
-    {paintingsA: mkPaintingTypes p k framesA}
-    {paintingsB: mkPaintingTypes p k framesB}
-    (pEqvs: mkPaintingEqvTypes eqvs paintingsA paintingsB),
-  TrRestrBlock eqvs (mkRestrFrameTypesAndFrames paintingsA)
-    (mkRestrFrameTypesAndFrames paintingsB) :=
-  match p return forall (framesA framesB: mkFrameTypes p k)
-    (eqvs: mkFrameEqvTypes framesA framesB)
-    (paintingsA: mkPaintingTypes p k framesA)
-    (paintingsB: mkPaintingTypes p k framesB)
-    (pEqvs: mkPaintingEqvTypes eqvs paintingsA paintingsB),
-    TrRestrBlock eqvs (mkRestrFrameTypesAndFrames paintingsA)
-      (mkRestrFrameTypesAndFrames paintingsB) with
-  | 0 => fun framesA framesB eqvs paintingsA paintingsB pEqvs =>
-      Build_TrRestrBlock 0 k framesA framesB eqvs
-        (mkRestrFrameTypesAndFrames paintingsA)
-        (mkRestrFrameTypesAndFrames paintingsB)
-        (fun _ _ => unit)
-        (fun _ _ _ => (tt; idEquiv))
-  | S p => fun framesA framesB eqvs paintingsA paintingsB pEqvs =>
-      let prevTr := mkTrRestrTypesAndFrames eqvs.1 pEqvs.1 in
-      Build_TrRestrBlock p.+1 k framesA framesB eqvs
-        (mkRestrFrameTypesAndFrames paintingsA)
-        (mkRestrFrameTypesAndFrames paintingsB)
-        (fun RA RB => mkTrRestrTypesStep eqvs prevTr RA RB)
-        (fun RA RB Q =>
-          (prevTr.(FrameEqvDef) Q.1;
-           sigTEquiv ((prevTr.(FrameEqvDef) Q.1).2)
-             (fun d => mkTrLayerEquiv pEqvs Q d)))
-  end.
-
-(** The translation-equipped pair of dependencies *)
-
-Class TrDepsRestr (p k: nat) := {
-  _depsA: DepsRestr p k;
-  _depsB: DepsRestr p k;
-  _frameEqvs: mkFrameEqvTypes _depsA.(_frames) _depsB.(_frames);
-  _paintingEqvs: mkPaintingEqvTypes _frameEqvs
-    _depsA.(_paintings) _depsB.(_paintings);
-  _trRestrs: (mkTrRestrTypesAndFrames _frameEqvs
-    _paintingEqvs).(TrRestrTypesDef)
-    _depsA.(_restrFrames) _depsB.(_restrFrames);
-}.
-
-#[local]
-Instance proj1TrDepsRestr {p k} (T: TrDepsRestr p.+1 k): TrDepsRestr p k.+1 :=
-{|
-  _depsA := T.(_depsA).(1);
-  _depsB := T.(_depsB).(1);
-  _frameEqvs := T.(_frameEqvs).1;
-  _paintingEqvs := T.(_paintingEqvs).1;
-  _trRestrs := T.(_trRestrs).1;
-|}.
-
-(** The computed next-level frame equivalences; their [eqvFun] is the
-    frame translation one level up. *)
-
-Definition mkFrameEqvs {p k} (T: TrDepsRestr p k):
-  mkFrameEqvTypes (mkFrames T.(_depsA)) (mkFrames T.(_depsB)) :=
-  (mkTrRestrTypesAndFrames T.(_frameEqvs)
-    T.(_paintingEqvs)).(FrameEqvDef) T.(_trRestrs).
-
-Definition mkFrameEqv {p k} (T: TrDepsRestr p k):
-  Equiv (mkFrame T.(_depsB)) (mkFrame T.(_depsA)) := (mkFrameEqvs T).2.
-
-(** The extension layer: relating the two towers' painting extensions
-
-    At the top, an equivalence between the fillers, fiberwise over the
-    frame translation. *)
-
-Inductive TrDepsExtension:
-  forall {p k} (T: TrDepsRestr p k),
-  DepsRestrExtension p k T.(_depsA) ->
-  DepsRestrExtension p k T.(_depsB) -> Type :=
-| TopTrDep {p} {T: TrDepsRestr p 0}
-    {EA: mkFrame T.(_depsA) -> HSet} {EB: mkFrame T.(_depsB) -> HSet}
-    (fillerEqvs: forall d: mkFrame T.(_depsB),
-      Equiv (EB d) (EA (mkFrameEqv T d))):
-    TrDepsExtension T (TopRestrDep EA) (TopRestrDep EB)
-| AddTrDep {p k} (T: TrDepsRestr p.+1 k)
-    {XA: DepsRestrExtension p.+1 k T.(_depsA)}
-    {XB: DepsRestrExtension p.+1 k T.(_depsB)}:
-    TrDepsExtension T XA XB ->
-    TrDepsExtension (proj1TrDepsRestr T)
-      (AddRestrDep T.(_depsA) XA) (AddRestrDep T.(_depsB) XB).
-
-Arguments TopTrDep {p T EA EB} _.
-Arguments AddTrDep {p k} T {XA XB} _.
-
-(** The painting equivalences over the frame translation, corresponding to
-    [mkPainting]: the filler equivalence at the top, a
-    [sigTEquiv]-composite of the layer equivalence and the recursive one
-    below. Each case has the constructor structure used by [mkPainting]. *)
-
-Fixpoint mkPaintingEqv {p k} {T: TrDepsRestr p k}
-  {XA: DepsRestrExtension p k T.(_depsA)}
-  {XB: DepsRestrExtension p k T.(_depsB)}
-  (TX: TrDepsExtension T XA XB):
-  forall d: mkFrame T.(_depsB),
-  Equiv (mkPainting XB d) (mkPainting XA (mkFrameEqv T d)) :=
-  match TX with
-  | TopTrDep fillerEqvs => fun d => fillerEqvs d
-  | AddTrDep T' TX' => fun d =>
-      sigTEquiv (mkTrLayerEquiv T'.(_paintingEqvs) T'.(_trRestrs) d)
-        (fun l => mkPaintingEqv TX' (d; l))
-  end.
-
-Fixpoint mkPaintingEqvsPrefix {p k}:
-  forall {T: TrDepsRestr p k}
-    {XA: DepsRestrExtension p k T.(_depsA)}
-    {XB: DepsRestrExtension p k T.(_depsB)}
-    (TX: TrDepsExtension T XA XB),
-  mkPaintingEqvTypes (mkFrameEqvs T).1
-    (mkPaintingsPrefix XA) (mkPaintingsPrefix XB) :=
-  match p with
-  | 0 => fun _ _ _ _ => tt
-  | S p => fun T XA XB TX =>
-      (mkPaintingEqvsPrefix (AddTrDep T TX);
-       mkPaintingEqv (AddTrDep T TX))
-  end.
-
-Definition mkPaintingEqvs {p k} {T: TrDepsRestr p k}
-  {XA: DepsRestrExtension p k T.(_depsA)}
-  {XB: DepsRestrExtension p k T.(_depsB)}
-  (TX: TrDepsExtension T XA XB):
-  mkPaintingEqvTypes (mkFrameEqvs T) (mkPaintings XA) (mkPaintings XB) :=
-  (mkPaintingEqvsPrefix TX; mkPaintingEqv TX).
-
-(** Translation coherence data for [DepsCohs]
-
-    The remaining translation data: the coherences stating that the
-    painting equivalences commute with the two towers' restr paintings
-    ([mkTrRestrPaintingType]), packaged with both sides' construction
-    data. From these, everything rebuilds one level
-    up — [mkTrRestrFrames] (the next-level translation coherences) and
-    [mkTrRestrPainting] (the next-level commutations). *)
-
-Definition mkTrRestrPaintingType {p k} (T: TrDepsRestr p.+1 k)
-  {XA: DepsRestrExtension p.+1 k T.(_depsA)}
-  {XB: DepsRestrExtension p.+1 k T.(_depsB)}
-  (TX: TrDepsExtension T XA XB)
-  (rpA: mkRestrPaintingTypes XA) (rpB: mkRestrPaintingTypes XB): Type :=
-  forall q (Hq: q <= k) (ε: arity) (d: mkFrame T.(_depsB).(1))
-    (c: (mkPaintings (T.(_depsB); XB)).2 d),
-  rew [T.(_depsA).(_paintings).2] T.(_trRestrs).2 q Hq ε d in
-    T.(_paintingEqvs).2 (T.(_depsB).(_restrFrames).2 q Hq ε d)
-      (rpB.2 q Hq ε d c) =
-  rpA.2 q Hq ε (mkFrameEqv (proj1TrDepsRestr T) d)
-    (mkPaintingEqv (AddTrDep T TX) d c).
-
-Fixpoint mkTrRestrPaintingTypes {p k}:
-  forall (T: TrDepsRestr p k)
-    {XA: DepsRestrExtension p k T.(_depsA)}
-    {XB: DepsRestrExtension p k T.(_depsB)}
-    (TX: TrDepsExtension T XA XB)
-    (rpA: mkRestrPaintingTypes XA) (rpB: mkRestrPaintingTypes XB), Type :=
-  match p return forall (T: TrDepsRestr p k)
-    (XA: DepsRestrExtension p k T.(_depsA))
-    (XB: DepsRestrExtension p k T.(_depsB))
-    (TX: TrDepsExtension T XA XB)
-    (rpA: mkRestrPaintingTypes XA) (rpB: mkRestrPaintingTypes XB), Type with
-  | 0 => fun _ _ _ _ _ _ => unit
-  | S p => fun T XA XB TX rpA rpB =>
-      { _: mkTrRestrPaintingTypes (proj1TrDepsRestr T) (AddTrDep T TX)
-             rpA.1 rpB.1 &T
-        mkTrRestrPaintingType T TX rpA rpB }
-  end.
-
-(** The translation-equipped [DepsCohs] pair *)
-
-Class TrDepsCohs (p k: nat) := {
-  _trDeps: TrDepsRestr p k;
-  _tExtA: DepsRestrExtension p k _trDeps.(_depsA);
-  _tExtB: DepsRestrExtension p k _trDeps.(_depsB);
-  _trExt: TrDepsExtension _trDeps _tExtA _tExtB;
-  _tRpA: mkRestrPaintingTypes _tExtA;
-  _tRpB: mkRestrPaintingTypes _tExtB;
-  _trRestrPaintings: mkTrRestrPaintingTypes _trDeps _trExt _tRpA _tRpB;
-  _tCohsA: mkCohFrameTypes _tRpA;
-  _tCohsB: mkCohFrameTypes _tRpB;
-}.
-
-Definition trDepsCohsA {p k} (TC: TrDepsCohs p k): DepsCohs p k := {|
-  _deps := TC.(_trDeps).(_depsA);
-  _extraDeps := TC.(_tExtA);
-  _restrPaintings := TC.(_tRpA);
-  _cohs := TC.(_tCohsA);
-|}.
-
-Definition trDepsCohsB {p k} (TC: TrDepsCohs p k): DepsCohs p k := {|
-  _deps := TC.(_trDeps).(_depsB);
-  _extraDeps := TC.(_tExtB);
-  _restrPaintings := TC.(_tRpB);
-  _cohs := TC.(_tCohsB);
-|}.
-
-#[local]
-Instance proj1TrDepsCohs {p k} (TC: TrDepsCohs p.+1 k): TrDepsCohs p k.+1 :=
-{|
-  _trDeps := proj1TrDepsRestr TC.(_trDeps);
-  _tExtA := (TC.(_trDeps).(_depsA); TC.(_tExtA))%extradepsrestr;
-  _tExtB := (TC.(_trDeps).(_depsB); TC.(_tExtB))%extradepsrestr;
-  _trExt := AddTrDep TC.(_trDeps) TC.(_trExt);
-  _tRpA := TC.(_tRpA).1;
-  _tRpB := TC.(_tRpB).1;
-  _trRestrPaintings := TC.(_trRestrPaintings).1;
-  _tCohsA := TC.(_tCohsA).1;
-  _tCohsB := TC.(_tCohsB).1;
-|}.
-
-(** The next-level translation coherences to be built, and the
-    next-level frame equivalences *)
-
-Definition mkTrRestrFramesType {p k} (TC: TrDepsCohs p k): Type :=
-  (mkTrRestrTypesAndFrames (mkFrameEqvs TC.(_trDeps))
-    (mkPaintingEqvs TC.(_trExt))).(TrRestrTypesDef)
-  (mkRestrFrames (depsCohs := trDepsCohsA TC))
-  (mkRestrFrames (depsCohs := trDepsCohsB TC)).
-
-Definition mkTrFrameEqvsNext {p k} (TC: TrDepsCohs p k)
-  (Q: mkTrRestrFramesType TC):
-  mkFrameEqvTypes (mkFrames (mkDepsRestr (depsCohs := trDepsCohsA TC)))
-    (mkFrames (mkDepsRestr (depsCohs := trDepsCohsB TC))) :=
-  (mkTrRestrTypesAndFrames (mkFrameEqvs TC.(_trDeps))
-    (mkPaintingEqvs TC.(_trExt))).(FrameEqvDef) Q.
-
-Lemma trLayerEqvNth {p k} {framesA framesB: mkFrameTypes p.+1 k}
-  {eqvs: mkFrameEqvTypes framesA framesB}
-  {paintingsA: mkPaintingTypes p.+1 k framesA}
-  {paintingsB: mkPaintingTypes p.+1 k framesB}
-  (pEqvs: mkPaintingEqvTypes eqvs paintingsA paintingsB)
-  {prevA prevB: RestrFrameTypeBlock p k.+1}
-  {prevTr: TrRestrBlock eqvs.1 prevA prevB}
-  {RA: mkRestrFrameTypesStep framesA prevA}
-  {RB: mkRestrFrameTypesStep framesB prevB}
-  (Q: mkTrRestrTypesStep eqvs prevTr RA RB)
-  (d: (prevB.(FrameDef) RB.1).2)
-  (l: mkLayer (paintings := paintingsB) RB d) (ω: arity):
-  nth (mkTrLayerEquiv pEqvs Q d l) ω =
-  compEquiv (pEqvs.2 (RB.2 0 leR_O ω d))
-    (rewEquiv (fun x => paintingsA.2 x) (Q.2 0 leR_O ω d))
-    (nth l ω).
-Proof.
-  now exact (layerEquivNth _ l ω).
-Qed.
-
-(** The next-level translation coherences
-
-    The layer case: componentwise, both sides reduce to transports of the
-    translated restricted painting; the stored commutation
-    [_trRestrPaintings] identifies them and the two 3-chains collapse by
-    [rew_cohLayer33] + [UIP] of the target frame — the [B]-side exchange
-    [_tCohsB] entering as a path under the frame equivalence. *)
-
-Lemma mkTrRestrLayer {p k} (TC: TrDepsCohs p.+1 k)
-  (Q: mkTrRestrFramesType (proj1TrDepsCohs TC))
-  (q: nat) (Hq: q <= k) (ε: arity)
-  (d: mkFrame (mkDepsRestr (depsCohs := trDepsCohsB (proj1TrDepsCohs TC)))):
-  rew [mkLayer TC.(_trDeps).(_depsA).(_restrFrames)]
-      (Q.2 q.+1 (⇑ Hq) ε d.1) in
-    mkTrLayerEquiv TC.(_trDeps).(_paintingEqvs) TC.(_trDeps).(_trRestrs)
-      ((mkRestrFrames
-         (depsCohs := trDepsCohsB (proj1TrDepsCohs TC))).2 q.+1 (⇑ Hq) ε d.1)
-      (mkRestrLayer TC.(_tRpB) TC.(_tCohsB) q Hq ε d.1 d.2)
-  = mkRestrLayer TC.(_tRpA) TC.(_tCohsA) q Hq ε
-      ((mkTrFrameEqvsNext (proj1TrDepsCohs TC) Q).2 d).1
-      ((mkTrFrameEqvsNext (proj1TrDepsCohs TC) Q).2 d).2.
-Proof.
-  apply ext; intros ω.
-  rewrite <- (map_subst (P := mkLayer _) (fun x l => nth l ω)
-    (Q.2 q.+1 (⇑ Hq) ε d.1)).
-  rewrite (trLayerEqvNth TC.(_trDeps).(_paintingEqvs)
-    TC.(_trDeps).(_trRestrs) _ _ ω).
-  change (((mkTrFrameEqvsNext (proj1TrDepsCohs TC) Q).2 d).2) with
-    (mkTrLayerEquiv (mkPaintingEqvs (AddTrDep TC.(_trDeps) TC.(_trExt)))
-      Q d.1 d.2).
-  rewrite 3 nth_lmap.
-  cbn [compEquiv rewEquiv eqvFun].
-  rewrite <- map_subst with
-    (f := fun x => TC.(_trDeps).(_paintingEqvs).2 x).
-  rewrite <- map_subst with
-    (f := fun x => TC.(_tRpA).2 q Hq ε x).
-  rewrite <- (TC.(_trRestrPaintings).2 q Hq ε
-    ((mkRestrFrames (depsCohs := trDepsCohsB (proj1TrDepsCohs TC))).2
-       0 leR_O ω d.1)
-    (nth d.2 ω)).
-  eapply (rew_cohLayer33
-    (P := fun x => TC.(_trDeps).(_depsA).(_paintings).2 x)
-    (rf0 := fun x => TC.(_trDeps).(_depsA).(_restrFrames).2 0 leR_O ω x)
-    (rfF := fun x => TC.(_trDeps).(_frameEqvs).2 x)
-    (rfG := fun x => TC.(_trDeps).(_depsA).(_restrFrames).2 q Hq ε x)
-    (S2 := fun m => TC.(_trDeps).(_depsA).(_paintings).2
-      (TC.(_trDeps).(_frameEqvs).2 m))
-    (S3 := fun n => TC.(_trDeps).(_depsA).(_paintings).2
-      (TC.(_trDeps).(_depsA).(_restrFrames).2 q Hq ε n))
-    (F := fun _ a => a) (G := fun _ a => a)).
-  now trivial.
-  now apply TC.(_trDeps).(_depsA).(_frames).2.(UIP).
-Qed.
-
-(** The frame case pairs the previous-stage coherence at offset [q.+1]
-    with the layer case: the offsets of the two towers align one to one,
-    so the previous-stage coherence applies directly. *)
-
-Lemma mkTrRestrFrameStep {p k} (TC: TrDepsCohs p.+1 k)
-  (Q: mkTrRestrFramesType (proj1TrDepsCohs TC))
-  (q: nat) (Hq: q <= k) (ε: arity)
-  (d: mkFrame (mkDepsRestr (depsCohs := trDepsCohsB (proj1TrDepsCohs TC)))):
-  mkFrameEqv TC.(_trDeps)
-    ((mkRestrFrames (depsCohs := trDepsCohsB TC)).2 q Hq ε d) =
-  (mkRestrFrames (depsCohs := trDepsCohsA TC)).2 q Hq ε
-    ((mkTrFrameEqvsNext (proj1TrDepsCohs TC) Q).2 d).
-Proof.
-  unshelve eapply eq_existT_curried.
-  - now exact (Q.2 q.+1 (⇑ Hq) ε d.1).
-  - now exact (mkTrRestrLayer TC Q q Hq ε d).
-Defined.
-
-Fixpoint mkTrRestrFrames {p k} (TC: TrDepsCohs p k) {struct p}:
-  mkTrRestrFramesType TC :=
-  match p return forall (TC: TrDepsCohs p k), mkTrRestrFramesType TC with
-  | 0 => fun TC => (tt; fun q Hq ε d => eq_refl)
-  | S p => fun TC =>
-      (mkTrRestrFrames (proj1TrDepsCohs TC);
-       mkTrRestrFrameStep TC (mkTrRestrFrames (proj1TrDepsCohs TC)))
-  end TC.
-
-(** The next-level translation-equipped pair of dependencies *)
-
-#[local]
-Instance mkTrDepsRestr {p k} (TC: TrDepsCohs p k): TrDepsRestr p.+1 k := {|
-  _depsA := mkDepsRestr (depsCohs := trDepsCohsA TC);
-  _depsB := mkDepsRestr (depsCohs := trDepsCohsB TC);
-  _frameEqvs := mkFrameEqvs TC.(_trDeps);
-  _paintingEqvs := mkPaintingEqvs TC.(_trExt);
-  _trRestrs := mkTrRestrFrames TC;
-|}.
-
-(** Translation data for [DepsCohsExtension] one level up *)
-
-Inductive TrDepsCohsExtension:
-  forall {p k} (TC: TrDepsCohs p k),
-  DepsCohsExtension p k (trDepsCohsA TC) ->
-  DepsCohsExtension p k (trDepsCohsB TC) -> Type :=
-| TopTrCohDep {p} {TC: TrDepsCohs p 0}
-    {EA: mkFrame (mkDepsRestr (depsCohs := trDepsCohsA TC)) -> HSet}
-    {EB: mkFrame (mkDepsRestr (depsCohs := trDepsCohsB TC)) -> HSet}
-    (fillerEqvs: forall d,
-      Equiv (EB d) (EA (mkFrameEqv (mkTrDepsRestr TC) d))):
-    TrDepsCohsExtension TC (TopCohDep EA) (TopCohDep EB)
-| AddTrCohDep {p k} (TC: TrDepsCohs p.+1 k)
-    {XCA: DepsCohsExtension p.+1 k (trDepsCohsA TC)}
-    {XCB: DepsCohsExtension p.+1 k (trDepsCohsB TC)}:
-    TrDepsCohsExtension TC XCA XCB ->
-    TrDepsCohsExtension (proj1TrDepsCohs TC)
-      (AddCohDep (trDepsCohsA TC) XCA) (AddCohDep (trDepsCohsB TC) XCB).
-
-Arguments TopTrCohDep {p TC EA EB} _.
-Arguments AddTrCohDep {p k} TC {XCA XCB} _.
-
-Fixpoint mkTrExtraDeps {p k} {TC: TrDepsCohs p k}
-  {XCA: DepsCohsExtension p k (trDepsCohsA TC)}
-  {XCB: DepsCohsExtension p k (trDepsCohsB TC)}
-  (TCX: TrDepsCohsExtension TC XCA XCB):
-  TrDepsExtension (mkTrDepsRestr TC) (mkExtraDeps XCA) (mkExtraDeps XCB) :=
-  match TCX with
-  | TopTrCohDep fillerEqvs => TopTrDep fillerEqvs
-  | AddTrCohDep TC' TCX' =>
-      AddTrDep (mkTrDepsRestr TC') (mkTrExtraDeps TCX')
-  end.
-
-(** The next-level restr-painting commutations
-
-    The definition follows [mkRestrPainting] by recursion on the offset [q]. At
-    [q = 0] both sides are the diagonal layer component; at [q.+1] the
-    pair decomposes into the layer case and the recursive call one stage
-    up, with identical transport paths on both sides, so the two match
-    directly. *)
-
-Fixpoint mkTrRestrPainting {p k} {TC: TrDepsCohs p k}
-  {XCA: DepsCohsExtension p k (trDepsCohsA TC)}
-  {XCB: DepsCohsExtension p k (trDepsCohsB TC)}
-  (TCX: TrDepsCohsExtension TC XCA XCB) q {struct q}:
-  forall (Hq: q <= k) (ε: arity)
-    (d: mkFrame (mkDepsRestr (depsCohs := trDepsCohsB TC)).(1))
-    (c: (mkPaintings ((mkDepsRestr (depsCohs := trDepsCohsB TC));
-           mkExtraDeps XCB)).2 d),
-  rew [(mkDepsRestr (depsCohs := trDepsCohsA TC)).(_paintings).2]
-      (mkTrRestrFrames TC).2 q Hq ε d in
-    mkPaintingEqv TC.(_trExt)
-      ((mkDepsRestr (depsCohs := trDepsCohsB TC)).(_restrFrames).2 q Hq ε d)
-      ((mkRestrPaintings XCB).2 q Hq ε d c) =
-  (mkRestrPaintings XCA).2 q Hq ε
-    (mkFrameEqv (proj1TrDepsRestr (mkTrDepsRestr TC)) d)
-    (mkPaintingEqv (AddTrDep (mkTrDepsRestr TC) (mkTrExtraDeps TCX)) d c).
-Proof.
-  destruct q; intros.
-  - now exact (eq_sym
-      (trLayerEqvNth (mkPaintingEqvs TC.(_trExt)) (mkTrRestrFrames TC)
-        d c.1 ε)).
-  - destruct TCX as [| p' k' TC' XCA' XCB' TCX'].
-    + now destruct (leR_O_contra Hq).
-    + unshelve eapply (eq_existT_curried_dep
-        (Q := mkPainting TC'.(_tExtA))).
-      * now exact (mkTrRestrLayer TC'
-          (mkTrRestrFrames (proj1TrDepsCohs TC')) q (⇓ Hq) ε (d; c.1)).
-      * now exact (mkTrRestrPainting p'.+1 k' TC' XCA' XCB' TCX' q (⇓ Hq) ε
-          (d; c.1) c.2).
-Defined.
-
-Fixpoint mkTrRestrPaintingsPrefix {p k}:
-  forall {TC: TrDepsCohs p k}
-    {XCA: DepsCohsExtension p k (trDepsCohsA TC)}
-    {XCB: DepsCohsExtension p k (trDepsCohsB TC)}
-    (TCX: TrDepsCohsExtension TC XCA XCB),
-  mkTrRestrPaintingTypes (proj1TrDepsRestr (mkTrDepsRestr TC))
-    (AddTrDep (mkTrDepsRestr TC) (mkTrExtraDeps TCX))
-    (mkRestrPaintingsPrefix XCA) (mkRestrPaintingsPrefix XCB) :=
-  match p return forall (TC: TrDepsCohs p k)
-    (XCA: DepsCohsExtension p k (trDepsCohsA TC))
-    (XCB: DepsCohsExtension p k (trDepsCohsB TC))
-    (TCX: TrDepsCohsExtension TC XCA XCB),
-    mkTrRestrPaintingTypes (proj1TrDepsRestr (mkTrDepsRestr TC))
-      (AddTrDep (mkTrDepsRestr TC) (mkTrExtraDeps TCX))
-      (mkRestrPaintingsPrefix XCA) (mkRestrPaintingsPrefix XCB) with
-  | 0 => fun _ _ _ _ => tt
-  | S p => fun TC XCA XCB TCX =>
-      (mkTrRestrPaintingsPrefix (AddTrCohDep TC TCX);
-       mkTrRestrPainting (AddTrCohDep TC TCX))
-  end.
-
-Definition mkTrRestrPaintings {p k} {TC: TrDepsCohs p k}
-  {XCA: DepsCohsExtension p k (trDepsCohsA TC)}
-  {XCB: DepsCohsExtension p k (trDepsCohsB TC)}
-  (TCX: TrDepsCohsExtension TC XCA XCB):
-  mkTrRestrPaintingTypes (mkTrDepsRestr TC) (mkTrExtraDeps TCX)
-    (mkRestrPaintings XCA) (mkRestrPaintings XCB) :=
-  (mkTrRestrPaintingsPrefix TCX; mkTrRestrPainting TCX).
-
-(** The tower data at a coinductive position *)
-
 Definition νDataAt {m} (Xpre: (νSetAt m).(prefix)): νSetData m :=
   (νSetAt m).(data) Xpre.
-
-(** The bisimulation tower and the coinductive equivalence
-
-    The corecursive state at a tower level: the translation data over
-    the two [νSetAt]-towers'
-    dependencies at a pair of prefixes, with the assembled [TrDepsRestr]
-    pinned by construction. The coinductive [νSetFromEquiv] then carries,
-    at each level, the filler equivalence, the restr-painting
-    commutations at it, and corecursively the equivalence of the tails
-    over the stepped state. *)
 
 Definition νTowerDeps {n} (Xpre: (νSetAt n).(prefix)): DepsRestr n 0 :=
   toDepsRestr (νDataAt Xpre).(restrFrames).
 
-Class TrTower (n: nat) (XpreA XpreB: (νSetAt n).(prefix)) := {
-  _twFrameEqvs: mkFrameEqvTypes (νTowerDeps XpreA).(_frames)
-    (νTowerDeps XpreB).(_frames);
-  _twPaintingEqvs: mkPaintingEqvTypes _twFrameEqvs
-    (νTowerDeps XpreA).(_paintings) (νTowerDeps XpreB).(_paintings);
-  _twTrRestrs: (mkTrRestrTypesAndFrames _twFrameEqvs
-    _twPaintingEqvs).(TrRestrTypesDef)
-    (νTowerDeps XpreA).(_restrFrames) (νTowerDeps XpreB).(_restrFrames);
+(** The full frame at a prefix, and the filler-family type over it. The
+    [this] field of [νSetFrom n Xpre] has type [νFillerType Xpre], and the
+    prefix one level up is [{Xpre &T νFillerType Xpre}], both definitionally.
+    [νFrameDom] is the [Type]-valued version used as a transport motive. *)
+
+Definition νFrame {n} (Xpre: (νSetAt n).(prefix)): HSet :=
+  mkFrame (νTowerDeps Xpre).
+
+Definition νFrameDom {n} (Xpre: (νSetAt n).(prefix)): Type := νFrame Xpre.
+
+Definition νFillerType {n} (Xpre: (νSetAt n).(prefix)): Type :=
+  νFrame Xpre -> HSet.
+
+(** The construction data assembled from a prefix one level up. At a tower
+    position, the pair of the prefix with the current filler assembles the
+    [DepsCohs] that the face operations consume. [νFrame Xp] at level
+    [n.+1] is [mkFrame (mkDepsRestr (depsCohs := prefixDepsCohs Xp))],
+    definitionally. *)
+
+Definition prefixDepsCohs {n} (Xp: (νSetAt n.+1).(prefix)): DepsCohs n 0 := {|
+  _deps := νTowerDeps Xp.1;
+  _extraDeps := TopRestrDep Xp.2;
+  _restrPaintings := (νDataAt Xp.1).(restrPaintings) Xp.2;
+  _cohs := (νDataAt Xp.1).(cohFrames) Xp.2;
+|}.
+
+(** The total space of cells at a prefix one level up — the result type of
+    [νFace] at [prefixDepsCohs], as a functor of the prefix *)
+
+Definition νTotalType {n} (Xp: (νSetAt n.+1).(prefix)): Type :=
+  {d: νFrame Xp.1 &T Xp.2 d}.
+
+(** The levelwise prefix relation, mutually with its conversion to equality
+
+    [PrefixRelDef] at level [n.+1] pairs a relation on the lower prefixes
+    with an equivalence of the filler families over the transport along the
+    lower equality; [prefixEqDef] converts the relation to an equality,
+    univalence and functional extensionality collapsing the filler
+    equivalences ([νFillerEq]). The two are mutually recursive on the
+    level, so [prefixEquivAt] builds them together. *)
+
+Record PrefixEquivPack (n: nat) := {
+  PrefixRelDef: (νSetAt n).(prefix) -> (νSetAt n).(prefix) -> Type;
+  prefixEqDef: forall XA XB, PrefixRelDef XA XB -> XA = XB;
 }.
 
-Definition towerTrDeps {n} {XpreA XpreB: (νSetAt n).(prefix)}
-  (W: TrTower n XpreA XpreB): TrDepsRestr n 0 := {|
-  _depsA := νTowerDeps XpreA;
-  _depsB := νTowerDeps XpreB;
-  _frameEqvs := W.(_twFrameEqvs);
-  _paintingEqvs := W.(_twPaintingEqvs);
-  _trRestrs := W.(_twTrRestrs);
-|}.
+Arguments PrefixRelDef {n} _ _ _.
+Arguments prefixEqDef {n} _ {XA XB} _.
 
-Definition trTowerDepsCohs {n} {XpreA XpreB: (νSetAt n).(prefix)}
-  (W: TrTower n XpreA XpreB)
-  {EA: mkFrame (νTowerDeps XpreA) -> HSet}
-  {EB: mkFrame (νTowerDeps XpreB) -> HSet}
-  (fEqv: forall d, Equiv (EB d) (EA (mkFrameEqv (towerTrDeps W) d)))
-  (rp: mkTrRestrPaintingTypes (towerTrDeps W)
-    (TopTrDep (T := towerTrDeps W) fEqv)
-    ((νDataAt XpreA).(restrPaintings) EA)
-    ((νDataAt XpreB).(restrPaintings) EB)):
-  TrDepsCohs n 0 := {|
-  _trDeps := towerTrDeps W;
-  _tExtA := TopRestrDep EA;
-  _tExtB := TopRestrDep EB;
-  _trExt := TopTrDep (T := towerTrDeps W) fEqv;
-  _tRpA := (νDataAt XpreA).(restrPaintings) EA;
-  _tRpB := (νDataAt XpreB).(restrPaintings) EB;
-  _trRestrPaintings := rp;
-  _tCohsA := (νDataAt XpreA).(cohFrames) EA;
-  _tCohsB := (νDataAt XpreB).(cohFrames) EB;
-|}.
+Definition νFillerEqvType {n} {XA XB: (νSetAt n).(prefix)} (e: XA = XB)
+  (EA: νFillerType XA) (EB: νFillerType XB): Type :=
+  forall d: νFrame XB, Equiv (EA (rew <- [νFrameDom] e in d)) (EB d).
 
-Definition trTowerStep {n} {XpreA XpreB: (νSetAt n).(prefix)}
-  (W: TrTower n XpreA XpreB)
-  {EA: mkFrame (νTowerDeps XpreA) -> HSet}
-  {EB: mkFrame (νTowerDeps XpreB) -> HSet}
-  (fEqv: forall d, Equiv (EB d) (EA (mkFrameEqv (towerTrDeps W) d)))
-  (rp: mkTrRestrPaintingTypes (towerTrDeps W)
-    (TopTrDep (T := towerTrDeps W) fEqv)
-    ((νDataAt XpreA).(restrPaintings) EA)
-    ((νDataAt XpreB).(restrPaintings) EB)):
-  TrTower n.+1 (XpreA; EA) (XpreB; EB) :=
-  Build_TrTower n.+1 (XpreA; EA) (XpreB; EB)
-    (mkFrameEqvs (towerTrDeps W))
-    (mkPaintingEqvs (TopTrDep (T := towerTrDeps W) fEqv))
-    (mkTrRestrFrames (trTowerDepsCohs W fEqv rp)).
+(** Transporting a filler family along a prefix equality precomposes with
+    the backward frame transport. The definition is transparent so that
+    the equality reduces when the prefix equality is [eq_refl]. *)
 
-CoInductive νSetFromEquiv {n} {XpreA XpreB: (νSetAt n).(prefix)}
-  (W: TrTower n XpreA XpreB)
-  (SA: νSetFrom n XpreA) (SB: νSetFrom n XpreB): Type := trCons {
-  thisEquiv: forall d: mkFrame (νTowerDeps XpreB),
-    Equiv (SB.(this _ _) d)
-      (SA.(this _ _) (mkFrameEqv (towerTrDeps W) d));
-  trRpEquiv: mkTrRestrPaintingTypes (towerTrDeps W)
-    (TopTrDep (T := towerTrDeps W) thisEquiv)
-    ((νDataAt XpreA).(restrPaintings) (SA.(this _ _)))
-    ((νDataAt XpreB).(restrPaintings) (SB.(this _ _)));
-  nextEquiv: νSetFromEquiv (trTowerStep W thisEquiv trRpEquiv)
+Definition rewνFillerType {n} {XA XB: (νSetAt n).(prefix)} (e: XA = XB)
+  (EA: νFillerType XA):
+  rew [νFillerType] e in EA = fun d => EA (rew <- [νFrameDom] e in d).
+Proof.
+  now destruct e.
+Defined.
+
+(** The filler-family equality induced by an equivalence family: funext of
+    the levelwise HSet equalities from univalence *)
+
+Definition νFillerEq {n} {XA XB: (νSetAt n).(prefix)} (e: XA = XB)
+  {EA: νFillerType XA} {EB: νFillerType XB}
+  (eqvs: νFillerEqvType e EA EB): rew [νFillerType] e in EA = EB :=
+  rewνFillerType e EA
+  • functional_extensionality_dep_good _ _ (fun d => hsetEq (eqvs d)).
+
+Fixpoint prefixEquivAt (n: nat): PrefixEquivPack n :=
+  match n return PrefixEquivPack n with
+  | 0 => Build_PrefixEquivPack 0
+      (fun _ _ => unit)
+      (fun XA XB _ => hunit_ext XA XB)
+  | S n => let prev := prefixEquivAt n in
+      Build_PrefixEquivPack n.+1
+        (fun XA XB =>
+          { r: prev.(PrefixRelDef) XA.1 XB.1 &T
+            νFillerEqvType (prev.(prefixEqDef) r) XA.2 XB.2 })
+        (fun XA XB r =>
+          eq_existT_curried (prev.(prefixEqDef) r.1)
+            (νFillerEq (prev.(prefixEqDef) r.1) r.2))
+  end.
+
+Definition PrefixRel n: (νSetAt n).(prefix) -> (νSetAt n).(prefix) -> Type :=
+  (prefixEquivAt n).(PrefixRelDef).
+
+Definition prefixEq {n} {XA XB: (νSetAt n).(prefix)}
+  (r: PrefixRel n XA XB): XA = XB :=
+  (prefixEquivAt n).(prefixEqDef) r.
+
+(** The relation one level up, from filler equivalences over the current
+    equality — definitionally a pair, named for the corecursion *)
+
+Definition relStep {n} {XA XB: (νSetAt n).(prefix)} (r: PrefixRel n XA XB)
+  {EA: νFillerType XA} {EB: νFillerType XB}
+  (eqvs: νFillerEqvType (prefixEq r) EA EB):
+  PrefixRel n.+1 (XA; EA) (XB; EB) := (r; eqvs).
+
+Definition rel0: PrefixRel 0 tt tt := tt.
+
+(** The equality generated by [relStep] unfolds to the curried sigma
+    equality of its components. *)
+
+Definition prefixEqStep {n} {XA XB: (νSetAt n).(prefix)}
+  (r: PrefixRel n XA XB) {EA: νFillerType XA} {EB: νFillerType XB}
+  (eqvs: νFillerEqvType (prefixEq r) EA EB):
+  prefixEq (relStep r eqvs) =
+  eq_existT_curried (prefixEq r) (νFillerEq (prefixEq r) eqvs) := eq_refl.
+
+(** Computing transport along a prefix equality
+
+    Three steps: backward transport of a total-space pair along a sigma
+    equality with a reflexive base moves only the filler component
+    ([rewTotalFamily]); backward transport of the filler component along the
+    funext-assembled family equality computes pointwise
+    ([rewνFillerFunext]); and pointwise backward transport along [hsetEq]
+    is the inverse of the equivalence ([hsetEqRewSym]).
+    [prefixEqRewTotal] assembles them after destructing the lower prefix
+    equality. *)
+
+Lemma rewTotalFamily {n} {X1: (νSetAt n).(prefix)}
+  {EA EB: νFillerType X1} (q: EA = EB)
+  (t: νTotalType ((X1; EB): (νSetAt n.+1).(prefix))):
+  rew <- [νTotalType]
+    (eq_existT_curried (P := νFillerType) (eq_refl X1) q
+     : ((X1; EA): (νSetAt n.+1).(prefix)) = (X1; EB)) in t =
+  (t.1; rew <- [fun E: νFillerType X1 => E t.1: Type] q in t.2).
+Proof.
+  now destruct q.
+Qed.
+
+Lemma rewνFillerFunext {n} {X1: (νSetAt n).(prefix)}
+  {EA EB: νFillerType X1} (H: forall d, EA d = EB d)
+  (d0: νFrame X1) (c: EB d0):
+  rew <- [fun E: νFillerType X1 => E d0: Type]
+    (functional_extensionality_dep_good EA EB H) in c =
+  rew <- [Dom] (H d0) in c.
+Proof.
+  unfold eq_rect_r.
+  rewrite (rew_map (fun h: HSet => h.(Dom)) (fun E: νFillerType X1 => E d0)).
+  rewrite <- eq_sym_f_equal.
+  now rewrite (f_equal__functional_extensionality_dep_good H d0).
+Qed.
+
+(** The three steps assembled, for an arbitrary lower equality: path
+    induction on it turns [νFillerEq] into the funext equality of the
+    filler families, which the two lemmas above compute. *)
+
+Lemma rewTotalνFillerEq {n} {XA XB: (νSetAt n).(prefix)} (e: XA = XB)
+  {EA: νFillerType XA} {EB: νFillerType XB}
+  (eqvs: νFillerEqvType e EA EB)
+  (t: νTotalType ((XB; EB): (νSetAt n.+1).(prefix))):
+  rew <- [νTotalType]
+    (eq_existT_curried (P := νFillerType) e (νFillerEq e eqvs)
+     : ((XA; EA): (νSetAt n.+1).(prefix)) = (XB; EB)) in t =
+  (rew <- [νFrameDom] e in t.1; invEq (eqvs t.1) t.2).
+Proof.
+  destruct e.
+  unfold νFillerEq; cbn [rewνFillerType].
+  rewrite eq_trans_refl_l.
+  rewrite (rewTotalFamily
+    (functional_extensionality_dep_good _ _ (fun d => hsetEq (eqvs d))) t).
+  apply (f_equal (fun c: EA t.1 =>
+    ((t.1; c): νTotalType ((XA; EA): (νSetAt n.+1).(prefix))))).
+  rewrite (rewνFillerFunext (fun d => hsetEq (eqvs d)) t.1 t.2).
+  now apply hsetEqRewSym.
+Qed.
+
+Lemma prefixEqRewTotal {n} {XA XB: (νSetAt n.+1).(prefix)}
+  (r: PrefixRel n.+1 XA XB) (t: νTotalType XB):
+  rew <- [νTotalType] (prefixEq r) in t =
+  (rew <- [νFrameDom] (prefixEq r.1) in t.1; invEq (r.2 t.1) t.2).
+Proof.
+  now exact (rewTotalνFillerEq (prefixEq r.1) r.2 t).
+Qed.
+
+(** The coinductive levelwise equivalence
+
+    At each level: the equivalence of the current filler families over the
+    prefix equality, and corecursively the equivalence of the tails over
+    the extended relation. The restriction and coherence data at each level
+    is computed from the prefix, so transport along the prefix equality
+    supplies its compatibility. *)
+
+CoInductive νSetFromEquiv {n} {XA XB: (νSetAt n).(prefix)}
+  (r: PrefixRel n XA XB)
+  (SA: νSetFrom n XA) (SB: νSetFrom n XB): Type := trCons {
+  thisEquiv: νFillerEqvType (prefixEq r) (SA.(this _ _)) (SB.(this _ _));
+  nextEquiv: νSetFromEquiv (relStep r thisEquiv)
     (SA.(next _ _)) (SB.(next _ _));
 }.
-
-Definition trTower0: TrTower 0 tt tt := Build_TrTower 0 tt tt tt tt tt.
 
 End νSetEquiv.
 

--- a/theories/νSet/Equiv/νSetRoundtrip.v
+++ b/theories/νSet/Equiv/νSetRoundtrip.v
@@ -1,8 +1,14 @@
-(** The translation side of the backward round trip [f ∘ g] of the
-    correspondence: [fg: νSetFromEquiv trTower0 (f (g X)) X].
+(** The indexed side of the backward round trip [f ∘ g] of the
+    correspondence: [fg: νSetFromEquiv rel0 (f (g X)) X].
 
-    This file constructs the translation-equipped chains, filler
-    equivalences, and level identifications used by the coinductive proof. *)
+    The bisimulation is built level by level. At each level the cells of the
+    presheaf [g X] in the ambient dimension are identified with the total
+    space of the position reached in [X] (the descent witness [Desc]), and
+    the candidate fillers of [f (g X)] over a frame transported along the
+    prefix equality contract onto the fillers of [X] ([fillerEquivOf]). The
+    frame identification carried along the corecursion states that the
+    candidate frame of a transported cell is the transport of its frame; it
+    steps by [νFaceEq], every face of the two frames agreeing. *)
 
 Import Logic.EqNotations.
 
@@ -20,103 +26,14 @@ Import A.
 
 Module Export PresheafOfνSet := PresheafOfνSet.PresheafOfνSet A.
 
-(** The face maps commute with the translations
-
-    Chains of translation-equipped stages map to [DepsCohsChain]s on both
-    sides. Along these chains, [getFrame] and [getPainting] compute on
-    translated frames and paintings, and [νFace] commutes with the
-    translations. This supplies the face equalities used by the [f ∘ g]
-    frame identification. *)
-
-Inductive TrCohsChain {P K} (TCTop: TrDepsCohs P K):
-  forall {p k}, TrDepsCohs p k -> Type :=
-| TrCohsChainNil: TrCohsChain TCTop TCTop
-| TrCohsChainCons {p k} {TC: TrDepsCohs p.+1 k}:
-    TrCohsChain TCTop TC -> TrCohsChain TCTop (proj1TrDepsCohs TC).
-
-Arguments TrCohsChainNil {P K TCTop}.
-Arguments TrCohsChainCons {P K TCTop p k TC} _.
-
-Fixpoint trCohsChainA {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC):
-  DepsCohsChain (trDepsCohsA TCTop) (trDepsCohsA TC) :=
-  match C with
-  | TrCohsChainNil => DepsCohsChainNil
-  | TrCohsChainCons C' => DepsCohsChainCons (trCohsChainA C')
-  end.
-
-Fixpoint trCohsChainB {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC):
-  DepsCohsChain (trDepsCohsB TCTop) (trDepsCohsB TC) :=
-  match C with
-  | TrCohsChainNil => DepsCohsChainNil
-  | TrCohsChainCons C' => DepsCohsChainCons (trCohsChainB C')
-  end.
-
-Lemma trGetFrame {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC)
-  (d: mkFrame (mkDepsRestr (depsCohs := trDepsCohsB TCTop))):
-  getFrame (cohsChainNext (trCohsChainA C))
-    (mkFrameEqv (mkTrDepsRestr TCTop) d) =
-  mkFrameEqv (mkTrDepsRestr TC)
-    (getFrame (cohsChainNext (trCohsChainB C)) d).
-Proof.
-  induction C; cbn; [now reflexivity | now rewrite IHC].
-Qed.
-
-Lemma trGetPainting {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC)
-  (d: mkFrame TC.(_trDeps).(_depsB))
-  (cp: mkPainting TC.(_tExtB) d):
-  getPainting (cohsChainExt (trCohsChainA C))
-    (mkFrameEqv TC.(_trDeps) d) (mkPaintingEqv TC.(_trExt) d cp) =
-  (mkFrameEqv TCTop.(_trDeps)
-     (getPainting (cohsChainExt (trCohsChainB C)) d cp).1;
-   mkPaintingEqv TCTop.(_trExt)
-     (getPainting (cohsChainExt (trCohsChainB C)) d cp).1
-     (getPainting (cohsChainExt (trCohsChainB C)) d cp).2).
-Proof.
-  revert d cp; induction C; intros d cp.
-  - now reflexivity.
-  - now exact (IHC (d; cp.1) cp.2).
-Qed.
-
-(** [νFace] on a translated frame is the translated [νFace]: one
-    cancellation of the diagonal translation coherence against the
-    layer's transport, then the painting round trip. *)
-
-Lemma νFaceTr {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC) (ε: arity)
-  (d: mkFrame (mkDepsRestr (depsCohs := trDepsCohsB TCTop))):
-  νFace (trCohsChainA C) ε (mkFrameEqv (mkTrDepsRestr TCTop) d) =
-  (mkFrameEqv TCTop.(_trDeps) (νFace (trCohsChainB C) ε d).1;
-   mkPaintingEqv TCTop.(_trExt) (νFace (trCohsChainB C) ε d).1
-     (νFace (trCohsChainB C) ε d).2).
-Proof.
-  unfold νFace.
-  rewrite trGetFrame.
-  rewrite (trLayerEqvNth (mkPaintingEqvs TC.(_trExt))
-    (mkTrRestrFrames TC) _ _ ε).
-  refine (f_equal
-    (fun z: {d0: mkFrame TC.(_trDeps).(_depsA) &T
-       mkPainting TC.(_tExtA) d0} =>
-     getPainting (cohsChainExt (trCohsChainA C)) z.1 z.2)
-    (eq_existT_curried
-      (eq_sym ((mkTrRestrFrames TC).2 0 leR_O ε
-        (getFrame (cohsChainNext (trCohsChainB C)) d).1))
-      (rew_sym_cancel _ _)) • _).
-  now exact (trGetPainting C _ _).
-Qed.
-
 (** Lifting arbitrary chains to equipped chains
 
     [νFaceEq]'s hypothesis quantifies over *arbitrary* [DepsCohsChain]s
-    from the shared top. Both equipped chain types — [PshCohsChain] on the
-    presheaf side, [TrCohsChain] on the translation side — step by
-    [proj1DepsCohs] on their [DepsCohs] images, so every chain is the
-    image of an equipped one; the identification is carried as a
-    sigma-package equality (the result type of [νFace] does not depend on
-    the endpoint, so packages can be rewritten wholesale). *)
+    from the shared top. On the presheaf side the equipped chains
+    ([PshCohsChain]) step by [proj1DepsCohs] on their [DepsCohs] images, so
+    every chain is the image of an equipped one; the identification is
+    carried as a sigma-package equality (the result type of [νFace] does
+    not depend on the endpoint, so packages can be rewritten wholesale). *)
 
 Lemma cohsChainStage {P K} {dcTop: DepsCohs P K} {p k} {dc: DepsCohs p k}
   (c: DepsCohsChain dcTop dc): p + cohsChainLen c = P.
@@ -145,31 +62,12 @@ Proof.
           DepsCohsChain (pshDepsCohs psh PCTop) dc0})) e').
 Qed.
 
-Lemma trChainLift {P K} (TCTop: TrDepsCohs P K)
-  {p k} {dc: DepsCohs p k}
-  (c0: DepsCohsChain (trDepsCohsA TCTop) dc):
-  {TC: TrDepsCohs p k &T {C: TrCohsChain TCTop TC &T
-    ((dc; c0): {dc0: DepsCohs p k &T
-       DepsCohsChain (trDepsCohsA TCTop) dc0}) =
-    (trDepsCohsA TC; trCohsChainA C)}}.
-Proof.
-  induction c0 as [|p k dc' c0' IH].
-  - now exact (TCTop; (TrCohsChainNil; eq_refl)).
-  - destruct IH as (TC', (C', e')).
-    refine (proj1TrDepsCohs TC'; (TrCohsChainCons C'; _)).
-    now exact (f_equal (fun s: {dc0: DepsCohs p.+1 k &T
-        DepsCohsChain (trDepsCohsA TCTop) dc0} =>
-      ((proj1DepsCohs s.1; DepsCohsChainCons s.2):
-        {dc0: DepsCohs p k.+1 &T
-          DepsCohsChain (trDepsCohsA TCTop) dc0})) e').
-Qed.
-
 (** Normal forms of chain packages
 
-    The [B]-side of the round trip compares [g]'s fuel-synthesized chains
-    with the [B]-images of lifted translation chains; both are iterated
-    [dcStep]s of the nil package, reconnected through length/stage
-    arithmetic alone. *)
+    The original-tower side of the round trip compares [g]'s
+    fuel-synthesized chains with arbitrary chains from the position's top;
+    both are iterated [dcStep]s of the nil package, reconnected through
+    length/stage arithmetic alone. *)
 
 Fixpoint dcStepIter {P K} {dcTop: DepsCohs P K} (j: nat)
   (s: DCPack dcTop): DCPack dcTop :=
@@ -187,33 +85,45 @@ Proof.
   - now rewrite dc2PackDepsStep, IHj.
 Qed.
 
-Fixpoint trCohsChainLen {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC): nat :=
-  match C with
-  | TrCohsChainNil => 0
-  | TrCohsChainCons C' => (trCohsChainLen C').+1
-  end.
-
-Lemma trCohsChainStage {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC):
-  p + trCohsChainLen C = P.
+Lemma chainPackNF {P K} {dcTop: DepsCohs P K} {p k} {dc: DepsCohs p k}
+  (c: DepsCohsChain dcTop dc):
+  ((p; (k; (dc; c))): DCPack dcTop) =
+  dcStepIter (cohsChainLen c) (P; (K; (dcTop; DepsCohsChainNil))).
 Proof.
-  induction C as [|p k TC C IH]; cbn [trCohsChainLen].
-  - now symmetry; apply plus_n_O.
-  - rewrite <- plus_n_Sm. now exact IH.
-Qed.
-
-Lemma trChainPackB {P K} {TCTop: TrDepsCohs P K}
-  {p k} {TC: TrDepsCohs p k} (C: TrCohsChain TCTop TC):
-  ((p; (k; (trDepsCohsB TC; trCohsChainB C))): DCPack (trDepsCohsB TCTop)) =
-  dcStepIter (trCohsChainLen C)
-    (P; (K; (trDepsCohsB TCTop; DepsCohsChainNil))).
-Proof.
-  induction C as [|p k TC C IH]; cbn [trCohsChainLen dcStepIter].
+  induction c as [|p k dc c IH]; cbn [cohsChainLen dcStepIter].
   - now reflexivity.
   - now rewrite <- IH.
 Qed.
 
+(** The face maps commute with prefix transport
+
+    At a prefix [Xp] one level up, the input frame of [νFace] is [νFrame Xp]
+    and its output is the total space [νTotalType Xp]; both are functors of
+    the prefix, and the chains from [prefixDepsCohs Xp] to a fixed endpoint
+    form a third one. So [νFace] commutes with wholesale transport along an
+    equality of prefixes, by path induction. The [Nil] case is stated
+    separately: transporting the empty chain lands on the empty chain of the
+    other prefix. *)
+
+Lemma νFaceRewPrefix {n} {XpA XpB: (νSetAt n.+1).(prefix)} (e: XpA = XpB)
+  {p k} {dc: DepsCohs p k} (cA: DepsCohsChain (prefixDepsCohs XpA) dc)
+  (ε: arity) (d: νFrameDom XpB):
+  νFace cA ε (rew <- [νFrameDom] e in d) =
+  rew <- [νTotalType] e in
+    νFace (rew [fun Xp => DepsCohsChain (prefixDepsCohs Xp) dc] e in cA) ε d.
+Proof.
+  now destruct e.
+Qed.
+
+Lemma νFaceRewPrefixNil {n} {XpA XpB: (νSetAt n.+1).(prefix)} (e: XpA = XpB)
+  (ε: arity) (d: νFrameDom XpB):
+  νFace (dcTop := prefixDepsCohs XpA) DepsCohsChainNil ε
+    (rew <- [νFrameDom] e in d) =
+  rew <- [νTotalType] e in
+    νFace (dcTop := prefixDepsCohs XpB) DepsCohsChainNil ε d.
+Proof.
+  now destruct e.
+Qed.
 
 (** The candidate-filler contraction: given a frame
     translation [tr], an identification [HF] of the cells with the total
@@ -368,75 +278,71 @@ Qed.
 
 (** The carried frame identification: the candidate
     frame of a cell transported from the position's total space is the
-    translated frame. Stated in the exact shape [fillerEquivOf] consumes. *)
+    backward transport of its frame along the prefix equality. Stated in
+    the exact shape [fillerEquivOf] consumes. *)
 
-Definition FrtInv {m} {XpreA XpreB: (νSetAt m.+1).(prefix)}
-  (T: PshTower (g X) m XpreA) (SB: νSetFrom m.+1 XpreB)
-  (HD: Desc SB) (W: TrTower m.+1 XpreA XpreB): Type :=
-  forall (D: mkFrame (νTowerDeps XpreB)) (c: SB.(this _ _) D),
+Definition FrtInv {m} {XpA XpB: (νSetAt m.+1).(prefix)}
+  (r: PrefixRel m.+1 XpA XpB)
+  (T: PshTower (g X) m XpA) (SB: νSetFrom m.+1 XpB) (HD: Desc SB): Type :=
+  forall (D: mkFrame (νTowerDeps XpB)) (c: SB.(this _ _) D),
   mkPshFrame (g X) (towerPshDeps (g X) T)
     (rew [Dom] (eq_sym (descTotal HD)) in
-      ((D; c): ({D0: mkFrame (νTowerDeps XpreB) & SB.(this _ _) D0}: HSet)))
-  = mkFrameEqv (towerTrDeps W) D.
+      ((D; c): ({D0: mkFrame (νTowerDeps XpB) & SB.(this _ _) D0}: HSet)))
+  = rew <- [νFrameDom] (prefixEq r) in D.
 
-(** The filler equivalence of the round trip at a level: the inverse of
-    the candidate-filler contraction over the frame identification. *)
+(** The filler equivalence of the round trip at a level: the
+    candidate-filler contraction over the frame identification, in the
+    direction the prefix relation stores it — from the candidate fillers
+    over the transported frame to the fillers of the position. *)
 
-Definition fgThis {m} {XpreA XpreB: (νSetAt m.+1).(prefix)}
-  (T: PshTower (g X) m XpreA) (SB: νSetFrom m.+1 XpreB)
-  (HD: Desc SB) (W: TrTower m.+1 XpreA XpreB) (FRT: FrtInv T SB HD W):
-  forall D: mkFrame (νTowerDeps XpreB),
-  Equiv (SB.(this _ _) D)
-    (mkPshFiller (g X) (towerPshDeps (g X) T) (mkFrameEqv (towerTrDeps W) D))
-  := fun D => symEquiv (fillerEquivOf (mkFrameEqv (towerTrDeps W))
-       (descTotal HD) (mkPshFrame (g X) (towerPshDeps (g X) T)) FRT D).
+Definition fgThis {m} {XpA XpB: (νSetAt m.+1).(prefix)}
+  (r: PrefixRel m.+1 XpA XpB)
+  (T: PshTower (g X) m XpA) (SB: νSetFrom m.+1 XpB) (HD: Desc SB)
+  (FRT: FrtInv r T SB HD):
+  νFillerEqvType (prefixEq r)
+    (mkPshFiller (g X) (towerPshDeps (g X) T)) (SB.(this _ _)) :=
+  fun D => fillerEquivOf (rewEquiv νFrameDom (eq_sym (prefixEq r)))
+    (descTotal HD) (mkPshFrame (g X) (towerPshDeps (g X) T)) FRT D.
 
-(** The bottom face of [g X] at the position, as [νFace] along the
-    [B]-image of a lifted translation chain: the fuel-synthesized package
-    and the image package are both [dcStep]-iterations of the nil package,
-    of the same length by the stage equation. *)
+(** The bottom face of [g X] at the position, as [νFace] along an
+    arbitrary chain from the position's top: the fuel-synthesized package
+    and the chain's own package are both [dcStep]-iterations of the nil
+    package, of the same length by the stage equation. *)
 
-Lemma fgFaceB {m} {XpreA XpreB: (νSetAt m.+1).(prefix)}
-  (W: TrTower m.+1 XpreA XpreB) (SB: νSetFrom m.+1 XpreB)
-  {EA: mkFrame (νTowerDeps XpreA) -> HSet}
-  (fEqv: forall d, Equiv (SB.(this _ _) d)
-    (EA (mkFrameEqv (towerTrDeps W) d)))
-  (rp: mkTrRestrPaintingTypes (towerTrDeps W)
-    (TopTrDep (T := towerTrDeps W) fEqv)
-    ((νDataAt XpreA).(restrPaintings) EA)
-    ((νDataAt XpreB).(restrPaintings) (SB.(this _ _))))
-  {p k} {TC: TrDepsCohs p k}
-  (C: TrCohsChain (trTowerDepsCohs W fEqv rp) TC)
+Lemma fgFaceB {m} {Xpre: (νSetAt m.+1).(prefix)} (SB: νSetFrom m.+1 Xpre)
+  {p k} {dc: DepsCohs p k} (cB: DepsCohsChain (νDepsCohsAt SB) dc)
   (Hp: p <= m.+1) (ε: arity) (t: νTotal (SB.(next _ _))):
-  gFace SB 0 p Hp ε t = νFace (trCohsChainB C) ε t.1.
+  gFace SB 0 p Hp ε t = νFace cB ε t.1.
 Proof.
-  change (νFaceFuel SB (m.+1 - p) ε t = νFace (trCohsChainB C) ε t.1).
+  change (νFaceFuel SB (m.+1 - p) ε t = νFace cB ε t.1).
   unfold νFaceFuel.
-  rewrite (f_equal (fun z => z - p) (eq_sym (trCohsChainStage C))
-    • addSubCancelL p (trCohsChainLen C)).
+  rewrite (f_equal (fun z => z - p) (eq_sym (cohsChainStage cB))
+    • addSubCancelL p (cohsChainLen cB)).
   now exact (f_equal
     (fun s: DCPack (νDepsCohsAt SB) => νFace s.2.2.2 ε t.1)
-    (chain2DownIter (νDepsCohs2At SB) (trCohsChainLen C)
-      • eq_sym (trChainPackB C))).
+    (chain2DownIter (νDepsCohs2At SB) (cohsChainLen cB)
+      • eq_sym (chainPackNF cB))).
 Qed.
 
 (** The step of the frame identification, by [νFaceEq]: every face of the
-    two frames agrees. Lift the arbitrary chain to the two equipped sides,
-    rewrite [νFace] with [pshνFace] and [νFaceTr], identify the transported
-    face with the face at the position using [descFace] and [fgFaceB], and
-    apply the current identification through [fillerEquivOfWhole]. *)
+    two frames agrees. Lift the arbitrary chain to the presheaf side and
+    rewrite [νFace] with [pshνFace]; on the original-tower side push the
+    prefix transport through [νFace] ([νFaceRewPrefix]) and compute it on
+    the resulting cell ([prefixEqRewTotal]); identify the two faces with the
+    face at the position using [descFace] and [fgFaceB]; and apply the
+    current identification through [fillerEquivOfWhole].
 
-Lemma fgFrameStep {m} {XpreA XpreB: (νSetAt m.+1).(prefix)}
-  (T: PshTower (g X) m XpreA) (rpPsh: PshTowerRestrPaintings (g X) T)
-  (SB: νSetFrom m.+1 XpreB) (HD: Desc SB)
-  (W: TrTower m.+1 XpreA XpreB) (FRT: FrtInv T SB HD W)
-  (rpTr: mkTrRestrPaintingTypes (towerTrDeps W)
-    (TopTrDep (T := towerTrDeps W) (fgThis T SB HD W FRT))
-    ((νDataAt XpreA).(restrPaintings)
-      (mkPshFiller (g X) (towerPshDeps (g X) T)))
-    ((νDataAt XpreB).(restrPaintings) (SB.(this _ _)))):
-  FrtInv (towerStep (g X) T rpPsh) (SB.(next _ _)) (DescS HD)
-    (trTowerStep W (fgThis T SB HD W FRT) rpTr).
+    The top of the arbitrary chain is retyped as [prefixDepsCohs] of the
+    stepped prefix before the transport is pushed through: the two forms
+    are convertible, but only the [prefixDepsCohs] one exposes the prefix
+    as an argument for the transport motive to abstract. *)
+
+Lemma fgFrameStep {m} {XpA XpB: (νSetAt m.+1).(prefix)}
+  (r: PrefixRel m.+1 XpA XpB)
+  (T: PshTower (g X) m XpA) (rpPsh: PshTowerRestrPaintings (g X) T)
+  (SB: νSetFrom m.+1 XpB) (HD: Desc SB) (FRT: FrtInv r T SB HD):
+  FrtInv (relStep r (fgThis r T SB HD FRT))
+    (towerStep (g X) T rpPsh) (SB.(next _ _)) (DescS HD).
 Proof.
   intros D c.
   refine (νFaceEq
@@ -444,24 +350,26 @@ Proof.
   intros p k dc c0 ε.
   destruct (pshChainLift (g X) (towerPshDepsCohs (g X) T rpPsh) c0)
     as (PC, (Cpsh, ePsh)).
-  destruct (trChainLift (trTowerDepsCohs W (fgThis T SB HD W FRT) rpTr) c0)
-    as (TC, (Ctr, eTr)).
-  pose (Hp := leR_eq_r (trCohsChainStage Ctr)
-    (leR_add_r p (trCohsChainLen Ctr))).
+  pose (Hp := leR_eq_r (cohsChainStage c0) (leR_add_r p (cohsChainLen c0))).
   refine (f_equal (fun s: {dc0: DepsCohs p k &T
       DepsCohsChain (pshDepsCohs (g X) (towerPshDepsCohs (g X) T rpPsh)) dc0}
     => νFace s.2 ε _) ePsh • _).
-  refine (_ • eq_sym (f_equal (fun s: {dc0: DepsCohs p k &T
-      DepsCohsChain (pshDepsCohs (g X) (towerPshDepsCohs (g X) T rpPsh)) dc0}
-    => νFace s.2 ε _) eTr)).
   rewrite (pshνFace (g X) Cpsh Hp ε).
-  rewrite (νFaceTr Ctr ε D).
+  change (DepsCohsChain (prefixDepsCohs
+    ((XpA; mkPshFiller (g X) (towerPshDeps (g X) T)):
+      (νSetAt m.+2).(prefix))) dc) in (type of c0).
+  rewrite (νFaceRewPrefix
+    (prefixEq (relStep r (fgThis r T SB HD FRT))) c0 ε D).
+  set (cB0 := rew [fun Xp => DepsCohsChain (prefixDepsCohs Xp) dc]
+    (prefixEq (relStep r (fgThis r T SB HD FRT))) in c0).
+  rewrite (prefixEqRewTotal (relStep r (fgThis r T SB HD FRT))
+    (νFace cB0 ε D)).
   rewrite (descTotalS HD).
   rewrite (descFace HD 0 p Hp Hp ε (D; c)).
-  rewrite (fgFaceB W SB (fgThis T SB HD W FRT) rpTr Ctr Hp ε (D; c)).
-  now exact (fillerEquivOfWhole (mkFrameEqv (towerTrDeps W)) (descTotal HD)
-    (mkPshFrame (g X) (towerPshDeps (g X) T)) FRT
-    (νFace (trCohsChainB Ctr) ε D).1 (νFace (trCohsChainB Ctr) ε D).2).
+  rewrite (fgFaceB SB cB0 Hp ε (D; c)).
+  now exact (fillerEquivOfWhole (rewEquiv νFrameDom (eq_sym (prefixEq r)))
+    (descTotal HD) (mkPshFrame (g X) (towerPshDeps (g X) T)) FRT
+    (νFace cB0 ε D).1 (νFace cB0 ε D).2).
 Qed.
 
 (** Base case of the frame identification. At level 0, the frame is
@@ -476,36 +384,34 @@ Definition frt0 (D: mkFrame (νTowerDeps (tt: (νSetAt 0).(prefix))))
   pshF0A (rew [Dom] (eq_sym (descTotal DescZ)) in
     ((D; c): ({D0: mkFrame (νTowerDeps (tt: (νSetAt 0).(prefix))) &
        X.(this _ _) D0}: HSet)))
-  = mkFrameEqv (towerTrDeps trTower0) D :=
-  hunit_ext tt (mkFrameEqv (towerTrDeps trTower0) D).
+  = rew <- [νFrameDom] (prefixEq rel0) in D :=
+  hunit_ext tt (rew <- [νFrameDom] (prefixEq rel0) in D).
 
 Definition fgThis0:
-  forall D: mkFrame (νTowerDeps (tt: (νSetAt 0).(prefix))),
-  Equiv (X.(this _ _) D)
-    (pshFiller0 (g X) (mkFrameEqv (towerTrDeps trTower0) D)) :=
-  fun D => symEquiv (fillerEquivOf (mkFrameEqv (towerTrDeps trTower0))
-    (descTotal DescZ) pshF0A frt0 D).
+  νFillerEqvType (prefixEq rel0) (pshFiller0 (g X)) (X.(this _ _)) :=
+  fun D => fillerEquivOf (rewEquiv νFrameDom (eq_sym (prefixEq rel0)))
+    (descTotal DescZ) pshF0A frt0 D.
 
 (** The level-1 base case of [fgFrameStep]. The only chain from stage 0 is
     empty, so both applications of [νFace] reduce by conversion. *)
 
 Lemma fgFrameStep0:
-  FrtInv (tower1 (g X)) (X.(next _ _)) (DescS DescZ)
-    (trTowerStep trTower0 fgThis0 tt).
+  FrtInv (relStep rel0 fgThis0) (tower1 (g X)) (X.(next _ _)) (DescS DescZ).
 Proof.
   intros D c.
-  refine (νFaceEq
-    (dcTop := trDepsCohsA (trTowerDepsCohs trTower0 fgThis0 tt)) _ _ _).
+  refine (νFaceEq (dcTop := prefixDepsCohs
+    ((tt; pshFiller0 (g X)): (νSetAt 1).(prefix))) _ _ _).
   intros p k dc c0 ε.
   destruct c0 as [|p k dc' c0'].
   2: { pose proof (cohsChainStage c0') as HS. now discriminate HS. }
-  rewrite (νFaceTr (TCTop := trTowerDepsCohs trTower0 fgThis0 tt)
-    TrCohsChainNil ε D).
+  rewrite (νFaceRewPrefixNil (prefixEq (relStep rel0 fgThis0)) ε D).
+  rewrite (prefixEqRewTotal (relStep rel0 fgThis0)
+    (νFace (dcTop := νDepsCohsAt X) DepsCohsChainNil ε D)).
   unfold νFace.
   rewrite nth_lam.
   rewrite (descTotalS DescZ).
   rewrite (descFace DescZ 0 0 leR_O leR_O ε (D; c)).
-  now exact (fillerEquivOfWhole (mkFrameEqv (towerTrDeps trTower0))
+  now exact (fillerEquivOfWhole (rewEquiv νFrameDom (eq_sym (prefixEq rel0)))
     (descTotal DescZ) pshF0A frt0
     (νFace (dcTop := νDepsCohsAt X) DepsCohsChainNil ε D).1
     (νFace (dcTop := νDepsCohsAt X) DepsCohsChainNil ε D).2).
@@ -513,46 +419,30 @@ Qed.
 
 (** The corecursion
 
-    The state is the pair of tower states with the descent witness, the
-    frame identification, and the restr-painting commutations at the
-    filler equivalence it induces; every component steps by its own step
-    lemma, and the filler equivalence is the contraction. *)
+    The state is the tower state of the presheaf side with the descent
+    witness, the prefix relation reached so far, and the frame
+    identification; every component steps by its own step lemma, and the
+    filler equivalence stored at each level is the contraction. *)
 
-CoFixpoint fgGen {m} {XpreA XpreB: (νSetAt m.+1).(prefix)}
-  (T: PshTower (g X) m XpreA) (rpPsh: PshTowerRestrPaintings (g X) T)
-  (SB: νSetFrom m.+1 XpreB) (HD: Desc SB)
-  (W: TrTower m.+1 XpreA XpreB) (FRT: FrtInv T SB HD W)
-  (rpTr: mkTrRestrPaintingTypes (towerTrDeps W)
-    (TopTrDep (T := towerTrDeps W) (fgThis T SB HD W FRT))
-    ((νDataAt XpreA).(restrPaintings)
-      (mkPshFiller (g X) (towerPshDeps (g X) T)))
-    ((νDataAt XpreB).(restrPaintings) (SB.(this _ _)))):
-  νSetFromEquiv W (pshNext (g X) m XpreA T rpPsh) SB :=
-  trCons _ _ _ W (pshNext (g X) m XpreA T rpPsh) SB
-    (fgThis T SB HD W FRT)
-    rpTr
-    (fgGen (towerStep (g X) T rpPsh) (towerStepRestrPaintings (g X) T rpPsh)
+CoFixpoint fgGen {m} {XpA XpB: (νSetAt m.+1).(prefix)}
+  (r: PrefixRel m.+1 XpA XpB)
+  (T: PshTower (g X) m XpA) (rpPsh: PshTowerRestrPaintings (g X) T)
+  (SB: νSetFrom m.+1 XpB) (HD: Desc SB) (FRT: FrtInv r T SB HD):
+  νSetFromEquiv r (pshNext (g X) m XpA T rpPsh) SB :=
+  trCons _ _ _ r (pshNext (g X) m XpA T rpPsh) SB
+    (fgThis r T SB HD FRT)
+    (fgGen (relStep r (fgThis r T SB HD FRT))
+      (towerStep (g X) T rpPsh) (towerStepRestrPaintings (g X) T rpPsh)
       (SB.(next _ _)) (DescS HD)
-      (trTowerStep W (fgThis T SB HD W FRT) rpTr)
-      (fgFrameStep T rpPsh SB HD W FRT rpTr)
-      (mkTrRestrPaintings (TopTrCohDep
-        (TC := trTowerDepsCohs W (fgThis T SB HD W FRT) rpTr)
-        (fgThis (towerStep (g X) T rpPsh) (SB.(next _ _)) (DescS HD)
-          (trTowerStep W (fgThis T SB HD W FRT) rpTr)
-          (fgFrameStep T rpPsh SB HD W FRT rpTr))))).
+      (fgFrameStep r T rpPsh SB HD FRT)).
 
-Definition fg: νSetFromEquiv trTower0 (f (g X)) X :=
-  trCons _ _ _ trTower0 (f (g X)) X
+Definition fg: νSetFromEquiv rel0 (f (g X)) X :=
+  trCons _ _ _ rel0 (f (g X)) X
     fgThis0
-    tt
-    (fgGen (tower1 (g X)) (tower1RestrPaintings (g X))
+    (fgGen (relStep rel0 fgThis0)
+      (tower1 (g X)) (tower1RestrPaintings (g X))
       (X.(next _ _)) (DescS DescZ)
-      (trTowerStep trTower0 fgThis0 tt)
-      fgFrameStep0
-      (mkTrRestrPaintings (TopTrCohDep
-        (TC := trTowerDepsCohs trTower0 fgThis0 tt)
-        (fgThis (tower1 (g X)) (X.(next _ _)) (DescS DescZ)
-          (trTowerStep trTower0 fgThis0 tt) fgFrameStep0)))).
+      fgFrameStep0).
 
 End FG.
 


### PR DESCRIPTION
# Univalence-based approach to νSet equivalence relation

## Overview

This pull request rewrites the bisimulation side of the correspondence proof — `Equiv/νSetEquiv.v` and the `fg` round trip in `Equiv/νSetRoundtrip.v` — replacing the data-carrying translation architecture with a prefix-equality architecture inspired by Alice Laroche's Agda construction. The change removes about 520 lines net; the statements of the final results are unchanged. It is a deliberate tradeoff: the round-trip witness `fg` stops being axiom-free, since this design produces the prefix equalities with univalence and functional extensionality (see the axiom table below).

In [`Bisim.agda`](https://github.com/alicelaroche/bonak-agda/blob/9655a9a30380794544a188be07327b52ca647735/src/%CE%BDSet/Bisim.agda), Alice defines the levelwise bisimulation mutually with its conversion to equality, turning each prefix equivalence into an equality through univalence as soon as it is formed; the `f ∘ g` half of [`Correspondence.agda`](https://github.com/alicelaroche/bonak-agda/blob/9655a9a30380794544a188be07327b52ca647735/src/Correspondence.agda) path-inducts on those equalities. `PrefixRel`/`prefixEq` and the transport computations of `νSetEquiv.v` below are the Rocq counterparts.

The data-carrying form of #33 had departed from this architecture: `νSetFromEquiv` carried equivalences between the two towers' frames and paintings, together with coherences stating their compatibility with the stored restriction operations, and the round trip rebuilt that translation structure at every stage of the construction.

Now `νSetEquiv.v` relates the finite prefixes of two towers levelwise by `PrefixRel` and converts each level's relation into an equality of prefixes by `prefixEq`, as soon as it is formed. The coinductive `νSetFromEquiv` then carries one filler-family equivalence per level and nothing else: all restriction and coherence data of the indexed construction is computed from the prefix, so equal prefixes transport the entire derived structure, and no compatibility fields are needed. The corecursion in `νSetRoundtrip.v` loses the translation towers and the restriction-commutation field accordingly, reasoning by transport along the prefix equalities instead.

## Axioms

Previously `fg` was closed under the global context. In this design the prefix equalities feed univalence and functional extensionality into every level of the relation, so `fg` now depends on both axioms. Since the final results assume univalence in any case, their assumptions are unchanged:

| result | assumptions |
| --- | --- |
| `f`, `g`, `gf` | none (unchanged) |
| `fg : νSetFromEquiv rel0 (f (g X)) X` | univalence and functional extensionality |
| `presheafνSetsEquiv`, `presheafEqνSets` | univalence, functional extensionality, and `νSetFromEquivEq` (unchanged) |

`νSetFromEquivEq` states the same coinductive extensionality as before, over the new form of the relation: its hypothesis now supplies one filler-family equivalence per level, over the equality of the prefixes reached so far, in place of the frame and painting equivalences with their restriction coherences.
