### PR TITLE
Indexed-fibred correspondence for `νDgnSets`

### DIFF
--- a/theories/Equiv/Correspondence.v
+++ b/theories/Equiv/Correspondence.v
@@ -15,18 +15,18 @@
 
 Set Warnings "-notation-overridden".
 From Bonak Require Import HSet Notation νSet.Layer Univalence
-  νSet Face PresheafEquiv νSetOfPresheaf PresheafOfνSet
-  νSetRoundtrip PresheafRoundtrip Limit.
+  νSet Face Equiv.PresheafEquiv Equiv.νSetOfPresheaf Equiv.PresheafOfνSet
+  Equiv.νSetRoundtrip Equiv.PresheafRoundtrip Limit.
 From Bonak.Lib Require Import Equiv.
 
 Set Primitive Projections.
 Set Printing Projections.
 Set Keyed Unification.
 
-Module Correspondence (A: LayerSig).
+Module CorrespondenceOn (A: LayerSig) (S: νSetSig A).
 Import A.
 
-Module Export PresheafRoundtrip := PresheafRoundtrip.PresheafRoundtrip A.
+Module Export PresheafRoundtrip := PresheafRoundtrip.PresheafRoundtripOn A S.
 
 (** Extensionality for the ν-set tower
 
@@ -48,6 +48,11 @@ Definition presheafνSetsEquiv: Equiv Presheaf νSets :=
 
 Definition presheafEqνSets: Presheaf = νSets := ua presheafνSetsEquiv.
 
+End CorrespondenceOn.
+
+Module Correspondence (A: LayerSig).
+Module Base := νSet.νSet A.
+Include CorrespondenceOn A Base.
 End Correspondence.
 
 Module CorrespondenceSimplicial := Correspondence SimplicialLayer.

--- a/theories/Equiv/Dgn/Correspondence.v
+++ b/theories/Equiv/Dgn/Correspondence.v
@@ -1,0 +1,28 @@
+(** The indexed and presheaf presentations of sets with degeneracies agree.
+    As for νSets, the two constructions preserve the operations, their
+    round trips give an equivalence, and univalence gives a type equality. *)
+
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT νSet.Layer Univalence Equiv.Dgn.νDgnSetRoundtrip.
+From Bonak.Lib Require Import Equiv.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module Correspondence (A: LayerSig).
+Module Export Roundtrip := Bonak.Equiv.Dgn.νDgnSetRoundtrip.νDgnSetRoundtrip A.
+
+Definition νDgnSetsPresheafEquiv:
+  Equiv νDgnSets {psh: PshEq.Psh.Presheaf &T PresheafDgn psh} :=
+  qinvEquiv g (fun P => f P.1 P.2) fg
+    (fun P => gfEq P.1 P.2).
+
+Definition νDgnSetsEqPresheaf:
+  νDgnSets = {psh: PshEq.Psh.Presheaf &T PresheafDgn psh} :=
+  ua νDgnSetsPresheafEquiv.
+
+End Correspondence.
+
+Module CorrespondenceSimplicial := Correspondence SimplicialLayer.
+Module CorrespondenceCubical := Correspondence CubicalLayer.

--- a/theories/Equiv/Dgn/PresheafEquiv.v
+++ b/theories/Equiv/Dgn/PresheafEquiv.v
@@ -1,0 +1,107 @@
+(** Equality of presheaves equipped with degeneracies. *)
+
+Import Logic.EqNotations.
+
+Set Warnings "-notation-overridden".
+From Stdlib Require Import Logic.FunctionalExtensionality.
+From Bonak Require Import SigT RewLemmas HSet LeSProp Notation νSet.Layer
+  Funext Univalence Equiv.PresheafEquiv.
+From Bonak.Lib Require Import Equiv.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module Type PshEqSig (A: LayerSig).
+Include Bonak.Equiv.PresheafEquiv.PresheafEquiv A.
+End PshEqSig.
+
+Module PresheafEquivOn (A: LayerSig) (E: PshEqSig A).
+Import A.
+
+Module Export PshEq := E.
+
+Definition Presheaf: Type := { psh: PshEq.Psh.Presheaf &T PresheafDgn psh }.
+
+Record PresheafEquiv (X Y: Presheaf) := {
+  underlyingEquiv: PshEq.PresheafEquiv X.1 Y.1;
+  DgnEquiv n i (Hi: i <= n) (x: X.1.(F0) n):
+    underlyingEquiv.(F0Equiv _ _) n.+1 (X.2.(Dgn _) n i Hi x) =
+    Y.2.(Dgn _) n i Hi (underlyingEquiv.(F0Equiv _ _) n x)
+}.
+
+Lemma structureEqIntro {psh: PshEq.Psh.Presheaf} (R S: PresheafDgn psh)
+  (e: R.(Dgn _) = S.(Dgn _)): R = S.
+Proof.
+  destruct R as [d ri rid rs rr], S as [d' si sid ss sr]; cbn in e.
+  destruct e.
+  f_equal;
+    repeat first [apply functional_extensionality_dep_good; intro
+                 |apply spropFunext; intro];
+    apply (psh.(F0) _).(UIP).
+Qed.
+
+Lemma presheafEqIntro (X Y: Presheaf)
+  (e0: X.1.(F0) = Y.1.(F0))
+  (ef: rew [fun F: nat -> HSet =>
+         forall n i (Hi: i <= n) (ε: arity), F n.+1 -> F n] e0 in
+       X.1.(Face) = Y.1.(Face))
+  (ed: rew [fun F: nat -> HSet =>
+         forall n i (Hi: i <= n), F n -> F n.+1] e0 in
+       X.2.(Dgn _) = Y.2.(Dgn _)): X = Y.
+Proof.
+  destruct X as [[F f c] R], Y as [[F' f' c'] S]; cbn in e0, ef, ed.
+  destruct e0; cbn in ef, ed. destruct ef.
+  assert (ec: c = c').
+  { repeat first [apply functional_extensionality_dep_good; intro
+                 |apply spropFunext; intro].
+    apply (F _).(UIP). }
+  destruct ec.
+  now destruct (structureEqIntro R S ed).
+Qed.
+
+Lemma rew_dgn_app {F G: nat -> HSet} (e: F = G)
+  (d: forall n i (Hi: i <= n), F n -> F n.+1)
+  n i (Hi: i <= n) (x: G n):
+  (rew [fun F: nat -> HSet =>
+     forall n i (Hi: i <= n), F n -> F n.+1] e in d) n i Hi x =
+  rew [fun F: nat -> HSet => (F n.+1).(Dom)] e in
+    d n i Hi (rew <- [fun F: nat -> HSet => (F n).(Dom)] e in x).
+Proof.
+  now destruct e.
+Qed.
+
+Lemma presheafEquivEq {X Y: Presheaf} (E: PresheafEquiv X Y):
+  X = Y.
+Proof.
+  pose (e := E.(underlyingEquiv _ _)).
+  apply (presheafEqIntro X Y
+    (functional_extensionality_dep_good _ _
+      (fun n => hsetEq (e.(F0Equiv _ _) n)))).
+  - exact (PshEq.presheafFaceEquivEq e).
+  - apply functional_extensionality_dep_good; intro n.
+    apply functional_extensionality_dep_good; intro i.
+    apply spropFunext; intro Hi.
+    apply functional_extensionality_dep_good; intro y.
+    rewrite rew_dgn_app.
+    unfold eq_rect_r.
+    rewrite (rew_map (fun h: HSet => h.(Dom)) (fun F: nat -> HSet => F n.+1)).
+    rewrite (rew_map (fun h: HSet => h.(Dom)) (fun F: nat -> HSet => F n)).
+    rewrite <- eq_sym_f_equal.
+    rewrite 2 funExtBetaHSet.
+    cbv beta.
+    rewrite hsetEqRew, hsetEqRewSym.
+    refine (E.(DgnEquiv _ _) n i Hi (invEq (e.(F0Equiv _ _) n) y) • _).
+    now exact (f_equal (Y.2.(Dgn _) n i Hi)
+      (secEq (e.(F0Equiv _ _) n) y)).
+Qed.
+
+End PresheafEquivOn.
+
+Module PresheafEquiv (A: LayerSig).
+Module Base := Bonak.Equiv.PresheafEquiv.PresheafEquiv A.
+Include PresheafEquivOn A Base.
+End PresheafEquiv.
+
+Module PresheafEquivSimplicial := PresheafEquiv SimplicialLayer.
+Module PresheafEquivCubical := PresheafEquiv CubicalLayer.

--- a/theories/Equiv/Dgn/PresheafOfνDgnSet.v
+++ b/theories/Equiv/Dgn/PresheafOfνDgnSet.v
@@ -1,0 +1,384 @@
+(** Cells, faces, and degeneracy maps read from the combined tower. *)
+
+Import Logic.EqNotations.
+
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT HSet LeSProp NatLemmas Notation νSet.Layer
+  νDgnSet Equiv.PresheafOfνSet Equiv.PresheafRoundtrip Equiv.Dgn.PresheafEquiv Limit.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module PresheafOfνDgnSet (A: LayerSig).
+Import A.
+
+Module Export DgnSet := νDgnSet.νDgnSet A.
+Module Export SetRoundtrip := Bonak.Equiv.PresheafRoundtrip.PresheafRoundtripOn A DgnSet.νSet.
+Module PshOfSet := SetRoundtrip.νSetRoundtrip.PresheafOfνSet.
+Module Export PshEquiv := Bonak.Equiv.Dgn.PresheafEquiv.PresheafEquivOn A
+  PshOfSet.νSetOfPresheaf.PshEq.
+
+Definition DgnPosition n: Type := {Y: DgnPrefix n &T νDgnSetsFrom n Y}.
+
+Definition dgnPositionNext n (s: DgnPosition n): DgnPosition n.+1 :=
+  (dgnExtend s.1 (this s.2); next s.2).
+
+Definition dgnPositionTotal n (s: DgnPosition n): HSet :=
+  {D: νFrame s.1.1 & (this s.2).1 D}.
+
+Definition dgnPositionCohs2 n (s: DgnPosition n): DepsCohs2 n 0 :=
+  dgnDepsCohs2 (νDataAt s.1.1) (this s.2).1 (this (next s.2)).1.
+
+Definition dgnPositionDeps n (s: DgnPosition n): DepsReflCohsSup n 0 :=
+  dgnDepsReflCohsSupFromData (νDataAt s.1.1)
+    (this s.2).1 (this (next s.2)).1
+    ((νDgnSetAt n).(dgnStepData) s.1.1 s.1.2 (this s.2).1 (this s.2).2).
+
+Definition dgnPositionMap n (s: DgnPosition n) i (Hi: i <= n)
+  (x: dgnPositionTotal n s): dgnPositionTotal n.+1 (dgnPositionNext n s) :=
+  (mkReflFrameAbove (dgnPositionDeps n s) (n - i) (sub_leR n i) x.1 x.2;
+   (this (next s.2)).2.1 (n - i) (sub_leR n i) x.1 x.2).
+
+Definition νDgnPack (m: nat) (X: νDgnSets): DgnPosition m := limitPack m X.
+
+(** Unfolding the tower gives prefixes whose bonding equations reduce to
+    reflexivity. The underlying νSet tower therefore has the same fillers
+    by conversion, including after taking [next]. *)
+
+Definition underlyingFrom (X: νDgnSets) (m: nat):
+  νSetFrom m (νDgnPack m X).1.1 :=
+  ofChain (T := νSetTel) (fun l => (νDgnPack l X).1.1)
+    (fun _ => eq_refl) m.
+
+Definition dgnF0 (X: νDgnSets) (n: nat): HSet :=
+  νTotal (underlyingFrom X n).
+
+Definition dgnFace (X: νDgnSets) n i (Hi: i <= n) (ε: arity):
+  dgnF0 X n.+1 -> dgnF0 X n :=
+  νFaceFuel (underlyingFrom X n) (n - i) ε.
+
+Definition underlyingPresheaf (X: νDgnSets): PshEq.Psh.Presheaf := {|
+  F0 := dgnF0 X;
+  Face := dgnFace X;
+  FaceCoh := fun n q Hq r Hr ε ω d =>
+    νFaceFuelCoh (underlyingFrom X n) q Hq r Hr ε ω d;
+|}.
+
+Definition dgnDataAt (X: νDgnSets) n:
+  DgnData (νDataAt (νDgnPack n X).1.1) (this (νDgnPack n X).2).1 :=
+  (νDgnSetAt n).(dgnStepData) (νDgnPack n X).1.1
+    (νDgnPack n X).1.2 (this (νDgnPack n X).2).1
+    (this (νDgnPack n X).2).2.
+
+Definition faceDown {p k} (dc2: DepsCohs2 p k) (fuel: nat) (ε: arity)
+  (d: mkFrame (mkDepsRestr (depsCohs := dc2.(_depsCohs)))) :=
+  νFace (dc2PackDeps (chain2Down dc2 fuel)).2.2.2 ε d.
+
+Definition dgnPositionFace n (s: DgnPosition n) i (Hi: i <= n) (ε: arity)
+  (x: dgnPositionTotal n.+1 (dgnPositionNext n s)): dgnPositionTotal n s :=
+  faceDown (dgnPositionCohs2 n s) (n - i) ε x.1.
+
+Lemma faceDownStep {p k} (dc2: DepsCohs2 p.+1 k) fuel (ε: arity)
+  (d: mkFrame (mkDepsRestr (depsCohs := dc2.(_depsCohs)))):
+  faceDown dc2 fuel.+1 ε d =
+  let y := faceDown (proj1DepsCohs2 dc2) fuel ε d.1 in
+  ((y.1; y.2.1); y.2.2).
+Proof.
+  unfold faceDown.
+  replace fuel.+1 with (fuel + 1) by
+    now rewrite <- plus_n_Sm, <- plus_n_O.
+  rewrite (chain2DownCat dc2 1 fuel).
+  unfold chain2Cat, dc2PackDeps.
+  cbn [projT1 projT2].
+  rewrite cohs2ChainDepsCohsCompose, νFaceCompose.
+  reflexivity.
+Qed.
+
+Lemma faceDownEq {p k} (dc2: DepsCohs2 p k)
+  (d d': mkFrame (mkDepsRestr (depsCohs := dc2.(_depsCohs))))
+  (H: forall i, i <= p -> forall ε,
+    faceDown dc2 i ε d = faceDown dc2 i ε d'): d = d'.
+Proof.
+  revert k dc2 d d' H; induction p; intros k dc2 d d' H.
+  all: apply (frameEqStep DepsCohsChainNil d d' (H 0 leR_O)).
+  - exact (hunit_ext _ _).
+  - apply (IHp _ (proj1DepsCohs2 dc2)). intros i Hi ε.
+    pose proof (H i.+1 (⇑ Hi) ε) as e.
+    rewrite 2 faceDownStep in e.
+    exact (getPaintingEq (ExtChainCons ExtChainNil) _ _ _ _ e).
+Qed.
+
+Definition dgnDepsAt (X: νDgnSets) n: DepsReflCohsSup n 0 :=
+  dgnDepsReflCohsSupFromData _ _ (this (νDgnPack n.+1 X).2).1 (dgnDataAt X n).
+
+Definition dgnDeps2At (X: νDgnSets) n: DepsReflCohs2 n 0 :=
+  dgnDepsReflCohs2FromData _ _ _ (this (νDgnPack n.+2 X).2).1
+    (dgnDataAt X n) (this (νDgnPack n.+1 X).2).2.1
+    (this (νDgnPack n.+1 X).2).2.2.
+
+Lemma faceDownAboveId {p k} (deps: DepsReflCohsSup p k)
+  i (Hi: i <= p) (ε: arity)
+  (d: mkFrame (RestrOfReflCohsSup deps))
+  (c: mkPainting (RestrExtOfReflCohsSup deps) d):
+  faceDown (Cohs2OfReflCohsSup deps) i ε (mkReflFrameAbove deps i Hi d c) =
+  (d; c).
+Proof.
+  revert p k deps Hi d c; induction i; intros p k deps Hi d c.
+  - unfold faceDown, mkReflFrameAbove, mkReflFramesAbove,
+      mkReflFramesAboveOf0AndS, mkReflFrameAboveOf0AndS.
+    cbn [projT2].
+    unfold mkReflFrameAbove0, mkReflLayerAbove0.
+    cbn [chain2Down dc2PackDeps νFace cohsChainExt cohsChainNext
+      getFrame getPainting projT1 projT2].
+    rewrite nth_lam.
+    symmetry.
+    exact (eq_existT_curried
+      (mkIdRestrReflFrameBelow deps.(_depsReflCohsInf) 0 leR_O ε d) eq_refl).
+  - destruct p; [now destruct (leR_O_contra Hi) |].
+    rewrite faceDownStep.
+    change
+      ((let y := faceDown (Cohs2OfReflCohsSup deps.(1)%depsreflcohssup) i ε
+          (mkReflFrameAbove deps.(1)%depsreflcohssup i Hi d.1 (d.2; c)) in
+        (((y.1; y.2.1); y.2.2):
+          {d': mkFrame (RestrOfReflCohsSup deps) &T
+            mkPainting (RestrExtOfReflCohsSup deps) d'})) = (d; c)).
+    now rewrite IHi.
+Qed.
+
+Definition aboveTotal {p k} (deps: DepsReflCohsSup p k)
+  (extra: DepsReflCohsSupExtension p k deps) i (Hi: i <= p)
+  (d: mkFrame (RestrOfReflCohsSup deps))
+  (c: mkPainting (RestrExtOfReflCohsSup deps) d):
+  {d': mkFrame (mkDepsRestr (depsCohs := CohsOfReflCohsSup deps)) &T
+    mkPainting (mkExtraDeps (CohsExtOfReflCohsSup deps)) d'} :=
+  (mkReflFrameAbove deps i Hi d c; mkReflPaintingAbove deps extra i Hi d c).
+
+Lemma aboveTotalStep {p k} (deps: DepsReflCohsSup p.+1 k)
+  (extra: DepsReflCohsSupExtension p.+1 k deps) i (Hi: i <= p)
+  (d: mkFrame (RestrOfReflCohsSup deps))
+  (c: mkPainting (RestrExtOfReflCohsSup deps) d):
+  aboveTotal deps extra i.+1 (⇑ Hi) d c =
+  let y := aboveTotal deps.(1)%depsreflcohssup (AddReflCohSupDep deps extra)
+    i Hi d.1 (d.2; c) in
+  ((y.1; y.2.1); y.2.2).
+Proof.
+  reflexivity.
+Qed.
+
+Lemma faceDownAboveSup {p k} (deps: DepsReflCohs2 p k)
+  q i (Hq: q <= i) (Hi: i <= p) (ε: arity)
+  (d: mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps)))
+  (c: mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) d):
+  faceDown (Cohs2OfReflCohsSup (mkDepsReflCohsSup deps)) q ε
+    (mkReflFrameAbove (mkDepsReflCohsSup deps) i.+1 (⇑ Hi) d c) =
+  let y := faceDown (Cohs2OfReflCohsSup deps.(_depsReflCohsSup)) q ε d in
+  aboveTotal deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) i Hi y.1 y.2.
+Proof.
+  revert p k deps i Hq Hi d c; induction q; intros p k deps i Hq Hi d c.
+  - unfold faceDown, aboveTotal.
+    cbn [chain2Down dc2PackDeps νFace cohsChainExt cohsChainNext
+      getFrame getPainting projT1 projT2].
+    unfold mkReflFrameAbove, mkReflFramesAbove, mkReflFramesAboveOf0AndS,
+      mkReflFrameAboveOf0AndS.
+    cbn [projT2].
+    unfold mkReflFramesAboveS.
+    cbn [mkCohReflRestrFrameAboveSupTypesAndReflFramesAbove
+      ReflFramesAboveSDef mkReflLayerAbove projT1 projT2].
+    rewrite nth_lam.
+    symmetry.
+    exact (eq_existT_curried
+      ((mkCohReflRestrFramesAboveSup deps).2 i 0 Hi leR_O ε d.1 (d.2; c))
+      eq_refl).
+  - destruct i; [now destruct (leR_O_contra Hq) |].
+    destruct p; [now destruct (leR_O_contra Hi) |].
+    rewrite 2 faceDownStep.
+    cbv zeta.
+    rewrite (aboveTotalStep deps.(_depsReflCohsSup)
+      deps.(_extraDepsReflCohsSup) i (⇓ Hi)).
+    exact (f_equal
+      (fun y:
+        {d': mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps.(1)%depsreflcohs2)) &T
+          mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)%depsreflcohs2)) d'} =>
+        (((y.1; y.2.1); y.2.2):
+          {d': mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) &T
+            mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) d'}))
+      (IHq _ _ deps.(1)%depsreflcohs2 i Hq Hi d.1 (d.2; c))).
+Qed.
+
+Definition belowPair {p k} (deps: DepsReflCohsSup p k)
+  (extra: DepsReflCohsSupExtension p k deps) i (Hi: i <= k)
+  (d: mkFrame (RestrOfReflCohsSup deps))
+  (c: mkPainting (RestrExtOfReflCohsSup deps) d):
+  {d': mkFrame (mkDepsRestr (depsCohs := CohsOfReflCohsSup deps)).(1) &T
+    mkPainting (AddRestrDep _ (mkExtraDeps (CohsExtOfReflCohsSup deps))) d'} :=
+  (mkReflFrameBelow deps.(_depsReflCohsInf) i Hi d;
+   mkReflPaintingBelow deps extra i Hi d c).
+
+Lemma belowPairStep {p k} (deps: DepsReflCohsSup p.+1 k)
+  (extra: DepsReflCohsSupExtension p.+1 k deps) i (Hi: i <= k)
+  (d: mkFrame (RestrOfReflCohsSup deps))
+  (c: mkPainting (RestrExtOfReflCohsSup deps) d):
+  belowPair deps extra i Hi d c =
+  let y := belowPair deps.(1)%depsreflcohssup (AddReflCohSupDep deps extra)
+    i.+1 (⇑ Hi) d.1 (d.2; c) in
+  ((y.1; y.2.1); y.2.2).
+Proof.
+  reflexivity.
+Qed.
+
+Lemma faceDownBelowInf {p k} (deps: DepsReflCohs2 p k)
+  q (Hq: q <= p) i (Hi: i <= k) (ε: arity)
+  (d: mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps))):
+  faceDown (Cohs2OfReflCohsSup (mkDepsReflCohsSup deps)).(1) q ε
+    (mkReflFrameBelow (mkDepsReflCohsSup deps).(_depsReflCohsInf) i Hi d) =
+  let y := faceDown (Cohs2OfReflCohsSup deps.(_depsReflCohsSup)) q ε d in
+  belowPair deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup) i Hi y.1 y.2.
+Proof.
+  revert p k deps Hq i Hi d; induction q; intros p k deps Hq i Hi d.
+  - unfold faceDown, belowPair.
+    cbn [chain2Down dc2PackDeps νFace cohsChainExt cohsChainNext
+      getFrame getPainting projT1 projT2].
+    unfold mkReflFrameBelow, mkReflFramesBelow.
+    cbn [mkCohReflRestrFrameBelowInfTypesAndReflFramesBelow
+      ReflFramesBelowDef mkReflLayerBelow projT1 projT2].
+    rewrite nth_lmap.
+    symmetry.
+    exact (eq_existT_curried
+      ((mkCohReflRestrFramesBelowInf deps).2 i 0 Hi leR_O ε d.1)
+      eq_refl).
+  - destruct p; [now destruct (leR_O_contra Hq) |].
+    rewrite 2 faceDownStep. cbv zeta.
+    rewrite (belowPairStep deps.(_depsReflCohsSup)
+      deps.(_extraDepsReflCohsSup) i Hi).
+    exact (f_equal
+      (fun y:
+        {d': mkFrame (mkDepsRestr (depsCohs :=
+          CohsOfReflCohsSup deps.(_depsReflCohsSup).(1)%depsreflcohssup)).(1) &T
+          mkPainting (AddRestrDep _ (mkExtraDeps (CohsExtOfReflCohsSup
+            deps.(_depsReflCohsSup).(1)%depsreflcohssup))) d'} =>
+        (((y.1; y.2.1); y.2.2):
+          {d': mkFrame (mkDepsRestr (depsCohs :=
+            CohsOfReflCohsSup deps.(_depsReflCohsSup))).(1) &T
+            mkPainting (AddRestrDep _ (mkExtraDeps (CohsExtOfReflCohsSup
+              deps.(_depsReflCohsSup)))) d'}))
+      (IHq _ _ deps.(1)%depsreflcohs2 Hq i.+1 (⇑ Hi) d.1)).
+Qed.
+
+Lemma faceDownAboveInf {p k} (deps: DepsReflCohs2 p k)
+  q i (Hi: i <= q) (Hq: q <= p) (ε: arity)
+  (d: mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps)))
+  (c: mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) d):
+  faceDown (Cohs2OfReflCohsSup (mkDepsReflCohsSup deps)) q.+1 ε
+    (mkReflFrameAbove (mkDepsReflCohsSup deps) i (Hi ↕ (↑ Hq)) d c) =
+  let y := faceDown (Cohs2OfReflCohsSup deps.(_depsReflCohsSup)) q ε d in
+  aboveTotal deps.(_depsReflCohsSup) deps.(_extraDepsReflCohsSup)
+    i (Hi ↕ Hq) y.1 y.2.
+Proof.
+  revert p k deps q Hi Hq d c; induction i; intros p k deps q Hi Hq d c.
+  - rewrite faceDownStep.
+    exact (f_equal
+      (fun y:
+        {d': mkFrame (mkDepsRestr (depsCohs :=
+          CohsOfReflCohsSup deps.(_depsReflCohsSup))).(1) &T
+          mkPainting (AddRestrDep _ (mkExtraDeps (CohsExtOfReflCohsSup
+            deps.(_depsReflCohsSup)))) d'} =>
+        (((y.1; y.2.1); y.2.2):
+          {d': mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) &T
+            mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) d'}))
+      (faceDownBelowInf deps q Hq 0 leR_O ε d)).
+  - destruct q; [now destruct (leR_O_contra Hi) |].
+    destruct p; [now destruct (leR_O_contra Hq) |].
+    rewrite faceDownStep.
+    rewrite (faceDownStep (Cohs2OfReflCohsSup deps.(_depsReflCohsSup)) q ε d).
+    cbv zeta.
+    rewrite (aboveTotalStep deps.(_depsReflCohsSup)
+      deps.(_extraDepsReflCohsSup) i (Hi ↕ Hq)).
+    exact (f_equal
+      (fun y:
+        {d': mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps.(1)%depsreflcohs2)) &T
+          mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps.(1)%depsreflcohs2)) d'} =>
+        (((y.1; y.2.1); y.2.2):
+          {d': mkFrame (RestrOfReflCohsSup (mkDepsReflCohsSup deps)) &T
+            mkPainting (RestrExtOfReflCohsSup (mkDepsReflCohsSup deps)) d'}))
+      (IHi _ _ deps.(1)%depsreflcohs2 q Hi Hq d.1 (d.2; c))).
+Qed.
+
+(** The Above operation counts down from the last dimension, so the
+    presheaf index [i] corresponds to [n - i]. *)
+
+Definition dgnAbove (X: νDgnSets) n i (Hi: i <= n)
+  (x: dgnF0 X n): dgnF0 X n.+1 :=
+  (mkReflFrameAbove (dgnDepsAt X n) i Hi x.1 x.2;
+   (this (νDgnPack n.+1 X).2).2.1 i Hi x.1 x.2).
+
+Definition dgnMap (X: νDgnSets) n i (Hi: i <= n):
+  dgnF0 X n -> dgnF0 X n.+1 :=
+  dgnAbove X n (n - i) (sub_leR n i).
+
+Lemma dgnFaceDgnId (X: νDgnSets) n i (Hi: i <= n) (ε: arity)
+  (x: dgnF0 X n):
+  dgnFace X n i Hi ε (dgnMap X n i Hi x) = x.
+Proof.
+  exact (faceDownAboveId (dgnDepsAt X n) (n - i) (sub_leR n i) ε x.1 x.2).
+Qed.
+
+Lemma dgnFaceDgnSup (X: νDgnSets) n i (Hi: i <= n) j (Hj: j <= i)
+  (ε: arity) (x: dgnF0 X n.+1):
+  dgnFace X n.+1 i.+1 (⇑ Hi) ε
+    (dgnMap X n.+1 j (Hj ↕ (↑ Hi)) x) =
+  dgnMap X n j (Hj ↕ Hi) (dgnFace X n i Hi ε x).
+Proof.
+  unfold dgnMap.
+  generalize (sub_leR n.+1 j).
+  rewrite (subSuccL (Hj ↕ Hi)). intro Hj'.
+  exact (faceDownAboveSup (dgnDeps2At X n) (n - i) (n - j)
+    (subAntitone Hj) (sub_leR n j) ε x.1 x.2).
+Qed.
+
+Lemma dgnFaceDgnInf (X: νDgnSets) n i j (Hij: i <= j) (Hj: j <= n)
+  (ε: arity) (x: dgnF0 X n.+1):
+  dgnFace X n.+1 i (Hij ↕ (↑ Hj)) ε
+    (dgnMap X n.+1 j.+1 (⇑ Hj) x) =
+  dgnMap X n j Hj (dgnFace X n i (Hij ↕ Hj) ε x).
+Proof.
+  unfold dgnFace, νFaceFuel.
+  rewrite (subSuccL (Hij ↕ Hj)).
+  exact (faceDownAboveInf (dgnDeps2At X n) (n - i) (n - j)
+    (subAntitone Hij) (sub_leR n i) ε x.1 x.2).
+Qed.
+
+Lemma dgnAboveAbove (X: νDgnSets) n q r (Hq: q <= r) (Hr: r <= n)
+  (x: dgnF0 X n):
+  dgnAbove X n.+1 r.+1 (⇑ Hr) (dgnAbove X n q (Hq ↕ Hr) x) =
+  dgnAbove X n.+1 q (Hq ↕ (↑ Hr)) (dgnAbove X n r Hr x).
+Proof.
+  apply (eq_existT_curried
+    (((dgnDataAt X n.+1).(dgnDataCore).(cohReflAboveAboveFrames)
+      (this (νDgnPack n.+2 X).2).1).2 q r Hq Hr x.1 x.2)).
+  exact (((this (νDgnPack n.+2 X).2).2.2).2 q r Hq Hr x.1 x.2).
+Qed.
+
+Lemma dgnMapDgnMap (X: νDgnSets) n j i (Hji: j <= i) (Hi: i <= n)
+  (x: dgnF0 X n):
+  dgnMap X n.+1 j (Hji ↕ (↑ Hi)) (dgnMap X n i Hi x) =
+  dgnMap X n.+1 i.+1 (⇑ Hi) (dgnMap X n j (Hji ↕ Hi) x).
+Proof.
+  unfold dgnMap.
+  generalize (sub_leR n.+1 j).
+  rewrite (subSuccL (Hji ↕ Hi)). intro Hj.
+  exact (dgnAboveAbove X n (n - i) (n - j)
+    (subAntitone Hji) (sub_leR n j) x).
+Qed.
+
+Definition gStructure (X: νDgnSets): PresheafDgn (underlyingPresheaf X) :=
+  Build_PresheafDgn (underlyingPresheaf X) (dgnMap X)
+    (dgnFaceDgnInf X) (dgnFaceDgnId X) (dgnFaceDgnSup X) (dgnMapDgnMap X).
+
+Definition g (X: νDgnSets): Presheaf :=
+  (underlyingPresheaf X; gStructure X).
+
+End PresheafOfνDgnSet.
+
+Module PresheafOfνDgnSetSimplicial := PresheafOfνDgnSet SimplicialLayer.
+Module PresheafOfνDgnSetCubical := PresheafOfνDgnSet CubicalLayer.

--- a/theories/Equiv/Dgn/PresheafRoundtrip.v
+++ b/theories/Equiv/Dgn/PresheafRoundtrip.v
@@ -1,0 +1,98 @@
+(** Recovering a presheaf with degeneracies from its indexed construction. *)
+
+Import Logic.EqNotations.
+
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT HSet LeSProp NatLemmas Notation νSet.Layer
+  Equiv.Dgn.νDgnSetOfPresheaf Limit.
+From Bonak.Lib Require Import Equiv.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module PresheafRoundtrip (A: LayerSig).
+Import A.
+Module Export Forward := Bonak.Equiv.Dgn.νDgnSetOfPresheaf.νDgnSetOfPresheaf A.
+
+Definition positionEquiv n {s t: DgnPosition n} (e: s = t):
+  Equiv (dgnPositionTotal n s) (dgnPositionTotal n t).
+Proof.
+  destruct e. exact idEquiv.
+Defined.
+
+Section Roundtrip.
+Variable psh: PshEq.Psh.Presheaf.
+Variable dgn: PresheafDgn psh.
+
+Definition candidateEquiv n:
+  Equiv (dgnPositionTotal n (pshDgnPosition psh dgn n)) (psh.(F0) n).
+Proof.
+  destruct n.
+  - exact (pshTotalEquiv psh 0).
+  - exact (pshTotalEquiv psh n.+1).
+Defined.
+
+Lemma gfFaceAt n (s: DgnPosition n) (e: s = pshDgnPosition psh dgn n)
+  i (Hi: i <= n) (ε: arity)
+  (x: dgnPositionTotal n.+1 (dgnPositionNext n s)):
+  candidateEquiv n (positionEquiv n e (dgnPositionFace n s i Hi ε x)) =
+  psh.(Face) n i Hi ε
+    (candidateEquiv n.+1 (positionEquiv n.+1
+      (f_equal (dgnPositionNext n) e • pshDgnPositionNext psh dgn n) x)).
+Proof.
+  subst s. destruct n.
+  - exact (pshCellFace psh 0 i Hi ε x).
+  - exact (pshCellFace psh n.+1 i Hi ε x).
+Qed.
+
+Lemma gfDgnAt n (s: DgnPosition n) (e: s = pshDgnPosition psh dgn n)
+  i (Hi: i <= n) (x: dgnPositionTotal n s):
+  candidateEquiv n.+1 (positionEquiv n.+1
+    (f_equal (dgnPositionNext n) e • pshDgnPositionNext psh dgn n)
+    (dgnPositionMap n s i Hi x)) =
+  dgn.(Dgn _) n i Hi (candidateEquiv n (positionEquiv n e x)).
+Proof.
+  subst s. destruct n.
+  - destruct i; [reflexivity | now destruct (leR_O_contra Hi)].
+  - change (pshRevDgn psh dgn n.+1 (n.+1 - i) (sub_leR n.+1 i)
+      (pshCell psh n.+1 x) = dgn.(Dgn _) n.+1 i Hi (pshCell psh n.+1 x)).
+    unfold pshRevDgn.
+    generalize (sub_leR n.+1 (n.+1 - i)).
+    rewrite (subSubCancel Hi). intro H. reflexivity.
+Qed.
+
+Definition gfF0 n:
+  Equiv ((g (f psh dgn)).1.(F0) n) (psh.(F0) n) :=
+  compEquiv (positionEquiv n (pshDgnPack psh dgn n)) (candidateEquiv n).
+
+Lemma gfFace n i (Hi: i <= n) (ε: arity)
+  (x: (g (f psh dgn)).1.(F0) n.+1):
+  gfF0 n ((g (f psh dgn)).1.(Face) n i Hi ε x) =
+  psh.(Face) n i Hi ε (gfF0 n.+1 x).
+Proof.
+  exact (gfFaceAt n (νDgnPack n (f psh dgn))
+    (pshDgnPack psh dgn n) i Hi ε x).
+Qed.
+
+Lemma gfDgn n i (Hi: i <= n)
+  (x: (g (f psh dgn)).1.(F0) n):
+  gfF0 n.+1 ((g (f psh dgn)).2.(Dgn _) n i Hi x) =
+  dgn.(Dgn _) n i Hi (gfF0 n x).
+Proof.
+  exact (gfDgnAt n (νDgnPack n (f psh dgn))
+    (pshDgnPack psh dgn n) i Hi x).
+Qed.
+
+Definition gf: PresheafEquiv (g (f psh dgn)) (psh; dgn) :=
+  Build_PresheafEquiv (g (f psh dgn)) (psh; dgn)
+    (PshEq.Build_PresheafEquiv _ psh gfF0 gfFace) gfDgn.
+
+Definition gfEq: g (f psh dgn) = (psh; dgn) :=
+  presheafEquivEq gf.
+
+End Roundtrip.
+End PresheafRoundtrip.
+
+Module PresheafRoundtripSimplicial := PresheafRoundtrip SimplicialLayer.
+Module PresheafRoundtripCubical := PresheafRoundtrip CubicalLayer.

--- a/theories/Equiv/Dgn/νDgnSetEquiv.v
+++ b/theories/Equiv/Dgn/νDgnSetEquiv.v
@@ -1,0 +1,100 @@
+(** Equality of degeneracy layers and of coherent towers of prefixes. *)
+
+Import Logic.EqNotations.
+
+Set Warnings "-notation-overridden".
+From Stdlib Require Import Logic.FunctionalExtensionality.
+From Bonak Require Import SigT HSet LeSProp Notation RewLemmas Funext
+  νSet.Layer Equiv.Dgn.PresheafRoundtrip Limit.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module νDgnSetEquiv (A: LayerSig).
+Import A.
+Module Export PshRoundtrip := Bonak.Equiv.Dgn.PresheafRoundtrip.PresheafRoundtrip A.
+
+Lemma cohAboveAbovePaintingIrrel {p k} (deps: DepsReflCohsSup p k)
+  (extra: DepsReflCohsSupExtension p k deps)
+  (frames: mkCohReflAboveAboveFrameTypes deps)
+  (a b: mkCohReflAboveAbovePaintingTypes deps extra frames): a = b.
+Proof.
+  revert k deps extra frames a b; induction p; intros k deps extra frames a b.
+  - exact (hunit_ext _ _).
+  - destruct a as [a a'], b as [b b'].
+    pose proof (IHp _ _ _ _ a b) as e. destruct e.
+    apply (f_equal (fun c => (a; c))).
+    repeat first [apply functional_extensionality_dep_good; intro
+                 |apply spropFunext; intro].
+    apply (mkPainting (mkExtraDeps (CohsExtOfReflCohsSup deps)) _).(UIP).
+Qed.
+
+Lemma dgnLayerEq {p} (C: νSetData p)
+  (E: mkFrame (dgnDepsRestr C) -> HSet)
+  (E': mkFrame (dgnDepsRestr (mkνSetData p C E)) -> HSet)
+  (D: DgnData C E)
+  (a b: {L: dgnHasReflFromData C E E' D &T dgnCohLFromData C E E' D L})
+  (H: forall i (Hi: i <= p) d c, a.1 i Hi d c = b.1 i Hi d c): a = b.
+Proof.
+  assert (e: a.1 = b.1).
+  { apply functional_extensionality_dep_good; intro i.
+    apply spropFunext; intro Hi.
+    apply functional_extensionality_dep_good; intro d.
+    apply functional_extensionality_dep_good; intro c. exact (H i Hi d c). }
+  apply (eq_existT_curried e).
+  apply cohAboveAbovePaintingIrrel.
+Qed.
+
+Definition DgnStepBase n: Type := {Y: DgnPrefix n &T νFillerType Y.1}.
+
+Definition dgnLayerType n (Z: DgnStepBase n): Type :=
+  (νDgnSetAt n).(dgnStepType) Z.1.1 Z.1.2 Z.2.
+
+Definition dgnExtendEq {n} {X Y: DgnPrefix n} (e: X = Y)
+  {a: dgnIncrType X} {b: dgnIncrType Y}
+  (ef: rew [fun Z: DgnPrefix n => νFillerType Z.1] e in a.1 = b.1)
+  (el: rew [dgnLayerType n] (eq_existT_curried e ef : ((X; a.1): DgnStepBase n) = (Y; b.1)) in (a.2: dgnLayerType n (X; a.1)) = b.2):
+  dgnExtend X a = dgnExtend Y b.
+Proof.
+  destruct e, a as [F L], b as [G M]; cbn in ef, el.
+  destruct ef; cbn in el. destruct el. reflexivity.
+Defined.
+
+Lemma dgnExtendEqBond {n} {X Y: DgnPrefix n} (e: X = Y)
+  {a: dgnIncrType X} {b: dgnIncrType Y}
+  (ef: rew [fun Z: DgnPrefix n => νFillerType Z.1] e in a.1 = b.1)
+  (el: rew [dgnLayerType n] (eq_existT_curried e ef : ((X; a.1): DgnStepBase n) = (Y; b.1)) in (a.2: dgnLayerType n (X; a.1)) = b.2):
+  f_equal (@dgnBond n) (dgnExtendEq e ef el) = e.
+Proof.
+  destruct e, a as [F L], b as [G M]; cbn in ef, el.
+  destruct ef; cbn in el. destruct el. reflexivity.
+Qed.
+
+Lemma dgnExtendEqUnderlying {n} {X Y: DgnPrefix n} (e: X = Y)
+  {a: dgnIncrType X} {b: dgnIncrType Y}
+  (ef: rew [fun Z: DgnPrefix n => νFillerType Z.1] e in a.1 = b.1)
+  (el: rew [dgnLayerType n] (eq_existT_curried e ef : ((X; a.1): DgnStepBase n) = (Y; b.1)) in (a.2: dgnLayerType n (X; a.1)) = b.2):
+  f_equal (fun Z: DgnPrefix n.+1 => Z.1) (dgnExtendEq e ef el) =
+  extendCong (T := νSetTel) (f_equal (fun Z: DgnPrefix n => Z.1) e)
+    (eq_sym (rew_map (@νFillerType n) (fun Z: DgnPrefix n => Z.1) e a.1) • ef).
+Proof.
+  destruct e, a as [F L], b as [G M]; cbn in ef, el.
+  destruct ef; cbn in el. destruct el. reflexivity.
+Qed.
+
+Definition dgnPackPath m (X: νDgnSets):
+  (νDgnPack m X).1 = X.(approx) m leR_O := limitPackPath m X.
+
+Lemma dgnPackPathS m (X: νDgnSets):
+  f_equal (@dgnBond m) (dgnPackPath m.+1 X) • X.(approxS) m leR_O leR_O =
+  dgnPackPath m X.
+Proof.
+  pose proof (limitPackPathS m X) as H.
+  now rewrite eq_trans_refl_l in H.
+Qed.
+
+End νDgnSetEquiv.
+
+Module νDgnSetEquivSimplicial := νDgnSetEquiv SimplicialLayer.
+Module νDgnSetEquivCubical := νDgnSetEquiv CubicalLayer.

--- a/theories/Equiv/Dgn/νDgnSetOfPresheaf.v
+++ b/theories/Equiv/Dgn/νDgnSetOfPresheaf.v
@@ -1,0 +1,275 @@
+(** Degeneracy layers over the νSet constructed from a presheaf. *)
+
+Import Logic.EqNotations.
+
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT HSet LeSProp NatLemmas Notation νSet.Layer
+  Equiv.Dgn.PresheafOfνDgnSet Limit.
+From Bonak.Lib Require Import Equiv.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module νDgnSetOfPresheaf (A: LayerSig).
+Import A.
+Module Export Backward := Bonak.Equiv.Dgn.PresheafOfνDgnSet.PresheafOfνDgnSet A.
+
+Section Forward.
+Variable psh: PshEq.Psh.Presheaf.
+Variable dgn: PresheafDgn psh.
+
+Definition pshTotal (n: nat): HSet := νTotal (pshFrom psh n).
+
+Definition pshTotalEquiv (n: nat): Equiv (pshTotal n) (psh.(F0) n) :=
+  match n with
+  | 0 => fillerEquiv
+      (B := mkFrame (toDepsRestr ((νSetAt 0).(data) tt).(restrFrames)))
+      (fun _: psh.(F0) 0 => tt)
+  | n.+1 => fillerEquiv (mkPshFrame psh (towerPshDeps psh (pshTw psh n)))
+  end.
+
+Definition pshCell n: pshTotal n -> psh.(F0) n := pshTotalEquiv n.
+
+Lemma pshCellInj n (x y: pshTotal n): pshCell n x = pshCell n y -> x = y.
+Proof.
+  exact (eqvInj (pshTotalEquiv n)).
+Qed.
+
+Definition pshFace n i (Hi: i <= n) (ε: arity):
+  pshTotal n.+1 -> pshTotal n :=
+  νFaceFuel (pshFrom psh n) (n - i) ε.
+
+Lemma pshCellFace n i (Hi: i <= n) (ε: arity) (x: pshTotal n.+1):
+  pshCell n (pshFace n i Hi ε x) =
+  psh.(Face) n i Hi ε (pshCell n.+1 x).
+Proof.
+  destruct n.
+  - exact (gfFaceBottom0 psh i Hi ε x).
+  - exact (gfFaceBottom psh n i Hi ε x).
+Qed.
+
+Definition pshRevFace n q (Hq: q <= n) (ε: arity):
+  psh.(F0) n.+1 -> psh.(F0) n :=
+  psh.(Face) n (n - q) (sub_leR n q) ε.
+
+Definition pshRevDgn n i (Hi: i <= n): psh.(F0) n -> psh.(F0) n.+1 :=
+  dgn.(Dgn _) n (n - i) (sub_leR n i).
+
+Lemma pshCellFaceDown n q (Hq: q <= n) (ε: arity) (x: pshTotal n.+1):
+  pshCell n (faceDown (νDepsCohs2At (pshFrom psh n)) q ε x.1) =
+  pshRevFace n q Hq ε (pshCell n.+1 x).
+Proof.
+  pose proof (pshCellFace n (n - q) (sub_leR n q) ε x) as e.
+  unfold pshFace in e. rewrite (subSubCancel Hq) in e. exact e.
+Qed.
+
+Lemma pshRevFaceDgnId n i (Hi: i <= n) (ε: arity) (x: psh.(F0) n):
+  pshRevFace n i Hi ε (pshRevDgn n i Hi x) = x.
+Proof.
+  exact (dgn.(FaceDgnId _) n (n - i) (sub_leR n i) ε x).
+Qed.
+
+Lemma pshRevFaceDgnSup n q i (Hq: q <= i) (Hi: i <= n)
+  (ε: arity) (x: psh.(F0) n.+1):
+  pshRevFace n.+1 q (Hq ↕ (↑ Hi)) ε (pshRevDgn n.+1 i.+1 (⇑ Hi) x) =
+  pshRevDgn n i Hi (pshRevFace n q (Hq ↕ Hi) ε x).
+Proof.
+  unfold pshRevFace, pshRevDgn.
+  generalize (sub_leR n.+1 q).
+  rewrite (subSuccL (Hq ↕ Hi)). intro H.
+  exact (dgn.(FaceDgnSup _) n (n - q) (sub_leR n q)
+    (n - i) (subAntitone Hq) ε x).
+Qed.
+
+Lemma pshRevFaceDgnInf n q i (Hi: i <= q) (Hq: q <= n)
+  (ε: arity) (x: psh.(F0) n.+1):
+  pshRevFace n.+1 q.+1 (⇑ Hq) ε (pshRevDgn n.+1 i (Hi ↕ (↑ Hq)) x) =
+  pshRevDgn n i (Hi ↕ Hq) (pshRevFace n q Hq ε x).
+Proof.
+  unfold pshRevFace, pshRevDgn.
+  generalize (sub_leR n.+1 i).
+  rewrite (subSuccL (Hi ↕ Hq)). intro H.
+  exact (dgn.(FaceDgnInf _) n (n - q) (n - i)
+    (subAntitone Hi) (sub_leR n i) ε x).
+Qed.
+
+Lemma pshRevDgnDgn n q r (Hq: q <= r) (Hr: r <= n) (x: psh.(F0) n):
+  pshRevDgn n.+1 r.+1 (⇑ Hr) (pshRevDgn n q (Hq ↕ Hr) x) =
+  pshRevDgn n.+1 q (Hq ↕ (↑ Hr)) (pshRevDgn n r Hr x).
+Proof.
+  unfold pshRevDgn.
+  generalize (sub_leR n.+1 q).
+  rewrite (subSuccL (Hq ↕ Hr)). intro H.
+  exact (dgn.(DgnDgn _) n (n - r) (n - q)
+    (subAntitone Hq) (sub_leR n q) x).
+Qed.
+
+Definition PshDgnPrefix (n: nat): Type :=
+  (νDgnSetAt n.+1).(dgnPrefix) (pshApprox psh n.+1).
+
+Definition pshDgnData n (R: PshDgnPrefix n):
+  DgnData (νDataAt (pshApprox psh n)) (this (pshFrom psh n)) :=
+  (νDgnSetAt n).(dgnStepData) (pshApprox psh n) R.1
+    (this (pshFrom psh n)) R.2.
+
+Definition pshDgnDeps n (R: PshDgnPrefix n): DepsReflCohsSup n 0 :=
+  dgnDepsReflCohsSupFromData _ _ (this (pshFrom psh n.+1)) (pshDgnData n R).
+
+Definition pshDgnDeps2 n (R: PshDgnPrefix n.+1): DepsReflCohs2 n 0 :=
+  dgnDepsReflCohs2FromData _ _ _ (this (pshFrom psh n.+2))
+    (pshDgnData n R.1) R.2.1 R.2.2.
+
+Definition pshAbove n (R: PshDgnPrefix n.+1) i (Hi: i <= n)
+  (x: pshTotal n): pshTotal n.+1 :=
+  (mkReflFrameAbove (pshDgnDeps n R.1) i Hi x.1 x.2; R.2.1 i Hi x.1 x.2).
+
+Fixpoint PshDgnGood n: PshDgnPrefix n -> Type :=
+  match n with
+  | 0 => fun _ => unit
+  | n.+1 => fun R =>
+      {_: PshDgnGood n R.1 &T
+        forall i (Hi: i <= n) (x: pshTotal n),
+        pshCell n.+1 (pshAbove n R i Hi x) =
+        pshRevDgn n i Hi (pshCell n x)}
+  end.
+
+Lemma pshAboveBoundary n (R: PshDgnPrefix n) (G: PshDgnGood n R)
+  i (Hi: i <= n) q (Hq: q <= n) (ε: arity) (x: pshTotal n):
+  pshCell n (faceDown (νDepsCohs2At (pshFrom psh n)) q ε
+    (mkReflFrameAbove (pshDgnDeps n R) i Hi x.1 x.2)) =
+  pshRevFace n q Hq ε (pshRevDgn n i Hi (pshCell n x)).
+Proof.
+  destruct (natOrder q i) as [H|e|H].
+  - destruct i; [now destruct (leR_O_contra H) |].
+    destruct n; [now destruct (leR_O_contra Hi) |].
+    change (νDepsCohs2At (pshFrom psh n.+1)) with
+      (Cohs2OfReflCohsSup (mkDepsReflCohsSup (pshDgnDeps2 n R))).
+    change (pshDgnDeps n.+1 R) with (mkDepsReflCohsSup (pshDgnDeps2 n R)).
+    rewrite (faceDownAboveSup (pshDgnDeps2 n R) q i H Hi).
+    cbv zeta.
+    match goal with |- _ = ?rhs =>
+      change (pshCell n.+1 (pshAbove n R i Hi
+        (faceDown (νDepsCohs2At (pshFrom psh n)) q ε x.1)) = rhs)
+    end.
+    rewrite G.2, (pshCellFaceDown n q (H ↕ Hi)).
+    symmetry. exact (pshRevFaceDgnSup n q i H Hi ε (pshCell n.+1 x)).
+  - destruct e.
+    rewrite (faceDownAboveId (pshDgnDeps n R) q Hq ε x.1 x.2).
+    symmetry. apply pshRevFaceDgnId.
+  - destruct q; [now destruct (leR_O_contra H) |].
+    destruct n; [now destruct (leR_O_contra Hq) |].
+    change (νDepsCohs2At (pshFrom psh n.+1)) with
+      (Cohs2OfReflCohsSup (mkDepsReflCohsSup (pshDgnDeps2 n R))).
+    change (pshDgnDeps n.+1 R) with (mkDepsReflCohsSup (pshDgnDeps2 n R)).
+    rewrite (faceDownAboveInf (pshDgnDeps2 n R) q i H Hq).
+    cbv zeta.
+    match goal with |- _ = ?rhs =>
+      change (pshCell n.+1 (pshAbove n R i (H ↕ Hq)
+        (faceDown (νDepsCohs2At (pshFrom psh n)) q ε x.1)) = rhs)
+    end.
+    rewrite G.2, (pshCellFaceDown n q Hq).
+    symmetry. exact (pshRevFaceDgnInf n q i H Hq ε (pshCell n.+1 x)).
+Qed.
+
+Lemma pshAboveFrame n (R: PshDgnPrefix n) (G: PshDgnGood n R)
+  i (Hi: i <= n) (x: pshTotal n):
+  mkReflFrameAbove (pshDgnDeps n R) i Hi x.1 x.2 =
+  mkPshFrame psh (towerPshDeps psh (pshTw psh n))
+    (pshRevDgn n i Hi (pshCell n x)).
+Proof.
+  apply (faceDownEq (νDepsCohs2At (pshFrom psh n))). intros q Hq ε.
+  apply pshCellInj.
+  rewrite (pshAboveBoundary n R G i Hi q Hq ε x).
+  symmetry.
+  exact (pshCellFaceDown n q Hq ε
+    (invEq (pshTotalEquiv n.+1) (pshRevDgn n i Hi (pshCell n x)))).
+Qed.
+
+Definition pshDgnLayer n (R: PshDgnPrefix n) (G: PshDgnGood n R):
+  dgnHasReflFromData _ _ (this (pshFrom psh n.+1)) (pshDgnData n R) :=
+  fun i Hi d c =>
+    (pshRevDgn n i Hi (pshCell n (d; c)); pshAboveFrame n R G i Hi (d; c)).
+
+Lemma totalSndEq {B: HSet} {P: B -> Type} {x y: B} {u: P x} {v: P y}
+  (e: x = y) (h: ((x; u): {b: B &T P b}) = (y; v)):
+  rew [P] e in u = v.
+Proof.
+  pose proof (projT2_eq h) as H.
+  now rewrite (B.(UIP) (h := projT1_eq h) (g := e)) in H.
+Qed.
+
+Definition pshDgnLayerCohTop n (R: PshDgnPrefix n.+1) (G: PshDgnGood n.+1 R):
+  cohReflAboveAboveL (pshDgnDeps2 n R) (pshDgnLayer n.+1 R G).
+Proof.
+  intros q r Hq Hr d c.
+  apply (totalSndEq (B := νFrame (pshApprox psh n.+2))
+    (P := fun D => (this (pshFrom psh n.+2)) D)).
+  apply (pshCellInj n.+2).
+  change
+    (pshRevDgn n.+1 r.+1 (⇑ Hr)
+      (pshCell n.+1 (pshAbove n R q (Hq ↕ Hr) (d; c))) =
+     pshRevDgn n.+1 q (Hq ↕ (↑ Hr))
+      (pshCell n.+1 (pshAbove n R r Hr (d; c)))).
+  rewrite !G.2. apply pshRevDgnDgn.
+Defined.
+
+Definition pshDgnLayerCoh n (R: PshDgnPrefix n) (G: PshDgnGood n R):
+  dgnCohLFromData _ _ (this (pshFrom psh n.+1)) (pshDgnData n R)
+    (pshDgnLayer n R G).
+Proof.
+  destruct n.
+  - exact tt.
+  - exact (mkCohReflAboveAbovePaintings (pshDgnDeps2 n R)
+      (TopReflCoh2Dep (deps := pshDgnDeps2 n R)
+        (pshDgnLayer n.+1 R G) (pshDgnLayerCohTop n R G))).
+Defined.
+
+Definition pshDgnPrefixStep n (R: PshDgnPrefix n) (G: PshDgnGood n R):
+  PshDgnPrefix n.+1 := (R; (pshDgnLayer n R G; pshDgnLayerCoh n R G)).
+
+Definition pshDgnGoodStep n (R: PshDgnPrefix n) (G: PshDgnGood n R):
+  PshDgnGood n.+1 (pshDgnPrefixStep n R G) :=
+  (G; fun i Hi x => eq_refl).
+
+Fixpoint pshDgnChain n: {R: PshDgnPrefix n &T PshDgnGood n R} :=
+  match n with
+  | 0 => ((tt; tt); tt)
+  | n.+1 =>
+      let s := pshDgnChain n in
+      (pshDgnPrefixStep n s.1 s.2; pshDgnGoodStep n s.1 s.2)
+  end.
+
+Definition pshDgnApprox n: DgnPrefix n :=
+  (pshApprox psh n;
+   match n return (νDgnSetAt n).(dgnPrefix) (pshApprox psh n) with
+   | 0 => tt
+   | n.+1 => (pshDgnChain n).1
+   end).
+
+Definition pshDgnFrom m: νDgnSetsFrom m (pshDgnApprox m) :=
+  ofChain (T := dgnTel) pshDgnApprox (fun n =>
+    match n with 0 => eq_refl | n.+1 => eq_refl end) m.
+
+Definition f: νDgnSets := pshDgnFrom 0.
+
+Definition pshDgnPosition n: DgnPosition n := (pshDgnApprox n; pshDgnFrom n).
+
+Definition pshDgnPositionNext n:
+  dgnPositionNext n (pshDgnPosition n) = pshDgnPosition n.+1.
+Proof.
+  destruct n; reflexivity.
+Defined.
+
+Fixpoint pshDgnPack n:
+  νDgnPack n f = pshDgnPosition n :=
+  match n with
+  | 0 => eq_refl
+  | n.+1 => f_equal (dgnPositionNext n) (pshDgnPack n) • pshDgnPositionNext n
+  end.
+
+End Forward.
+End νDgnSetOfPresheaf.
+
+Module νDgnSetOfPresheafSimplicial := νDgnSetOfPresheaf SimplicialLayer.
+Module νDgnSetOfPresheafCubical := νDgnSetOfPresheaf CubicalLayer.

--- a/theories/Equiv/Dgn/νDgnSetRoundtrip.v
+++ b/theories/Equiv/Dgn/νDgnSetRoundtrip.v
@@ -1,0 +1,342 @@
+(** Recovering an indexed degeneracy tower from its presheaf. *)
+
+Import Logic.EqNotations.
+
+Set Warnings "-notation-overridden".
+From Bonak Require Import SigT HSet LeSProp NatLemmas Notation RewLemmas
+  νSet.Layer Equiv.Dgn.νDgnSetEquiv Limit.
+From Bonak.Lib Require Import Equiv.
+
+Set Primitive Projections.
+Set Printing Projections.
+Set Keyed Unification.
+
+Module νDgnSetRoundtrip (A: LayerSig).
+Import A.
+Module Export DgnEq := Bonak.Equiv.Dgn.νDgnSetEquiv.νDgnSetEquiv A.
+
+Definition prefixFaceFuel {n} (P: (νSetAt n.+1).(prefix)) fuel (ε: arity)
+  (d: νFrame P): νTotalType P :=
+  νFace (dcStepIter fuel
+    (n; (0; (prefixDepsCohs P; DepsCohsChainNil)))).2.2.2 ε d.
+
+Lemma prefixFaceFuelRew {n} {P Q: (νSetAt n.+1).(prefix)} (e: P = Q)
+  fuel (ε: arity) (d: νFrame Q):
+  prefixFaceFuel P fuel ε (rew <- [νFrameDom] e in d) =
+  rew <- [νTotalType] e in prefixFaceFuel Q fuel ε d.
+Proof.
+  now destruct e.
+Qed.
+
+Lemma prefixFaceFuelEq {n} (P: (νSetAt n.+1).(prefix)) (E: νFillerType P)
+  fuel (ε: arity) (d: νFrame P):
+  prefixFaceFuel P fuel ε d =
+  faceDown (dgnDepsCohs2 (νDataAt P.1) P.2 E) fuel ε d.
+Proof.
+  unfold prefixFaceFuel, faceDown. rewrite chain2DownIter. reflexivity.
+Qed.
+
+Definition dgnStepInput n (Z: DgnStepBase n.+1): Type := νTotalType Z.1.1.
+
+Lemma dgnStepBaseEqInput n {P Q: DgnPrefix n.+1} (e: P = Q)
+  {F: νFillerType P.1} {G: νFillerType Q.1}
+  (ef: rew [fun Z: DgnPrefix n.+1 => νFillerType Z.1] e in F = G)
+  (x: νTotalType Q.1):
+  rew <- [dgnStepInput n]
+    (eq_existT_curried e ef: ((P; F): DgnStepBase n.+1) = (Q; G)) in
+    (x: dgnStepInput n (Q; G)) =
+  rew <- [@νTotalType n] (f_equal (fun Z: DgnPrefix n.+1 => Z.1) e) in x.
+Proof.
+  destruct e. cbn in ef. destruct ef. reflexivity.
+Qed.
+
+Definition dgnStepPrefix n (Z: DgnStepBase n): (νSetAt n.+1).(prefix) :=
+  (Z.1.1; Z.2).
+
+Lemma dgnStepPrefixEq {n} {P Q: DgnPrefix n} (e: P = Q)
+  {F: νFillerType P.1} {G: νFillerType Q.1}
+  (ef: rew [fun Z: DgnPrefix n => νFillerType Z.1] e in F = G):
+  f_equal (dgnStepPrefix n)
+    (eq_existT_curried e ef: ((P; F): DgnStepBase n) = (Q; G)) =
+  extendCong (T := νSetTel) (f_equal (fun Z: DgnPrefix n => Z.1) e)
+    (eq_sym (rew_map (@νFillerType n) (fun Z: DgnPrefix n => Z.1) e F) • ef).
+Proof.
+  destruct e. cbn in ef. destruct ef. reflexivity.
+Qed.
+
+Definition dgnStepOutput n (Z: DgnStepBase n.+1): Type :=
+  {D: νFrame Z.1.1 &T Z.2 D}.
+
+Definition dgnLayerMap n (Z: DgnStepBase n.+1) (L: dgnLayerType n.+1 Z)
+  i (Hi: i <= n) (x: dgnStepInput n Z): dgnStepOutput n Z :=
+  (mkReflFrameAbove
+    (dgnDepsReflCohsSupFromData (νDataAt Z.1.1.1) Z.1.1.2 Z.2
+      ((νDgnSetAt n).(dgnStepData) Z.1.1.1 Z.1.2.1 Z.1.1.2 Z.1.2.2))
+    (n - i) (sub_leR n i) x.1 x.2;
+   L.1 (n - i) (sub_leR n i) x.1 x.2).
+
+Lemma dgnLayerEqByMap n (Z: DgnStepBase n.+1) (L M: dgnLayerType n.+1 Z)
+  (H: forall i (Hi: i <= n) x,
+    dgnLayerMap n Z L i Hi x = dgnLayerMap n Z M i Hi x): L = M.
+Proof.
+  apply dgnLayerEq. intros i Hi d c.
+  pose proof (H (n - i) (sub_leR n i) (d; c)) as h.
+  unfold dgnLayerMap in h.
+  revert h. generalize (sub_leR n (n - i)).
+  rewrite (subSubCancel Hi). intros Hi' h.
+  exact (totalSndEq (B := νFrame Z.1.1) (P := fun D => Z.2 D) eq_refl h).
+Qed.
+
+Lemma dgnLayerRewEq n {Z W: DgnStepBase n.+1} (e: Z = W)
+  (L: dgnLayerType n.+1 Z) (M: dgnLayerType n.+1 W)
+  (H: forall i (Hi: i <= n) (x: dgnStepInput n W),
+    rew <- [dgnStepOutput n] e in dgnLayerMap n W M i Hi x =
+    dgnLayerMap n Z L i Hi (rew <- [dgnStepInput n] e in x)):
+  rew [dgnLayerType n.+1] e in L = M.
+Proof.
+  destruct e. apply dgnLayerEqByMap. intros i Hi x.
+  symmetry. exact (H i Hi x).
+Qed.
+
+Section FG.
+Variable X: νDgnSets.
+Let psh := (g X).1.
+Let dgn := (g X).2.
+
+Definition pshFrameAt n: psh.(F0) n -> νFrame (pshApprox psh n) :=
+  match n with
+  | 0 => fun _ => tt
+  | n.+1 => mkPshFrame psh (towerPshDeps psh (pshTw psh n))
+  end.
+
+Definition FgFrame n (e: pshApprox psh n = (νDgnPack n X).1.1): Type :=
+  forall x: psh.(F0) n, pshFrameAt n x =
+    rew <- [@νFrameDom n] e in (x.1: νFrameDom (νDgnPack n X).1.1).
+
+Definition fgFillers n (e: pshApprox psh n = (νDgnPack n X).1.1)
+  (H: FgFrame n e):
+  νFillerEqvType e (this (pshFrom psh n)) (this (νDgnPack n X).2).1.
+Proof.
+  destruct n.
+  - exact (fun D => fillerEquivOf (rewEquiv νFrameDom (eq_sym e))
+      eq_refl (pshFrameAt 0) (fun D c => H (D; c)) D).
+  - exact (fun D => fillerEquivOf (rewEquiv νFrameDom (eq_sym e))
+      eq_refl (pshFrameAt n.+1) (fun D c => H (D; c)) D).
+Defined.
+
+Lemma fgFillersTotal n (e: pshApprox psh n = (νDgnPack n X).1.1)
+  (H: FgFrame n e) (x: psh.(F0) n):
+  rew <- [@νTotalType n]
+    (extendCong (T := νSetTel) e (νFillerEq e (fgFillers n e H)))
+    in (x: νTotalType (νDgnPack n.+1 X).1.1) =
+  invEq (pshTotalEquiv psh n) x.
+Proof.
+  rewrite rewTotalνFillerEq.
+  symmetry. destruct n.
+  - exact (fillerEquivOfWhole (rewEquiv νFrameDom (eq_sym e)) eq_refl
+      (pshFrameAt 0) (fun D c => H (D; c)) x.1 x.2).
+  - exact (fillerEquivOfWhole (rewEquiv νFrameDom (eq_sym e)) eq_refl
+      (pshFrameAt n.+1) (fun D c => H (D; c)) x.1 x.2).
+Qed.
+
+Definition fgUnderlying n
+  (e: pshDgnApprox psh dgn n = (νDgnPack n X).1):
+  pshApprox psh n = (νDgnPack n X).1.1 :=
+  f_equal (fun Z: DgnPrefix n => Z.1) e.
+
+Definition fgFillerPath n
+  (e: pshDgnApprox psh dgn n = (νDgnPack n X).1)
+  (H: FgFrame n (fgUnderlying n e)):
+  rew [fun Z: DgnPrefix n => νFillerType Z.1] e in
+    (this (pshFrom psh n): νFillerType (pshDgnApprox psh dgn n).1) =
+  (this (νDgnPack n X).2).1 :=
+  rew_map (@νFillerType n) (fun Z: DgnPrefix n => Z.1) e (this (pshFrom psh n)) •
+  νFillerEq (fgUnderlying n e) (fgFillers n (fgUnderlying n e) H).
+
+Definition fgStepPath n
+  (e: pshDgnApprox psh dgn n = (νDgnPack n X).1)
+  (H: FgFrame n (fgUnderlying n e)):
+  ((pshDgnApprox psh dgn n; this (pshFrom psh n)): DgnStepBase n) =
+  ((νDgnPack n X).1; (this (νDgnPack n X).2).1) :=
+  eq_existT_curried e (fgFillerPath n e H).
+
+Lemma fgStepOutput n
+  (e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1)
+  (H: FgFrame n.+1 (fgUnderlying n.+1 e)) (x: psh.(F0) n.+1):
+  rew <- [dgnStepOutput n] (fgStepPath n.+1 e H) in
+    (x: dgnStepOutput n ((νDgnPack n.+1 X).1; (this (νDgnPack n.+1 X).2).1)) =
+  invEq (pshTotalEquiv psh n.+1) x.
+Proof.
+  change (rew <- [fun Z: DgnStepBase n.+1 => νTotalType (dgnStepPrefix n.+1 Z)]
+    (fgStepPath n.+1 e H) in
+    (x: νTotalType (dgnStepPrefix n.+1
+      ((νDgnPack n.+1 X).1; (this (νDgnPack n.+1 X).2).1))) =
+    invEq (pshTotalEquiv psh n.+1) x).
+  unfold eq_rect_r. rewrite rew_map, <- eq_sym_map_distr.
+  unfold fgStepPath. rewrite dgnStepPrefixEq.
+  unfold fgFillerPath. rewrite eq_trans_sym_cancel_l.
+  apply fgFillersTotal.
+Qed.
+
+Lemma fgStepInput n
+  (e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1)
+  (H: FgFrame n.+1 (fgUnderlying n.+1 e)) (x: psh.(F0) n):
+  rew <- [dgnStepInput n] (fgStepPath n.+1 e H) in
+    (x: dgnStepInput n ((νDgnPack n.+1 X).1; (this (νDgnPack n.+1 X).2).1)) =
+  rew <- [@νTotalType n] (fgUnderlying n.+1 e) in
+    (x: νTotalType (νDgnPack n.+1 X).1.1).
+Proof.
+  apply dgnStepBaseEqInput.
+Qed.
+
+Lemma fgFrameStep n
+  (e: pshApprox psh n.+1 = (νDgnPack n.+1 X).1.1)
+  (H: forall x: psh.(F0) n,
+    rew <- [@νTotalType n] e in (x: νTotalType (νDgnPack n.+1 X).1.1) =
+    invEq (pshTotalEquiv psh n) x)
+  (x: psh.(F0) n.+1):
+  mkPshFrame psh (towerPshDeps psh (pshTw psh n)) x =
+  rew <- [@νFrameDom n.+1] e in (x.1: νFrameDom (νDgnPack n.+1 X).1.1).
+Proof.
+  apply (faceDownEq (νDepsCohs2At (pshFrom psh n))). intros q Hq ε.
+  rewrite <- !(prefixFaceFuelEq (pshApprox psh n.+1) (this (pshFrom psh n.+1))),
+    prefixFaceFuelRew.
+  rewrite H. apply (pshCellInj psh n).
+  rewrite (prefixFaceFuelEq (pshApprox psh n.+1) (this (pshFrom psh n.+1))).
+  match goal with |- _ = ?rhs =>
+    change (pshCell psh n (faceDown (νDepsCohs2At (pshFrom psh n)) q ε
+      (invEq (pshTotalEquiv psh n.+1) x).1) = rhs)
+  end.
+  rewrite (pshCellFaceDown psh n q Hq).
+  unfold pshCell. rewrite !secEq.
+  unfold pshRevFace.
+  change (faceDown (dgnPositionCohs2 n (νDgnPack n X)) (n - (n - q)) ε x.1 =
+    prefixFaceFuel (νDgnPack n.+1 X).1.1 q ε x.1).
+  rewrite (subSubCancel Hq).
+  symmetry.
+  exact (prefixFaceFuelEq (νDgnPack n.+1 X).1.1
+    (this (νDgnPack n.+1 X).2).1 q ε x.1).
+Qed.
+
+Definition FgTotal n
+  (e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1): Type :=
+  forall x: psh.(F0) n,
+    rew <- [@νTotalType n] (fgUnderlying n.+1 e) in
+      (x: νTotalType (νDgnPack n.+1 X).1.1) =
+    invEq (pshTotalEquiv psh n) x.
+
+Lemma fgLayer n
+  (e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1)
+  (HT: FgTotal n e) (HF: FgFrame n.+1 (fgUnderlying n.+1 e)):
+  rew [dgnLayerType n.+1] (fgStepPath n.+1 e HF) in
+    ((this (pshDgnFrom psh dgn n.+1)).2:
+      dgnLayerType n.+1 (pshDgnApprox psh dgn n.+1; this (pshFrom psh n.+1))) =
+  (this (νDgnPack n.+1 X).2).2.
+Proof.
+  apply dgnLayerRewEq. intros i Hi x.
+  rewrite fgStepOutput, fgStepInput, HT.
+  apply (pshCellInj psh n.+1).
+  change (pshTotalEquiv psh n.+1
+    (invEq (pshTotalEquiv psh n.+1) (dgn.(Dgn _) n i Hi x)) =
+    pshRevDgn psh dgn n (n - i) (sub_leR n i)
+      (pshCell psh n (invEq (pshTotalEquiv psh n) x))).
+  unfold pshCell, pshRevDgn. rewrite !secEq.
+  generalize (sub_leR n (n - i)).
+  rewrite (subSubCancel Hi). intro H. reflexivity.
+Qed.
+
+Definition fgNext n
+  (e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1)
+  (HT: FgTotal n e):
+  pshDgnApprox psh dgn n.+2 = (νDgnPack n.+2 X).1 :=
+  let HF := fgFrameStep n (fgUnderlying n.+1 e) HT in
+  dgnExtendEq e (a := this (pshDgnFrom psh dgn n.+1))
+    (b := this (νDgnPack n.+1 X).2)
+    (fgFillerPath n.+1 e HF) (fgLayer n e HT HF).
+
+Lemma fgNextTotal n
+  (e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1)
+  (HT: FgTotal n e): FgTotal n.+1 (fgNext n e HT).
+Proof.
+  unfold FgTotal, fgUnderlying, fgNext. intro x.
+  rewrite (dgnExtendEqUnderlying e
+    (a := this (pshDgnFrom psh dgn n.+1)) (b := this (νDgnPack n.+1 X).2)
+    (fgFillerPath n.+1 e (fgFrameStep n (fgUnderlying n.+1 e) HT))
+    (fgLayer n e HT (fgFrameStep n (fgUnderlying n.+1 e) HT))).
+  unfold fgFillerPath. rewrite eq_trans_sym_cancel_l.
+  apply fgFillersTotal.
+Qed.
+
+Lemma fgNextBond n
+  (e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1)
+  (HT: FgTotal n e):
+  f_equal (@dgnBond n.+1) (fgNext n e HT) = e.
+Proof.
+  exact (dgnExtendEqBond e
+    (a := this (pshDgnFrom psh dgn n.+1)) (b := this (νDgnPack n.+1 X).2)
+    (fgFillerPath n.+1 e (fgFrameStep n (fgUnderlying n.+1 e) HT))
+    (fgLayer n e HT (fgFrameStep n (fgUnderlying n.+1 e) HT))).
+Qed.
+
+Definition fgFrame0: FgFrame 0 eq_refl := fun x => hunit_ext tt x.1.
+
+Definition fgBase: pshDgnApprox psh dgn 1 = (νDgnPack 1 X).1 :=
+  dgnExtendEq eq_refl (a := this (pshDgnFrom psh dgn 0)) (b := this X)
+    (fgFillerPath 0 eq_refl fgFrame0) (hunit_ext _ _).
+
+Lemma fgBaseTotal: FgTotal 0 fgBase.
+Proof.
+  unfold FgTotal, fgUnderlying, fgBase. intro x.
+  rewrite (dgnExtendEqUnderlying eq_refl
+    (a := this (pshDgnFrom psh dgn 0)) (b := this X)
+    (fgFillerPath 0 eq_refl fgFrame0) (hunit_ext _ _)).
+  unfold fgFillerPath. rewrite eq_trans_sym_cancel_l.
+  apply fgFillersTotal.
+Qed.
+
+Fixpoint fgChain n:
+  {e: pshDgnApprox psh dgn n.+1 = (νDgnPack n.+1 X).1 &T FgTotal n e} :=
+  match n with
+  | 0 => (fgBase; fgBaseTotal)
+  | n.+1 =>
+      let s := fgChain n in
+      (fgNext n s.1 s.2; fgNextTotal n s.1 s.2)
+  end.
+
+Definition fgPrefix n: pshDgnApprox psh dgn n = (νDgnPack n X).1 :=
+  match n with
+  | 0 => eq_refl
+  | n.+1 => (fgChain n).1
+  end.
+
+Definition pshDgnBond n:
+  @dgnBond n (pshDgnApprox psh dgn n.+1) = pshDgnApprox psh dgn n :=
+  match n with 0 => eq_refl | n.+1 => eq_refl end.
+
+Lemma fgPrefixBond n:
+  f_equal (@dgnBond n) (fgPrefix n.+1) = pshDgnBond n • fgPrefix n.
+Proof.
+  destruct n.
+  - exact (dgnExtendEqBond eq_refl
+      (a := this (pshDgnFrom psh dgn 0)) (b := this X)
+      (fgFillerPath 0 eq_refl fgFrame0) (hunit_ext _ _)).
+  - cbn [fgPrefix fgChain pshDgnBond].
+    rewrite eq_trans_refl_l. apply fgNextBond.
+Qed.
+
+Theorem fg: f psh dgn = X.
+Proof.
+  unshelve eapply limitEqIntro.
+  - exact (fun n => fgPrefix n • dgnPackPath n X).
+  - apply ({_: hunit & hunit}).(UIP).
+  - intro n. cbv beta.
+    rewrite eq_trans_map_distr, <- eq_trans_assoc.
+    rewrite (dgnPackPathS n X), (fgPrefixBond n).
+    rewrite eq_trans_assoc. reflexivity.
+Qed.
+
+End FG.
+End νDgnSetRoundtrip.
+
+Module νDgnSetRoundtripSimplicial := νDgnSetRoundtrip SimplicialLayer.
+Module νDgnSetRoundtripCubical := νDgnSetRoundtrip CubicalLayer.

--- a/theories/Equiv/Face.v
+++ b/theories/Equiv/Face.v
@@ -108,6 +108,20 @@ Fixpoint extChainCompose {P K} {depsTop: DepsRestr P K}
   | ExtChainCons c2' => ExtChainCons (extChainCompose c1 c2')
   end.
 
+Lemma getPaintingCompose {P K} {depsTop: DepsRestr P K}
+  {extTop: DepsRestrExtension P K depsTop}
+  {p k} {depsMid: DepsRestr p k} {extMid: DepsRestrExtension p k depsMid}
+  {p' k'} {deps: DepsRestr p' k'} {ext: DepsRestrExtension p' k' deps}
+  (a: ExtChain extTop extMid) (b: ExtChain extMid ext)
+  (d: mkFrame deps) (cp: mkPainting ext d):
+  getPainting (extChainCompose a b) d cp =
+  getPainting a (getPainting b d cp).1 (getPainting b d cp).2.
+Proof.
+  revert d cp; induction b; intros d cp.
+  - reflexivity.
+  - exact (IHb (d; cp.1) cp.2).
+Defined.
+
 (** The frame chain underlying a painting chain. *)
 
 Fixpoint extChainDeps {P K} {depsTop: DepsRestr P K}
@@ -316,6 +330,20 @@ Lemma cohsChainNextCompose {P K} {dcTop: DepsCohs P K}
   chainCompose (cohsChainNext a) (cohsChainNext b).
 Proof.
   induction b; cbn; [now reflexivity | now rewrite IHb].
+Defined.
+
+Lemma νFaceCompose {P K} {dcTop: DepsCohs P K}
+  {p k} {dcMid: DepsCohs p k} {p' k'} {dc: DepsCohs p' k'}
+  (a: DepsCohsChain dcTop dcMid) (b: DepsCohsChain dcMid dc)
+  (ε: arity) (d: mkFrame (mkDepsRestr (depsCohs := dcTop))):
+  νFace (cohsChainCompose a b) ε d =
+  getPainting (cohsChainExt a)
+    (νFace b ε (getFrame (cohsChainNext a) d)).1
+    (νFace b ε (getFrame (cohsChainNext a) d)).2.
+Proof.
+  unfold νFace.
+  rewrite cohsChainExtCompose, cohsChainNextCompose, <- getFrameCompose.
+  apply getPaintingCompose.
 Defined.
 
 Lemma extChainDepsExt {P K} {dcTop: DepsCohs P K} {p k} {dc: DepsCohs p k}

--- a/theories/Equiv/Face.v
+++ b/theories/Equiv/Face.v
@@ -15,16 +15,16 @@ Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
 From Bonak Require Import SigT HSet LeSProp Notation νSet.Layer νSet.
-From Bonak Require νSetEquiv.
+From Bonak Require Equiv.νSetEquiv.
 
 Set Primitive Projections.
 Set Printing Projections.
 Set Keyed Unification.
 
-Module Face (A: LayerSig).
+Module FaceOn (A: LayerSig) (S: νSetSig A).
 Import A.
 
-Module Export νSetEquiv := Bonak.Equiv.νSetEquiv.νSetEquiv A.
+Module Export νSetEquiv := Bonak.Equiv.νSetEquiv.νSetEquivOn A S.
 
 (** Chains of projections between frame stages *)
 
@@ -576,6 +576,11 @@ Proof.
   now exact (hunit_ext _ _).
 Qed.
 
+End FaceOn.
+
+Module Face (A: LayerSig).
+Module Base := νSet.νSet A.
+Include FaceOn A Base.
 End Face.
 
 Module FaceSimplicial := Face SimplicialLayer.

--- a/theories/Equiv/PresheafEquiv.v
+++ b/theories/Equiv/PresheafEquiv.v
@@ -88,12 +88,12 @@ Qed.
     [funExtBetaHSet]); and transport along [hsetEq] is the equivalence
     ([hsetEqRew]). *)
 
-Lemma presheafEquivEq {psh1 psh2: Presheaf} (E: PresheafEquiv psh1 psh2):
-  psh1 = psh2.
-Proof.
-  apply (presheafEqIntro psh1 psh2
+Lemma presheafFaceEquivEq {psh1 psh2: Presheaf} (E: PresheafEquiv psh1 psh2):
+  rew [fun F0: nat -> HSet =>
+    forall n q (Hq: q <= n) (ε: arity), F0 n.+1 -> F0 n]
     (functional_extensionality_dep_good _ _
-      (fun n => hsetEq (F0Equiv _ _ E n)))).
+      (fun n => hsetEq (F0Equiv _ _ E n))) in psh1.(Face) = psh2.(Face).
+Proof.
   apply functional_extensionality_dep_good; intro n.
   apply functional_extensionality_dep_good; intro q.
   apply spropFunext; intro Hq.
@@ -108,6 +108,12 @@ Proof.
   rewrite hsetEqRew, hsetEqRewSym.
   refine (FaceEquiv _ _ E n q Hq ε (invEq (F0Equiv _ _ E n.+1) Y) • _).
   now exact (f_equal (psh2.(Face) n q Hq ε) (secEq (F0Equiv _ _ E n.+1) Y)).
+Qed.
+
+Lemma presheafEquivEq {psh1 psh2: Presheaf} (E: PresheafEquiv psh1 psh2):
+  psh1 = psh2.
+Proof.
+  exact (presheafEqIntro psh1 psh2 _ (presheafFaceEquivEq E)).
 Qed.
 
 End PresheafEquiv.

--- a/theories/Equiv/PresheafOfνSet.v
+++ b/theories/Equiv/PresheafOfνSet.v
@@ -10,16 +10,16 @@ Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
 From Bonak Require Import SigT HSet LeSProp NatLemmas Notation νSet.Layer
-  νSet Face Presheaf νSetOfPresheaf Limit.
+  νSet Face Presheaf Equiv.νSetOfPresheaf Limit.
 
 Set Primitive Projections.
 Set Printing Projections.
 Set Keyed Unification.
 
-Module PresheafOfνSet (A: LayerSig).
+Module PresheafOfνSetOn (A: LayerSig) (S: νSetSig A).
 Import A.
 
-Module Export νSetOfPresheaf := νSetOfPresheaf.νSetOfPresheaf A.
+Module Export νSetOfPresheaf := νSetOfPresheaf.νSetOfPresheafOn A S.
 
 (** The tower data at a position
 
@@ -250,6 +250,11 @@ Definition g (X: νSets): Presheaf := {|
     gFaceCoh X n q (leR_eq_r (plus_n_O n) Hq) r Hr ε ω d;
 |}.
 
+End PresheafOfνSetOn.
+
+Module PresheafOfνSet (A: LayerSig).
+Module Base := νSet.νSet A.
+Include PresheafOfνSetOn A Base.
 End PresheafOfνSet.
 
 Module PresheafOfνSetSimplicial := PresheafOfνSet SimplicialLayer.

--- a/theories/Equiv/PresheafRoundtrip.v
+++ b/theories/Equiv/PresheafRoundtrip.v
@@ -8,17 +8,17 @@ Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
 From Bonak Require Import SigT HSet LeSProp NatLemmas Notation νSet.Layer
-  νSet Face Presheaf νSetOfPresheaf PresheafOfνSet νSetRoundtrip Limit.
+  νSet Face Presheaf Equiv.νSetOfPresheaf Equiv.PresheafOfνSet Equiv.νSetRoundtrip Limit.
 From Bonak.Lib Require Import Equiv.
 
 Set Primitive Projections.
 Set Printing Projections.
 Set Keyed Unification.
 
-Module PresheafRoundtrip (A: LayerSig).
+Module PresheafRoundtripOn (A: LayerSig) (S: νSetSig A).
 Import A.
 
-Module Export νSetRoundtrip := νSetRoundtrip.νSetRoundtrip A.
+Module Export νSetRoundtrip := νSetRoundtrip.νSetRoundtripOn A S.
 
 Section RoundTripGF.
 
@@ -205,6 +205,11 @@ Definition gf: PresheafEquiv (g (f psh)) psh :=
 
 End RoundTripGF.
 
+End PresheafRoundtripOn.
+
+Module PresheafRoundtrip (A: LayerSig).
+Module Base := νSet.νSet A.
+Include PresheafRoundtripOn A Base.
 End PresheafRoundtrip.
 
 Module PresheafRoundtripSimplicial := PresheafRoundtrip SimplicialLayer.

--- a/theories/Equiv/νSetEquiv.v
+++ b/theories/Equiv/νSetEquiv.v
@@ -208,13 +208,8 @@ Qed.
     The [m]-step unfolding of a νSet: the reached prefix, packed with the
     remaining tower so the recursion needs no arithmetic. *)
 
-Fixpoint νSetPack (m: nat) (S: νSets):
-  {Xp: (νSetAt m).(prefix) &T νSetFrom m Xp} :=
-  match m with
-  | 0 => (tt; S)
-  | S m => (((νSetPack m S).1; this ((νSetPack m S).2));
-            next ((νSetPack m S).2))
-  end.
+Definition νSetPack (m: nat) (S: νSets):
+  {Xp: (νSetAt m).(prefix) &T νSetFrom m Xp} := limitPack m S.
 
 (** The levelwise equivalence
 
@@ -247,58 +242,15 @@ Definition νSetsEquiv (SA SB: νSets): Type := Limit (eqvTel SA SB) 0 tt.
     destructors. [packPath] identifies that prefix with level [m] of the
     tower's stored chain. *)
 
-Fixpoint packApprox (m: nat) (S: νSets) (l: nat) {struct m}:
-  forall Hl: m <= l, ((νSetPack m S).2).(approx) l Hl = S.(approx) l leR_O :=
-  match m return forall Hl: m <= l,
-    ((νSetPack m S).2).(approx) l Hl = S.(approx) l leR_O with
-  | 0 => fun _ => eq_refl
-  | m.+1 => fun Hl => packApprox m S l (↓ Hl)
-  end.
-
 Definition packPath (m: nat) (S: νSets):
-  (νSetPack m S).1 = S.(approx) m leR_O :=
-  eq_sym ((νSetPack m S).2).(approxO)
-  • packApprox m S m leR_refl.
-
-(** Reading it off is compatible with the bonding equations:
-    [νSetPack]'s own bonding equation is [eq_refl] (its prefix at [m.+1]
-    is literally a pair over its prefix at [m]), the tower's is
-    [approxS]. *)
-
-Lemma packApproxS (m: nat) (S: νSets) (l: nat) (Hl: m <= l) (HSl: m <= l.+1):
-  f_equal (fun Y: (νSetAt l.+1).(prefix) => Y.1) (packApprox m S l.+1 HSl)
-    • S.(approxS) l leR_O leR_O
-  = ((νSetPack m S).2).(approxS) l Hl HSl • packApprox m S l Hl.
-Proof.
-  revert l Hl HSl; induction m as [|m IH]; intros l Hl HSl.
-  - cbn. now rewrite ?eq_trans_refl_l, ?eq_trans_refl_r.
-  - exact (IH l (↓ Hl) (↓ HSl)).
-Qed.
-
-(** The generic truncation law at this telescope: its [bondExtend] is
-    [eq_refl], so the trailing composite disappears and [bondApproxEta]
-    reads as the first projection of the Σ-equality [approxEta] is built
-    from. *)
-
-Definition approxEtaProj {n} {X: (νSetAt n).(prefix)} (ν: νSetFrom n X):
-  f_equal (fun Y: (νSetAt n.+1).(prefix) => Y.1) (approxEta ν)
-  = ν.(approxS) n leR_refl (↑ leR_refl) • ν.(approxO) :=
-  bondApproxEta ν.
+  (νSetPack m S).1 = S.(approx) m leR_O := limitPackPath m S.
 
 Lemma packPathS (m: nat) (S: νSets):
   f_equal (fun Y: (νSetAt m.+1).(prefix) => Y.1) (packPath m.+1 S)
     • S.(approxS) m leR_O leR_O = packPath m S.
 Proof.
-  unfold packPath.
-  change ((νSetPack m.+1 S).2).(approxO)
-    with (approxEta ((νSetPack m S).2)).
-  change (packApprox m.+1 S m.+1 leR_refl)
-    with (packApprox m S m.+1 (↓ leR_refl)).
-  rewrite eq_trans_map_distr, <- eq_sym_map_distr.
-  rewrite (approxEtaProj ((νSetPack m S).2)).
-  rewrite <- eq_trans_assoc.
-  rewrite (packApproxS m S m leR_refl (↓ leR_refl)).
-  apply eq_trans_sym_cancel_common.
+  pose proof (limitPackPathS m S) as H.
+  now rewrite eq_trans_refl_l in H.
 Qed.
 
 (** From coherent prefix paths to tower equality

--- a/theories/Equiv/νSetEquiv.v
+++ b/theories/Equiv/νSetEquiv.v
@@ -33,10 +33,10 @@ Set Primitive Projections.
 Set Printing Projections.
 Set Keyed Unification.
 
-Module νSetEquiv (A: LayerSig).
+Module νSetEquivOn (A: LayerSig) (S: νSetSig A).
 Import A.
 
-Module Export νSet := νSet.νSet A.
+Module Export νSet := S.
 
 Definition νDataAt {m} (Xpre: (νSetAt m).(prefix)): νSetData m :=
   (νSetAt m).(data) Xpre.
@@ -362,6 +362,11 @@ Definition νSetsEquivEq {SA SB: νSets} (E: νSetsEquiv SA SB): SA = SB :=
       • f_equal (@prefixEq m (νSetPack m SA).1 (νSetPack m SB).1)
           (E.(approxS) m leR_O leR_O)).
 
+End νSetEquivOn.
+
+Module νSetEquiv (A: LayerSig).
+Module Base := νSet.νSet A.
+Include νSetEquivOn A Base.
 End νSetEquiv.
 
 Module νSetEquivSimplicial := νSetEquiv SimplicialLayer.

--- a/theories/Equiv/νSetOfPresheaf.v
+++ b/theories/Equiv/νSetOfPresheaf.v
@@ -12,16 +12,16 @@ Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
 From Bonak Require Import SigT RewLemmas HSet LeSProp Notation νSet.Layer
-  νSet Face PresheafEquiv Limit.
+  νSet Face Equiv.PresheafEquiv Limit.
 
 Set Primitive Projections.
 Set Printing Projections.
 Set Keyed Unification.
 
-Module νSetOfPresheaf (A: LayerSig).
+Module νSetOfPresheafOn (A: LayerSig) (S: νSetSig A).
 Import A.
 
-Module Export Face := Face.Face A.
+Module Export Face := Face.FaceOn A S.
 Module Export PshEq := PresheafEquiv.PresheafEquiv A.
 
 Section νSetOfPresheaf.
@@ -711,6 +711,11 @@ End νSetOfPresheaf.
 Arguments PshCohsChainNil {psh m P K PCTop}.
 Arguments PshCohsChainCons {psh m P K PCTop p k PC} _.
 
+End νSetOfPresheafOn.
+
+Module νSetOfPresheaf (A: LayerSig).
+Module Base := νSet.νSet A.
+Include νSetOfPresheafOn A Base.
 End νSetOfPresheaf.
 
 Module νSetOfPresheafSimplicial := νSetOfPresheaf SimplicialLayer.

--- a/theories/Equiv/νSetRoundtrip.v
+++ b/theories/Equiv/νSetRoundtrip.v
@@ -15,17 +15,17 @@ Import Logic.EqNotations.
 
 Set Warnings "-notation-overridden".
 From Bonak Require Import SigT RewLemmas HSet LeSProp NatLemmas Notation νSet.Layer
-  νSet Face Presheaf νSetOfPresheaf PresheafOfνSet Limit.
+  νSet Face Presheaf Equiv.νSetOfPresheaf Equiv.PresheafOfνSet Limit.
 From Bonak.Lib Require Import Equiv.
 
 Set Primitive Projections.
 Set Printing Projections.
 Set Keyed Unification.
 
-Module νSetRoundtrip (A: LayerSig).
+Module νSetRoundtripOn (A: LayerSig) (S: νSetSig A).
 Import A.
 
-Module Export PresheafOfνSet := PresheafOfνSet.PresheafOfνSet A.
+Module Export PresheafOfνSet := PresheafOfνSet.PresheafOfνSetOn A S.
 
 (** Lifting arbitrary chains to equipped chains
 
@@ -524,6 +524,11 @@ Definition fg: νSetsEquiv (f (g X)) X :=
     (fun m _ => (fgChain m).1) eq_refl (fun m _ _ => eq_refl).
 End FG.
 
+End νSetRoundtripOn.
+
+Module νSetRoundtrip (A: LayerSig).
+Module Base := νSet.νSet A.
+Include νSetRoundtripOn A Base.
 End νSetRoundtrip.
 
 Module νSetRoundtripSimplicial := νSetRoundtrip SimplicialLayer.

--- a/theories/Lib/Limit.v
+++ b/theories/Lib/Limit.v
@@ -129,6 +129,64 @@ Definition next {T n s} (L: Limit T n s):
   approxS l Hl HSl := L.(approxS) l (↓ Hl) (↓ HSl);
 |}.
 
+(** Finite unfoldings
+
+    Iterating [this] and [next] gives a stage and its remaining limit.
+    The resulting stage agrees with the stored approximation, and these
+    paths respect the bonding equations. *)
+
+Section FiniteUnfoldings.
+Local Set Keyed Unification.
+
+Fixpoint limitPack {T s} (m: nat) (L: Limit T 0 s):
+  {t: T.(stage) m &T Limit T m t} :=
+  match m with
+  | 0 => (s; L)
+  | m.+1 =>
+      let p := limitPack m L in (extend p.1 (this p.2); next p.2)
+  end.
+
+Fixpoint limitPackApprox {T s} (m: nat) (L: Limit T 0 s) l:
+  forall Hl: m <= l, (limitPack m L).2.(approx) l Hl = L.(approx) l leR_O :=
+  match m return forall Hl: m <= l,
+    (limitPack m L).2.(approx) l Hl = L.(approx) l leR_O with
+  | 0 => fun _ => eq_refl
+  | m.+1 => fun Hl => limitPackApprox m L l (↓ Hl)
+  end.
+
+Definition limitPackPath {T s} m (L: Limit T 0 s):
+  (limitPack m L).1 = L.(approx) m leR_O :=
+  eq_sym (limitPack m L).2.(approxO) • limitPackApprox m L m leR_refl.
+
+Lemma limitPackApproxS {T s} m (L: Limit T 0 s) l
+  (Hl: m <= l) (HSl: m <= l.+1):
+  f_equal (@bond T l) (limitPackApprox m L l.+1 HSl) •
+    L.(approxS) l leR_O leR_O =
+  (limitPack m L).2.(approxS) l Hl HSl • limitPackApprox m L l Hl.
+Proof.
+  revert l Hl HSl; induction m; intros l Hl HSl.
+  - cbn. now rewrite ?eq_trans_refl_l, ?eq_trans_refl_r.
+  - exact (IHm l (↓ Hl) (↓ HSl)).
+Qed.
+
+Lemma limitPackPathS {T s} m (L: Limit T 0 s):
+  f_equal (@bond T m) (limitPackPath m.+1 L) • L.(approxS) m leR_O leR_O =
+  T.(bondExtend) m (limitPack m L).1 (this (limitPack m L).2) • limitPackPath m L.
+Proof.
+  unfold limitPackPath.
+  change (limitPack m.+1 L).2.(approxO) with (approxEta (limitPack m L).2).
+  change (limitPackApprox m.+1 L m.+1 leR_refl)
+    with (limitPackApprox m L m.+1 (↓ leR_refl)).
+  rewrite eq_trans_map_distr, <- eq_sym_map_distr, <- eq_trans_assoc.
+  rewrite (limitPackApproxS m L m leR_refl (↓ leR_refl)).
+  symmetry. apply eq_trans_shift_l.
+  rewrite eq_trans_assoc, (bondApproxEta (limitPack m L).2), <- eq_trans_assoc.
+  apply f_equal.
+  now rewrite eq_trans_assoc, eq_trans_sym_inv_r, eq_trans_refl_l.
+Qed.
+
+End FiniteUnfoldings.
+
 (** Building limits
 
     [ofChain] restricts a globally coherent family to the levels at or

--- a/theories/Lib/NatLemmas.v
+++ b/theories/Lib/NatLemmas.v
@@ -6,6 +6,27 @@ From Bonak Require Import Notation LeSProp.
 
 Set Keyed Unification.
 
+Inductive NatOrder (i j: nat): Type :=
+| NatOrderLt: i.+1 <= j -> NatOrder i j
+| NatOrderEq: i = j -> NatOrder i j
+| NatOrderGt: j.+1 <= i -> NatOrder i j.
+
+Arguments NatOrderLt {i j} _.
+Arguments NatOrderEq {i j} _.
+Arguments NatOrderGt {i j} _.
+
+Fixpoint natOrder (i j: nat) {struct i}: NatOrder i j.
+Proof.
+  destruct i as [|i], j as [|j].
+  - exact (NatOrderEq eq_refl).
+  - exact (@NatOrderLt 0 j.+1 (@leR_O j)).
+  - exact (@NatOrderGt i.+1 0 (@leR_O i)).
+  - destruct (natOrder i j) as [H|e|H].
+    + exact (@NatOrderLt i.+1 j.+1 H).
+    + exact (NatOrderEq (f_equal S e)).
+    + exact (@NatOrderGt i.+1 j.+1 H).
+Defined.
+
 Definition natUIP {a b: nat} (e e': a = b): e = e' :=
   UIP_dec PeanoNat.Nat.eq_dec e e'.
 
@@ -61,6 +82,17 @@ Qed.
 Lemma subDiag (a: nat): a - a = 0.
 Proof.
   induction a. reflexivity. now exact IHa.
+Qed.
+
+Lemma subAntitone {i j n: nat}: i <= j -> n - j <= n - i.
+Proof.
+  revert i j; induction n; intros i j H.
+  - now exact leR_refl.
+  - destruct i as [|i], j as [|j].
+    + exact leR_refl.
+    + exact (↑ (sub_leR n j)).
+    + now destruct (leR_O_contra H).
+    + now exact (IHn i j H).
 Qed.
 
 Lemma addSubCancelL (a b: nat): (a + b) - a = b.

--- a/theories/νSet/Presheaf.v
+++ b/theories/νSet/Presheaf.v
@@ -29,6 +29,21 @@ Record Presheaf := {
     Face n r (Hr ↕ Hq) ω (Face n.+1 q.+1 (⇑ Hq) ε X)
 }.
 
+Record PresheafDgn (psh: Presheaf): Type := {
+  Dgn n q (Hq: q <= n): psh.(F0) n -> psh.(F0) n.+1;
+  FaceDgnInf n r q (Hr: r <= q) (Hq: q <= n) (ε: arity) (X: psh.(F0) n.+1):
+    psh.(Face) n.+1 r (Hr ↕ (↑ Hq)) ε (Dgn n.+1 q.+1 (⇑ Hq) X) =
+    Dgn n q Hq (psh.(Face) n r (Hr ↕ Hq) ε X);
+  FaceDgnId n q (Hq: q <= n) (ε: arity) (X: psh.(F0) n):
+    psh.(Face) n q Hq ε (Dgn n q Hq X) = X;
+  FaceDgnSup n q (Hq: q <= n) r (Hr: r <= q) (ε: arity) (X: psh.(F0) n.+1):
+    psh.(Face) n.+1 q.+1 (⇑ Hq) ε (Dgn n.+1 r (Hr ↕ (↑ Hq)) X) =
+    Dgn n r (Hr ↕ Hq) (psh.(Face) n q Hq ε X);
+  DgnDgn n r q (Hr: r <= q) (Hq: q <= n) (X: psh.(F0) n):
+    Dgn n.+1 r (Hr ↕ (↑ Hq)) (Dgn n q Hq X) =
+    Dgn n.+1 q.+1 (⇑ Hq) (Dgn n r (Hr ↕ Hq) X)
+}.
+
 End Presheaf.
 
 Module PresheafSimplicial := Presheaf SimplicialLayer.

--- a/theories/νSet/νSet.v
+++ b/theories/νSet/νSet.v
@@ -666,6 +666,10 @@ Definition νSets := νSetFrom 0 tt.
 
 End νSet.
 
+Module Type νSetSig (A: LayerSig).
+Include νSet A.
+End νSetSig.
+
 Module νSetSimplicial := νSet SimplicialLayer.
 Module νSetCubical := νSet CubicalLayer.
 


### PR DESCRIPTION
# Indexed-fibred correspondence for `νDgnSets`
## Overview

Completes the degeneracy extension proposed in [#33](https://github.com/artagnon/bonak/pull/33): the indexed `νDgnSets` construction is equivalent to the fibred presentation given by a presheaf equipped with degeneracy maps and their four identities. The added record is:

```coq
Record PresheafDgn (psh: Presheaf): Type := {
  Dgn n q (Hq: q <= n): psh.(F0) n -> psh.(F0) n.+1;
  FaceDgnInf n r q (Hr: r <= q) (Hq: q <= n) (ε: arity) (X: psh.(F0) n.+1):
    psh.(Face) n.+1 r (Hr ↕ (↑ Hq)) ε (Dgn n.+1 q.+1 (⇑ Hq) X) =
    Dgn n q Hq (psh.(Face) n r (Hr ↕ Hq) ε X);
  FaceDgnId n q (Hq: q <= n) (ε: arity) (X: psh.(F0) n):
    psh.(Face) n q Hq ε (Dgn n q Hq X) = X;
  FaceDgnSup n q (Hq: q <= n) r (Hr: r <= q) (ε: arity) (X: psh.(F0) n.+1):
    psh.(Face) n.+1 q.+1 (⇑ Hq) ε (Dgn n.+1 r (Hr ↕ (↑ Hq)) X) =
    Dgn n r (Hr ↕ Hq) (psh.(Face) n q Hq ε X);
  DgnDgn n r q (Hr: r <= q) (Hq: q <= n) (X: psh.(F0) n):
    Dgn n.+1 r (Hr ↕ (↑ Hq)) (Dgn n q Hq X) =
    Dgn n.+1 q.+1 (⇑ Hq) (Dgn n r (Hr ↕ Hq) X)
}.
```

The correspondence is proved over `LayerSig`, with simplicial and cubical layer instances, and yields:

```coq
νDgnSetsEqPresheaf : νDgnSets = {psh: Presheaf &T PresheafDgn psh}
```

Both construction maps and the presheaf round-trip equivalence are axiom-free. The indexed round trip, the final equivalence, and the type equality assume exactly univalence and functional extensionality.

## Proof architecture

The proof uses the combined νSet-and-degeneracy tower introduced in [#36](https://github.com/artagnon/bonak/pull/36), reindexed in [#38](https://github.com/artagnon/bonak/pull/38), and represented by the generic ω-limit of [#39](https://github.com/artagnon/bonak/pull/39).

`Equiv/Dgn/` supplies both constructions and round trips. Reading the tower recovers its cells, faces, and degeneracies. Reconstruction uses the existing νSet representation of fillers as presheaf cells with a prescribed boundary, and equips these fillers with degeneracy layers. The presheaf round trip projects the reconstructed cells back to the original presheaf cells, proving this is an equivalence compatible with faces and degeneracies. The indexed round trip follows the prefix-equality approach of [#34](https://github.com/artagnon/bonak/pull/34), identifying fillers and degeneracy layers together at each finite stage, then applying limit extensionality.

## Reuse and proof size

The proof reuses the existing face operations and their laws, the filler construction and its round-trip equivalences, and limit extensionality. To share these definitions and proofs with the underlying νSet module inside `νDgnSet`, the base correspondence now accepts a module satisfying `νSetSig`. Generic finite-unfolding lemmas in `Limit.v` serve both correspondences.

The size of the indexed construction might suggest a much larger correspondence proof: `νDgnSet.v` has 2588 lines, compared with 690 for `νSet.v`. However, the incremental development in `Equiv/Dgn/` occupies just 1334 lines — less than half the 2855 lines of the base correspondence it builds on. The additional work establishes the degeneracy laws and their compatibility with the constructions and round trips.
