### PR TITLE
νDgnSet: refactoring of the coinductive closure

### DIFF
--- a/theories/νSet/νDgnSet.v
+++ b/theories/νSet/νDgnSet.v
@@ -2504,24 +2504,24 @@ Fixpoint νDgnSetAt n: νDgnSet n (νSetAt n) :=
   | n.+1 => mkνDgnSetSn (νSetAt n) (νDgnSetAt n)
   end.
 
-CoInductive νDgnSetFrom n
-  (X: (νSetAt n).(prefix))
-  (M: νSetFrom n X)
-  (R: (νDgnSetAt n).(dgnPrefix) (X; this n X M)): Type := dcons {
-  dgnL: dgnHasReflFromData
-    ((νSetAt n).(data) X)
-    (this n X M)
-    (this n.+1 (X; this n X M) (next n X M))
-    ((νDgnSetAt n).(dgnData) (X; this n X M) R);
-  dgnCohL: dgnCohLFromData
-    ((νSetAt n).(data) X)
-    (this n X M)
-    (this n.+1 (X; this n X M) (next n X M))
-    ((νDgnSetAt n).(dgnData) (X; this n X M) R) dgnL;
-  dgnNext: νDgnSetFrom n.+1 (X; this n X M) (next n X M) (R; (dgnL; dgnCohL));
+(** A νSet prefix paired with the degeneracy prefix over it. *)
+Definition DgnPrefix (l: nat): Type :=
+  { X: (νSetAt l.+1).(prefix) &T (νDgnSetAt l).(dgnPrefix) X }.
+
+CoInductive νDgnSetsFrom n (Y: DgnPrefix n): Type := dgncons {
+  dgnFiller: mkFrame
+    (toDepsRestr ((νSetAt n.+1).(data) Y.1).(restrFrames)) -> HSet;
+  dgnReflL: dgnHasReflFromData
+    ((νSetAt n).(data) Y.1.1) Y.1.2 dgnFiller
+    ((νDgnSetAt n).(dgnData) Y.1 Y.2);
+  dgnReflCohL: dgnCohLFromData
+    ((νSetAt n).(data) Y.1.1) Y.1.2 dgnFiller
+    ((νDgnSetAt n).(dgnData) Y.1 Y.2) dgnReflL;
+  dgnNext: νDgnSetsFrom n.+1
+    ((Y.1; dgnFiller); (Y.2; (dgnReflL; dgnReflCohL)));
 }.
 
-Definition νDgnSets (X: νSets) := νDgnSetFrom 0 tt X tt.
+Definition νDgnSets := { Y: DgnPrefix 0 &T νDgnSetsFrom 0 Y }.
 
 End νDgnSet.
 
@@ -2532,9 +2532,9 @@ Definition Simplicial := νDgnSetSimplicial.νDgnSets.
 Definition Cubical := νDgnSetCubical.νDgnSets.
 
 Example Simplicial1 :=
-  Eval lazy -[leR] in (νDgnSetSimplicial.νDgnSetAt 1).(νDgnSetSimplicial.dgnPrefix).
+  Eval lazy -[leR] in νDgnSetSimplicial.DgnPrefix 1.
 
 Example Cubical1 :=
-  Eval lazy -[leR] in (νDgnSetCubical.νDgnSetAt 1).(νDgnSetCubical.dgnPrefix).
+  Eval lazy -[leR] in νDgnSetCubical.DgnPrefix 1.
 
 Print Cubical1.


### PR DESCRIPTION
## Overview

This PR changes how the degeneracy tower of `νDgnSet.v` is closed at infinity. The finite telescope (`νDgnSetAt` and everything before it) is untouched; only the coinductive closure, the total object, and the printed examples change.

The motivation comes from the correspondence between the indexed and fibred presentations ([#33](https://github.com/artagnon/bonak/pull/33)). Its follow-up discussion envisages extending the correspondence to degeneracies, relating `νDgnSets` as a standalone type — a cubical (or simplicial) set packaged with its degeneracies as one object — to its fibred counterpart `PresheafDgns`. The combined coinductive closure implemented here provides that standalone type. It also eases the equality reasoning such a correspondence needs: with a closure fibered over the coinductive νSet tower, any equality or bisimulation principle must first equalize the underlying towers and then transport the degeneracy tower along that path, whereas every stage of the combined telescope is finite telescope data, to which such principles apply directly.

Previously, `CoInductive νDgnSetFrom n X M R` was fibered over the coinductive νSet tower `M: νSetFrom n X`: every field went through `M`'s destructors `this`/`next`, and the total object `νDgnSets X` equipped a separately supplied tower `X: νSets` with degeneracies.

Now the tower closes over the combined telescope. A stage

```coq
Definition DgnPrefix (l: nat): Type :=
  { X: (νSetAt l.+1).(prefix) &T (νDgnSetAt l).(dgnPrefix) X }.
```

pairs a νSet prefix with the degeneracy prefix over it, and `νDgnSetsFrom n (Y: DgnPrefix n)` produces the next νSet filler as its own field (`dgnFiller`) alongside the degeneracy data (`dgnReflL`, `dgnReflCohL`), so `dgnNext`'s index is the literally extended telescope and no coinductive value occurs in the stage data. The total object

```coq
Definition νDgnSets := { Y: DgnPrefix 0 &T νDgnSetsFrom 0 Y }.
```

is self-contained: a ν-set together with its degeneracies as one object. Accordingly, `Simplicial` and `Cubical` are now closed types rather than structures over a given tower, and the `Simplicial1`/`Cubical1` examples evaluate the closed type `DgnPrefix 1` — the level-2 νSet prefix paired with the degeneracy prefix over it — in the same way `SemiSimplicial4` in `νSet.v` evaluates a closed prefix type.
